### PR TITLE
Refatorar estrutura interna conforme AGENTS.md

### DIFF
--- a/src/ayvu/chunking.py
+++ b/src/ayvu/chunking.py
@@ -21,8 +21,8 @@ def split_text(text: str, limit: int = DEFAULT_CHUNK_LIMIT) -> list[str]:
         for sentence in _split_sentences(paragraph):
             if len(sentence) <= limit:
                 _append_chunk(chunks, sentence, limit)
-            else:
-                chunks.extend(_split_words(sentence, limit))
+                continue
+            chunks.extend(_split_words(sentence, limit))
     return [chunk for chunk in chunks if chunk]
 
 
@@ -72,8 +72,8 @@ def _split_words(text: str, limit: int) -> list[str]:
         if current and len(current) + len(token) > limit:
             chunks.append(current.rstrip())
             current = token
-        else:
-            current += token
+            continue
+        current += token
     if current:
         chunks.append(current.rstrip())
     return chunks
@@ -84,6 +84,5 @@ def _append_chunk(chunks: list[str], text: str, limit: int) -> None:
         return
     if chunks and len(chunks[-1]) + len(text) <= limit:
         chunks[-1] += text
-    else:
-        chunks.append(text)
-
+        return
+    chunks.append(text)

--- a/src/ayvu/cli.py
+++ b/src/ayvu/cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
@@ -9,6 +10,7 @@ from rich.progress import BarColumn, Progress, SpinnerColumn, TaskProgressColumn
 from rich.table import Table
 
 from .cache import TranslationCache
+from .domain import LanguagePair, OutputPlan, TranslationOptions
 from .epub_io import extract_markdown, inspect_epub, translate_epub
 from .glossary import GlossaryError, load_glossary
 from .translator import LibreTranslateTranslator, TranslatorError, create_translator
@@ -17,6 +19,74 @@ from .validation import validate_output_epub
 
 app = typer.Typer(help="Translate local EPUB files with a local HTTP translator.")
 console = Console()
+
+
+@dataclass
+class TextProgressCounters:
+    translated: int = 0
+    cache: int = 0
+    dry_run: int = 0
+    error: int = 0
+
+    def record(self, status: str) -> None:
+        if status == "translated":
+            self.translated += 1
+            return
+        if status == "cache":
+            self.cache += 1
+            return
+        if status == "dry_run":
+            self.dry_run += 1
+            return
+        if status == "error":
+            self.error += 1
+            return
+        raise ValueError(f"Unknown text progress status: {status}")
+
+    @property
+    def processed(self) -> int:
+        return self.translated + self.cache + self.dry_run + self.error
+
+    def new_count(self, dry_run: bool) -> int:
+        if dry_run:
+            return self.dry_run
+        return self.translated
+
+
+class TranslationProgress:
+    def __init__(self, progress: Progress, dry_run: bool) -> None:
+        self._progress = progress
+        self._dry_run = dry_run
+        self._counters = TextProgressCounters()
+        self._chapter_task = progress.add_task("Chapters", total=None)
+        self._text_task = progress.add_task("Texts", total=None)
+
+    def chapter_started(self, index: int, total: int, name: str) -> None:
+        self._progress.update(
+            self._chapter_task,
+            total=total,
+            description=self._chapter_description(index, total, name),
+        )
+
+    def chapter_done(self, index: int, total: int, name: str, _stats: object) -> None:
+        self._progress.advance(self._chapter_task)
+        self._progress.update(self._chapter_task, description=self._chapter_description(index, total, name))
+
+    def text_processed(self, status: str) -> None:
+        self._counters.record(status)
+        self._progress.advance(self._text_task)
+        self._progress.update(self._text_task, description=self._text_description())
+
+    def _chapter_description(self, index: int, total: int, name: str) -> str:
+        return f"Chapters {index}/{total}: {_shorten(name)}"
+
+    def _text_description(self) -> str:
+        new_label = "would translate" if self._dry_run else "new"
+        new_count = self._counters.new_count(self._dry_run)
+        return (
+            f"Texts {self._counters.processed} | {new_label} {new_count} | "
+            f"cache {self._counters.cache} | errors {self._counters.error}"
+        )
 
 
 @app.command()
