### PR TITLE
Concluir alinhamento interno conforme AGENTS.md

### DIFF
--- a/src/ayvu/cache.py
+++ b/src/ayvu/cache.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import hashlib
 import sqlite3
+from dataclasses import dataclass
 from pathlib import Path
+
+from .domain import LanguagePair
 
 
 SCHEMA = """
@@ -23,6 +26,16 @@ def text_hash(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
+@dataclass(frozen=True)
+class CacheKey:
+    text: str
+    language_pair: LanguagePair
+
+    @property
+    def original_text_hash(self) -> str:
+        return text_hash(self.text)
+
+
 class TranslationCache:
     def __init__(self, path: str | Path) -> None:
         self.path = Path(path)
@@ -31,7 +44,7 @@ class TranslationCache:
         self.connection.execute(SCHEMA)
         self.connection.commit()
 
-    def get(self, text: str, source: str, target: str) -> str | None:
+    def get(self, key: CacheKey) -> str | None:
         row = self.connection.execute(
             """
             SELECT translated_text
@@ -40,11 +53,11 @@ class TranslationCache:
               AND target_lang = ?
               AND original_text_hash = ?
             """,
-            (source, target, text_hash(text)),
+            (key.language_pair.source, key.language_pair.target, key.original_text_hash),
         ).fetchone()
         return row[0] if row else None
 
-    def set(self, text: str, translated_text: str, source: str, target: str) -> None:
+    def set(self, key: CacheKey, translated_text: str) -> None:
         self.connection.execute(
             """
             INSERT INTO translations (
@@ -58,7 +71,13 @@ class TranslationCache:
             ON CONFLICT(source_lang, target_lang, original_text_hash)
             DO UPDATE SET translated_text = excluded.translated_text
             """,
-            (source, target, text_hash(text), text, translated_text),
+            (
+                key.language_pair.source,
+                key.language_pair.target,
+                key.original_text_hash,
+                key.text,
+                translated_text,
+            ),
         )
         self.connection.commit()
 
@@ -70,4 +89,3 @@ class TranslationCache:
 
     def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
         self.close()
-

--- a/src/ayvu/glossary.py
+++ b/src/ayvu/glossary.py
@@ -2,10 +2,30 @@ from __future__ import annotations
 
 import json
 import re
+from dataclasses import dataclass, field
 from pathlib import Path
 
 
-Glossary = dict[str, str]
+@dataclass(frozen=True)
+class Glossary:
+    terms: dict[str, str] = field(default_factory=dict)
+
+    def apply(self, text: str) -> str:
+        if not self.terms:
+            return text
+        result = text
+        for source_term, target_term in self._ordered_terms():
+            if not source_term:
+                continue
+            pattern = re.compile(rf"(?<!\w){re.escape(source_term)}(?!\w)", re.IGNORECASE)
+            result = pattern.sub(lambda match: _match_case(match.group(0), target_term), result)
+        return result
+
+    def _ordered_terms(self) -> list[tuple[str, str]]:
+        return sorted(self.terms.items(), key=lambda item: len(item[0]), reverse=True)
+
+    def __bool__(self) -> bool:
+        return bool(self.terms)
 
 
 class GlossaryError(ValueError):
@@ -14,7 +34,7 @@ class GlossaryError(ValueError):
 
 def load_glossary(path: str | Path | None) -> Glossary:
     if not path:
-        return {}
+        return Glossary()
     glossary_path = Path(path)
     if not glossary_path.exists():
         raise GlossaryError(f"Glossary file not found: {glossary_path}")
@@ -29,19 +49,15 @@ def load_glossary(path: str | Path | None) -> Glossary:
 
     if not isinstance(data, dict):
         raise GlossaryError("Glossary JSON must be an object mapping terms to translations")
-    return {str(key): str(value) for key, value in data.items()}
+    return Glossary({str(key): str(value) for key, value in data.items()})
 
 
-def apply_glossary(text: str, glossary: Glossary | None) -> str:
+def apply_glossary(text: str, glossary: Glossary | dict[str, str] | None) -> str:
     if not glossary:
         return text
-    result = text
-    for source_term, target_term in sorted(glossary.items(), key=lambda item: len(item[0]), reverse=True):
-        if not source_term:
-            continue
-        pattern = re.compile(rf"(?<!\w){re.escape(source_term)}(?!\w)", re.IGNORECASE)
-        result = pattern.sub(lambda match: _match_case(match.group(0), target_term), result)
-    return result
+    if isinstance(glossary, Glossary):
+        return glossary.apply(text)
+    return Glossary({str(key): str(value) for key, value in glossary.items()}).apply(text)
 
 
 def _match_case(original: str, replacement: str) -> str:

--- a/src/ayvu/html_translate.py
+++ b/src/ayvu/html_translate.py
@@ -5,8 +5,9 @@ from dataclasses import dataclass, field
 
 from bs4 import BeautifulSoup, Comment, Declaration, Doctype, NavigableString, ProcessingInstruction
 
-from .cache import TranslationCache
+from .cache import CacheKey, TranslationCache
 from .chunking import split_text
+from .domain import LanguagePair
 from .glossary import Glossary, apply_glossary
 from .translator import Translator
 
@@ -112,7 +113,9 @@ def translate_text(
     if not parts.core:
         return TextTranslationResult(text=text)
 
-    cached = cache.get(parts.core, source, target)
+    language_pair = LanguagePair(source=source, target=target)
+    cache_key = CacheKey(text=parts.core, language_pair=language_pair)
+    cached = cache.get(cache_key)
     if cached is not None:
         return TextTranslationResult(text=parts.restore(apply_glossary(cached, glossary)), from_cache=True)
 
@@ -124,7 +127,7 @@ def translate_text(
         for chunk in split_text(parts.core, limit=chunk_limit)
     ]
     translated = "".join(translated_chunks)
-    cache.set(parts.core, translated, source, target)
+    cache.set(cache_key, translated)
     translated = apply_glossary(translated, glossary)
     return TextTranslationResult(text=parts.restore(translated))
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,17 +1,24 @@
-from ayvu.cache import TranslationCache
+from ayvu.cache import CacheKey, TranslationCache
+from ayvu.domain import LanguagePair
+
+
+def _cache_key(text: str, source: str = "en", target: str = "pt") -> CacheKey:
+    return CacheKey(text=text, language_pair=LanguagePair(source=source, target=target))
 
 
 def test_cache_round_trip(tmp_path):
     cache_path = tmp_path / "translations.sqlite"
     with TranslationCache(cache_path) as cache:
-        assert cache.get("Hello", "en", "pt") is None
-        cache.set("Hello", "Olá", "en", "pt")
-        assert cache.get("Hello", "en", "pt") == "Olá"
+        key = _cache_key("Hello")
+
+        assert cache.get(key) is None
+        cache.set(key, "Olá")
+        assert cache.get(key) == "Olá"
 
 
 def test_cache_is_language_specific(tmp_path):
     cache_path = tmp_path / "translations.sqlite"
     with TranslationCache(cache_path) as cache:
-        cache.set("Hello", "Olá", "en", "pt")
-        assert cache.get("Hello", "en", "es") is None
+        cache.set(_cache_key("Hello", "en", "pt"), "Olá")
 
+        assert cache.get(_cache_key("Hello", "en", "es")) is None

--- a/tests/test_glossary.py
+++ b/tests/test_glossary.py
@@ -1,10 +1,10 @@
 import pytest
 
-from ayvu.glossary import GlossaryError, apply_glossary, load_glossary
+from ayvu.glossary import Glossary, GlossaryError, apply_glossary, load_glossary
 
 
 def test_apply_glossary_replaces_terms():
-    glossary = {"Game Loop": "loop de jogo", "Object Pool": "pool de objetos"}
+    glossary = Glossary({"Game Loop": "loop de jogo", "Object Pool": "pool de objetos"})
     assert apply_glossary("A Game Loop can use an Object Pool.", glossary) == (
         "A loop de jogo can use an pool de objetos."
     )
@@ -15,8 +15,18 @@ def test_apply_glossary_preserves_all_caps():
 
 
 def test_apply_glossary_prefers_longer_terms():
-    glossary = {"Pattern": "padrão", "Design Pattern": "padrão de projeto"}
+    glossary = Glossary({"Pattern": "padrão", "Design Pattern": "padrão de projeto"})
     assert apply_glossary("Design Pattern", glossary) == "padrão de projeto"
+
+
+def test_load_glossary_returns_glossary_object(tmp_path):
+    glossary_path = tmp_path / "glossary.json"
+    glossary_path.write_text('{"Observer": "Observer"}', encoding="utf-8")
+
+    glossary = load_glossary(glossary_path)
+
+    assert isinstance(glossary, Glossary)
+    assert glossary.apply("OBSERVER") == "OBSERVER"
 
 
 def test_load_glossary_missing_file_has_clear_error(tmp_path):

--- a/tests/test_html_translate.py
+++ b/tests/test_html_translate.py
@@ -1,4 +1,5 @@
-from ayvu.cache import TranslationCache
+from ayvu.cache import CacheKey, TranslationCache
+from ayvu.domain import LanguagePair
 from ayvu.html_translate import extract_visible_text, translate_html, translate_text
 from ayvu.translator import Translator
 
@@ -69,7 +70,8 @@ def test_translate_html_uses_cache(tmp_path):
 def test_translate_text_result_reports_cache_hit(tmp_path):
     translator = FakeTranslator()
     with TranslationCache(tmp_path / "cache.sqlite") as cache:
-        cache.set("Keep me", "Mantenha-me", "en", "pt")
+        cache_key = CacheKey(text="Keep me", language_pair=LanguagePair(source="en", target="pt"))
+        cache.set(cache_key, "Mantenha-me")
 
         result = translate_text(" Keep me ", translator, cache, "en", "pt")
 


### PR DESCRIPTION
## Objetivo

Concluir a rodada de alinhamento interno com o AGENTS.md, encerrando os conceitos restantes que ainda estavam representados como primitivos soltos.

Closes #8

## O que mudou

- Cria CacheKey para o cache SQLite usar texto e par de idiomas como conceito explicito.
- Atualiza TranslationCache para receber CacheKey em get e set.
- Ajusta translate_text para construir CacheKey antes de consultar ou gravar no cache.
- Transforma Glossary em objeto com comportamento proprio.
- Mantem apply_glossary como fachada compatível para usos simples.
- Adiciona testes para CacheKey, Glossary carregado de JSON e cache hit em translate_text.

## Fora do escopo

- Nao altera schema SQLite.
- Nao muda comandos ou flags da CLI.
- Nao implementa traducao por bloco com placeholders.

## Validacao

- uv run pytest -> 28 passed