@@ -76,9 +146,17 @@ def translate(
     chunk_limit: int = typer.Option(3000, "--chunk-limit", help="Maximum characters sent per request."),
 ) -> None:
     """Translate EPUB visible text while preserving EPUB structure."""
-    output_path = _resolve_output_path(epub_path, output, target)
+    language_pair = LanguagePair(source=source, target=target)
+    translation_options = TranslationOptions(
+        language_pair=language_pair,
+        dry_run=dry_run,
+        fail_fast=fail_fast,
+        chunk_limit=chunk_limit,
+    )
+    output_plan = OutputPlan.for_translation(epub_path, output, language_pair, dry_run=dry_run)
+    output_path = output_plan.path
 
-    if output_path.exists() and not overwrite and not dry_run:
+    if output_plan.blocks_existing_file(overwrite):
         console.print(f"[red]Output already exists:[/red] {output_path}")
         console.print("Use --overwrite to replace it.")
         raise typer.Exit(code=1)
@@ -90,9 +168,12 @@ def translate(
         console.print("Create the file, pass the correct path, or remove --glossary to run without one.")
         raise typer.Exit(code=1) from exc
 
-    translator = create_translator(translator_name, url=url, timeout=timeout, retries=retries)
-
-    counters = {"translated": 0, "cache": 0, "dry_run": 0, "error": 0}
+    try:
+        translator = create_translator(translator_name, url=url, timeout=timeout, retries=retries)
+    except TranslatorError as exc:
+        console.print(f"[red]Translator error:[/red] {exc}")
+        console.print("Use --translator libretranslate.")
+        raise typer.Exit(code=1) from exc
 
     with Progress(
         SpinnerColumn(),
@@ -102,33 +183,7 @@ def translate(
         TimeElapsedColumn(),
         console=console,
     ) as progress:
-        chapter_task = progress.add_task("Chapters", total=None)
-        text_task = progress.add_task("Texts", total=None)
-
-        def on_chapter_start(index: int, total: int, name: str) -> None:
-            progress.update(
-                chapter_task,
-                total=total,
-                description=f"Chapters {index}/{total}: {_shorten(name)}",
-            )
-
-        def on_chapter_done(index: int, total: int, name: str, _stats: object) -> None:
-            progress.advance(chapter_task)
-            progress.update(chapter_task, description=f"Chapters {index}/{total}: {_shorten(name)}")
-
-        def on_text_processed(status: str) -> None:
-            counters[status] = counters.get(status, 0) + 1
-            processed = sum(counters.values())
-            new_label = "would translate" if dry_run else "new"
-            new_count = counters["dry_run"] if dry_run else counters["translated"]
-            progress.advance(text_task)
-            progress.update(
-                text_task,
-                description=(
-                    f"Texts {processed} | {new_label} {new_count} | "
-                    f"cache {counters['cache']} | errors {counters['error']}"
-                ),
-            )
+        progress_view = TranslationProgress(progress, dry_run=dry_run)
 
         with TranslationCache(cache_path) as cache:
             report = translate_epub(
@@ -136,15 +191,11 @@ def translate(
                 output_path,
                 translator=translator,
                 cache=cache,
-                source=source,
-                target=target,
+                options=translation_options,
                 glossary=glossary,
-                dry_run=dry_run,
-                fail_fast=fail_fast,
-                chunk_limit=chunk_limit,
-                on_chapter_start=on_chapter_start,
-                on_chapter_done=on_chapter_done,
-                on_text_processed=on_text_processed,
+                on_chapter_start=progress_view.chapter_started,
+                on_chapter_done=progress_view.chapter_done,
+                on_text_processed=progress_view.text_processed,
             )
 
     _print_report(
@@ -207,14 +258,6 @@ def _shorten(text: str, max_length: int = 50) -> str:
     if len(text) <= max_length:
         return text
     return text[: max_length - 3] + "..."
-
-
-def _resolve_output_path(epub_path: Path, output: Optional[Path], target: str) -> Path:
-    if output is not None:
-        return output
-
-    target_label = target.strip() or "translated"
-    return epub_path.with_name(f"{epub_path.stem}-{target_label}.epub")
 
 
 if __name__ == "__main__":

--- a/src/ayvu/domain.py
+++ b/src/ayvu/domain.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class LanguagePair:
+    source: str
+    target: str
+
+    @property
+    def target_label(self) -> str:
+        return self.target.strip() or "translated"
+
+
+@dataclass(frozen=True)
+class OutputPlan:
+    path: Path
+    dry_run: bool = False
+
+    @classmethod
+    def for_translation(
+        cls,
+        input_path: Path,
+        explicit_output: Path | None,
+        language_pair: LanguagePair,
+        dry_run: bool = False,
+    ) -> "OutputPlan":
+        if explicit_output is not None:
+            return cls(path=explicit_output, dry_run=dry_run)
+
+        output_path = input_path.with_name(f"{input_path.stem}-{language_pair.target_label}.epub")
+        return cls(path=output_path, dry_run=dry_run)
+
+    def blocks_existing_file(self, overwrite: bool) -> bool:
+        if self.dry_run:
+            return False
+        if overwrite:
+            return False
+        return self.path.exists()
+
+
+@dataclass(frozen=True)
+class TranslationOptions:
+    language_pair: LanguagePair
+    dry_run: bool = False
+    fail_fast: bool = False
+    chunk_limit: int = 3000
+
+    @property
+    def source(self) -> str:
+        return self.language_pair.source
+
+    @property
+    def target(self) -> str:
+        return self.language_pair.target

--- a/src/ayvu/epub_io.py
+++ b/src/ayvu/epub_io.py
@@ -10,6 +10,7 @@ from ebooklib import ITEM_DOCUMENT
 from ebooklib import epub
 
 from .cache import TranslationCache
+from .domain import TranslationOptions
 from .glossary import Glossary
 from .html_translate import HtmlTranslationStats, extract_visible_text, translate_html
 from .translator import Translator
@@ -39,6 +40,41 @@ class TranslationReport:
     errors: list[str] = field(default_factory=list)
     output_path: Path | None = None
 
+    def record_missing_document(self, document: "EpubDocument") -> str:
+        message = f"{document.name}: document not found in EPUB archive at {document.archive_path}"
+        self.errors.append(message)
+        return message
+
+    def record_chapter(self, stats: HtmlTranslationStats) -> None:
+        self.texts_translated += stats.translated
+        self.texts_from_cache += stats.from_cache
+        self.texts_skipped += stats.skipped
+        self.errors.extend(stats.errors)
+        self.chapters_processed += 1
+
+    def record_chapter_error(self, document: "EpubDocument", exc: Exception) -> None:
+        self.errors.append(f"{document.name}: {exc}")
+
+
+@dataclass(frozen=True)
+class EpubDocument:
+    name: str
+    archive_path: str
+
+
+@dataclass
+class EpubReplacements:
+    items: dict[str, bytes] = field(default_factory=dict)
+
+    def add(self, archive_path: str, content: bytes) -> None:
+        self.items[archive_path] = content
+
+    def content_for(self, filename: str, source_epub: ZipFile) -> bytes:
+        replacement = self.items.get(filename)
+        if replacement is not None:
+            return replacement
+        return source_epub.read(filename)
+
 
 def inspect_epub(path: str | Path) -> EpubInfo:
     epub_path = Path(path)
@@ -63,12 +99,8 @@ def translate_epub(
     output_path: str | Path,
     translator: Translator,
     cache: TranslationCache,
-    source: str,
-    target: str,
+    options: TranslationOptions,
     glossary: Glossary | None = None,
-    dry_run: bool = False,
-    fail_fast: bool = False,
-    chunk_limit: int = 3000,
     on_chapter_start: ChapterStartCallback | None = None,
     on_chapter_done: ChapterDoneCallback | None = None,
     on_text_processed: TextProgressCallback | None = None,
@@ -78,53 +110,48 @@ def translate_epub(
     book = epub.read_epub(str(source_path))
     report = TranslationReport(output_path=destination_path)
     opf_base_path = _get_opf_base_path(source_path)
-    replacements: dict[str, bytes] = {}
+    replacements = EpubReplacements()
 
-    documents = list(book.get_items_of_type(ITEM_DOCUMENT))
+    documents = _document_entries(book, opf_base_path)
     total_documents = len(documents)
 
     with ZipFile(source_path, "r") as source_epub:
         archive_names = set(source_epub.namelist())
 
-        for index, item in enumerate(documents, start=1):
-            item_name = item.get_name()
-            item_path = _document_zip_path(opf_base_path, item_name)
-            if item_path not in archive_names:
-                message = f"{item_name}: document not found in EPUB archive at {item_path}"
-                report.errors.append(message)
-                if fail_fast:
-                    raise FileNotFoundError(item_path)
+        for index, document in enumerate(documents, start=1):
+            if document.archive_path not in archive_names:
+                report.record_missing_document(document)
+                if options.fail_fast:
+                    raise FileNotFoundError(document.archive_path)
                 continue
 
             if on_chapter_start:
-                on_chapter_start(index, total_documents, item_name)
+                on_chapter_start(index, total_documents, document.name)
 
             try:
                 translated_content, stats = translate_html(
-                    source_epub.read(item_path),
+                    source_epub.read(document.archive_path),
                     translator=translator,
                     cache=cache,
-                    source=source,
-                    target=target,
+                    source=options.source,
+                    target=options.target,
                     glossary=glossary,
-                    dry_run=dry_run,
-                    fail_fast=fail_fast,
-                    chunk_limit=chunk_limit,
+                    dry_run=options.dry_run,
+                    fail_fast=options.fail_fast,
+                    chunk_limit=options.chunk_limit,
                     on_text_processed=on_text_processed,
                 )
-                if not dry_run:
-                    replacements[item_path] = translated_content
-                _merge_stats(report, stats)
-                report.chapters_processed += 1
+                if not options.dry_run:
+                    replacements.add(document.archive_path, translated_content)
+                report.record_chapter(stats)
                 if on_chapter_done:
-                    on_chapter_done(index, total_documents, item_name, stats)
+                    on_chapter_done(index, total_documents, document.name, stats)
             except Exception as exc:
-                message = f"{item_name}: {exc}"
-                report.errors.append(message)
-                if fail_fast:
+                report.record_chapter_error(document, exc)
+                if options.fail_fast:
                     raise
 
-    if not dry_run:
+    if not options.dry_run:
         destination_path.parent.mkdir(parents=True, exist_ok=True)
         _copy_epub_with_replacements(source_path, destination_path, replacements)
 
@@ -177,16 +204,22 @@ def _document_zip_path(opf_base_path: PurePosixPath, item_name: str) -> str:
     return path.as_posix()
 
 
+def _document_entries(book: epub.EpubBook, opf_base_path: PurePosixPath) -> list[EpubDocument]:
+    documents: list[EpubDocument] = []
+    for item in book.get_items_of_type(ITEM_DOCUMENT):
+        name = item.get_name()
+        documents.append(EpubDocument(name=name, archive_path=_document_zip_path(opf_base_path, name)))
+    return documents
+
+
 def _copy_epub_with_replacements(
     input_path: Path,
     output_path: Path,
-    replacements: dict[str, bytes],
+    replacements: EpubReplacements,
 ) -> None:
     with ZipFile(input_path, "r") as source_epub, ZipFile(output_path, "w") as output_epub:
         for info in source_epub.infolist():
-            data = replacements.get(info.filename)
-            if data is None:
-                data = source_epub.read(info.filename)
+            data = replacements.content_for(info.filename, source_epub)
             if info.filename == "mimetype":
                 info.compress_type = ZIP_STORED
             output_epub.writestr(info, data)
@@ -197,10 +230,3 @@ def _first_metadata(book: epub.EpubBook, namespace: str, name: str) -> str | Non
     if not values:
         return None
     return values[0][0]
-
-
-def _merge_stats(report: TranslationReport, stats: HtmlTranslationStats) -> None:
-    report.texts_translated += stats.translated
-    report.texts_from_cache += stats.from_cache
-    report.texts_skipped += stats.skipped
-    report.errors.extend(stats.errors)

--- a/src/ayvu/html_translate.py
+++ b/src/ayvu/html_translate.py
@@ -39,6 +39,12 @@ class TextParts:
         return self.leading + core + self.trailing
 
 
+@dataclass(frozen=True)
+class TextTranslationResult:
+    text: str
+    from_cache: bool = False
+
+
 def extract_visible_text(html: str | bytes) -> list[str]:
     soup = BeautifulSoup(html, "lxml-xml")
     return [str(text_node) for text_node in _visible_text_nodes(soup) if str(text_node).strip()]
@@ -68,7 +74,7 @@ def translate_html(
         original = str(text_node)
 
         try:
-            translated_text, used_cache = translate_text(
+            result = translate_text(
                 original,
                 translator=translator,
                 cache=cache,
@@ -79,8 +85,8 @@ def translate_html(
                 chunk_limit=chunk_limit,
             )
             if not dry_run:
-                text_node.replace_with(NavigableString(translated_text))
-            _record_success(stats, used_cache, dry_run, on_text_processed)
+                text_node.replace_with(NavigableString(result.text))
+            _record_success(stats, result.from_cache, dry_run, on_text_processed)
         except Exception as exc:
             stats.errors.append(str(exc))
             _notify_text_processed(on_text_processed, "error")
@@ -101,17 +107,17 @@ def translate_text(
     glossary: Glossary | None = None,
     dry_run: bool = False,
     chunk_limit: int = 3000,
-) -> tuple[str, bool]:
+) -> TextTranslationResult:
     parts = TextParts.from_text(text)
     if not parts.core:
-        return text, False
+        return TextTranslationResult(text=text)
 
     cached = cache.get(parts.core, source, target)
     if cached is not None:
-        return parts.restore(apply_glossary(cached, glossary)), True
+        return TextTranslationResult(text=parts.restore(apply_glossary(cached, glossary)), from_cache=True)
 
     if dry_run:
-        return text, False
+        return TextTranslationResult(text=text)
 
     translated_chunks = [
         translator.translate(chunk, source, target)
@@ -120,7 +126,7 @@ def translate_text(
     translated = "".join(translated_chunks)
     cache.set(parts.core, translated, source, target)
     translated = apply_glossary(translated, glossary)
-    return parts.restore(translated), False
+    return TextTranslationResult(text=parts.restore(translated))
 
 
 def _visible_text_nodes(soup: BeautifulSoup) -> list[NavigableString]:

--- a/src/ayvu/translator.py
+++ b/src/ayvu/translator.py
@@ -7,7 +7,14 @@ from dataclasses import dataclass
 import requests
 
 
+SUPPORTED_TRANSLATORS = ("libretranslate",)
+
+
 class TranslatorError(RuntimeError):
+    pass
+
+
+class UnsupportedTranslatorError(TranslatorError):
     pass
 
 
@@ -90,6 +97,6 @@ class LibreTranslateTranslator(Translator):
 
 def create_translator(name: str, url: str, timeout: float = 30.0, retries: int = 2) -> Translator:
     if name != "libretranslate":
-        raise ValueError(f"Unsupported translator: {name}")
+        supported = ", ".join(SUPPORTED_TRANSLATORS)
+        raise UnsupportedTranslatorError(f"Unsupported translator: {name}. Supported translators: {supported}.")
     return LibreTranslateTranslator(url=url, timeout=timeout, retries=retries)
-

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,14 +1,88 @@
 from pathlib import Path
 
-from ayvu.cli import _resolve_output_path
+import pytest
+from typer.testing import CliRunner
+
+from ayvu.cli import TextProgressCounters, app
+from ayvu.domain import LanguagePair, OutputPlan, TranslationOptions
 
 
-def test_resolve_output_path_keeps_explicit_output():
+runner = CliRunner()
+
+
+def test_output_plan_keeps_explicit_output():
     output = Path("traduzidos/livro-final.epub")
+    language_pair = LanguagePair(source="en", target="pt")
 
-    assert _resolve_output_path(Path("livro.epub"), output, "pt") == output
+    plan = OutputPlan.for_translation(Path("livro.epub"), output, language_pair)
+
+    assert plan.path == output
 
 
-def test_resolve_output_path_uses_target_suffix_next_to_input():
-    assert _resolve_output_path(Path("books/livro.epub"), None, "pt-BR") == Path("books/livro-pt-BR.epub")
+def test_output_plan_uses_target_suffix_next_to_input():
+    language_pair = LanguagePair(source="en", target="pt-BR")
 
+    plan = OutputPlan.for_translation(Path("books/livro.epub"), None, language_pair)
+
+    assert plan.path == Path("books/livro-pt-BR.epub")
+
+
+def test_output_plan_uses_translated_suffix_when_target_is_blank():
+    language_pair = LanguagePair(source="en", target=" ")
+
+    plan = OutputPlan.for_translation(Path("books/livro.epub"), None, language_pair)
+
+    assert plan.path == Path("books/livro-translated.epub")
+
+
+def test_output_plan_dry_run_does_not_block_existing_output(tmp_path):
+    output = tmp_path / "livro-pt.epub"
+    output.write_text("already here", encoding="utf-8")
+
+    plan = OutputPlan(path=output, dry_run=True)
+
+    assert not plan.blocks_existing_file(overwrite=False)
+
+
+def test_translation_options_exposes_language_pair_values():
+    language_pair = LanguagePair(source="en", target="pt")
+
+    options = TranslationOptions(language_pair=language_pair)
+
+    assert options.source == "en"
+    assert options.target == "pt"
+
+
+def test_text_progress_counters_track_known_statuses():
+    counters = TextProgressCounters()
+
+    counters.record("translated")
+    counters.record("cache")
+    counters.record("dry_run")
+    counters.record("error")
+
+    assert counters.processed == 4
+    assert counters.new_count(dry_run=False) == 1
+    assert counters.new_count(dry_run=True) == 1
+    assert counters.cache == 1
+    assert counters.error == 1
+
+
+def test_text_progress_counters_reject_unknown_status():
+    counters = TextProgressCounters()
+
+    with pytest.raises(ValueError, match="Unknown text progress status"):
+        counters.record("unknown")
+
+
+def test_translate_command_has_clear_error_for_unknown_translator(tmp_path):
+    epub_path = tmp_path / "book.epub"
+    epub_path.write_bytes(b"not a real epub")
+
+    result = runner.invoke(app, ["translate", str(epub_path), "--translator", "unknown", "--dry-run"])
+
+    assert result.exit_code == 1
+    assert "Translator error:" in result.output
+    assert "Unsupported translator: unknown" in result.output
+    assert "Use --translator libretranslate." in result.output
+    assert "Traceback" not in result.output

--- a/tests/test_epub_io.py
+++ b/tests/test_epub_io.py
@@ -1,6 +1,30 @@
 from pathlib import PurePosixPath
 
-from ayvu.epub_io import _document_zip_path
+from ebooklib import ITEM_DOCUMENT
+
+from ayvu.epub_io import EpubReplacements, _document_entries, _document_zip_path
+
+
+class FakeBook:
+    def __init__(self, names: list[str]) -> None:
+        self._items = [FakeItem(name) for name in names]
+
+    def get_items_of_type(self, item_type: int) -> list["FakeItem"]:
+        assert item_type == ITEM_DOCUMENT
+        return self._items
+
+
+class FakeItem:
+    def __init__(self, name: str) -> None:
+        self._name = name
+
+    def get_name(self) -> str:
+        return self._name
+
+
+class FakeZip:
+    def read(self, filename: str) -> bytes:
+        return f"original:{filename}".encode("utf-8")
 
 
 def test_document_zip_path_for_root_opf():
@@ -9,3 +33,23 @@ def test_document_zip_path_for_root_opf():
 
 def test_document_zip_path_for_nested_opf():
     assert _document_zip_path(PurePosixPath("OEBPS"), "text/chapter.xhtml") == "OEBPS/text/chapter.xhtml"
+
+
+def test_document_entries_keep_item_names_and_archive_paths():
+    book = FakeBook(["text/chapter.xhtml", "text/next.xhtml"])
+
+    documents = _document_entries(book, PurePosixPath("OEBPS"))
+
+    assert [document.name for document in documents] == ["text/chapter.xhtml", "text/next.xhtml"]
+    assert [document.archive_path for document in documents] == [
+        "OEBPS/text/chapter.xhtml",
+        "OEBPS/text/next.xhtml",
+    ]
+
+
+def test_epub_replacements_return_replacement_or_original_content():
+    replacements = EpubReplacements()
+    replacements.add("chapter.xhtml", b"translated")
+
+    assert replacements.content_for("chapter.xhtml", FakeZip()) == b"translated"
+    assert replacements.content_for("style.css", FakeZip()) == b"original:style.css"

--- a/tests/test_html_translate.py
+++ b/tests/test_html_translate.py
@@ -1,5 +1,5 @@
 from ayvu.cache import TranslationCache
-from ayvu.html_translate import extract_visible_text, translate_html
+from ayvu.html_translate import extract_visible_text, translate_html, translate_text
 from ayvu.translator import Translator
 
 
@@ -64,6 +64,18 @@ def test_translate_html_uses_cache(tmp_path):
     assert "Mantenha-me" in output.decode("utf-8")
     assert stats.from_cache == 1
     assert translator.calls == ["Keep me"]
+
+
+def test_translate_text_result_reports_cache_hit(tmp_path):
+    translator = FakeTranslator()
+    with TranslationCache(tmp_path / "cache.sqlite") as cache:
+        cache.set("Keep me", "Mantenha-me", "en", "pt")
+
+        result = translate_text(" Keep me ", translator, cache, "en", "pt")
+
+    assert result.text == " Mantenha-me "
+    assert result.from_cache
+    assert translator.calls == []
 
 
 def test_translate_html_does_not_translate_doctype_or_comments(tmp_path):


### PR DESCRIPTION
## Objetivo

Refatorar a estrutura interna do Ayvu para alinhar melhor o codigo com as regras do AGENTS.md, sem mudar comandos ou flags publicas.

Refs #8

## O que mudou

- Cria value objects pequenos para idioma, plano de saida e opcoes de traducao.
- Move a resolucao de output para OutputPlan.
- Reduz parametros soltos em translate_epub usando TranslationOptions.
- Separa o progresso da traducao em objetos de CLI.
- Troca o resultado implicito de translate_text por TextTranslationResult.
- Melhora o erro para tradutor invalido, evitando traceback esperado de usuario.
- Introduz EpubDocument, EpubReplacements e metodos em TranslationReport.
- Simplifica fluxo em chunking.py removendo else desnecessario.

## Fora do escopo

- Nao muda formato do cache SQLite.
- Nao muda comandos ou flags da CLI.
- Nao implementa traducao por bloco com placeholders.

## Validacao

- uv run pytest -> 27 passed