### PR TITLE
Melhorar confirmação para saída existente

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ uv run ayvu translate livro.epub \
   --glossary glossary.json
 ```
 
-Sobrescrever uma saída existente:
+Se a saída já existir, o Ayvu mostra o caminho calculado e pergunta se deve sobrescrever.
+Para pular a pergunta e sobrescrever direto:
 
 ```bash
 uv run ayvu translate livro.epub \

--- a/src/ayvu/cli.py
+++ b/src/ayvu/cli.py
@@ -157,9 +157,9 @@ def translate(
     output_path = output_plan.path
 
     if output_plan.blocks_existing_file(overwrite):
-        console.print(f"[red]Output already exists:[/red] {output_path}")
-        console.print("Use --overwrite to replace it.")
-        raise typer.Exit(code=1)
+        if not _confirm_existing_output_overwrite(output_path):
+            console.print("[red]Canceled:[/red] existing output was not changed.")
+            raise typer.Exit(code=1)
 
     try:
         glossary = load_glossary(glossary_path)
@@ -252,6 +252,12 @@ def _print_report(
 
     for error in errors:
         console.print(f"[yellow]Error:[/yellow] {error}")
+
+
+def _confirm_existing_output_overwrite(output_path: Path) -> bool:
+    console.print(f"[yellow]Output path:[/yellow] {output_path}")
+    console.print("[yellow]Translated EPUB already exists.[/yellow]")
+    return typer.confirm("Overwrite existing translated EPUB?", default=False)
 
 
 def _shorten(text: str, max_length: int = 50) -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -86,3 +86,42 @@ def test_translate_command_has_clear_error_for_unknown_translator(tmp_path):
     assert "Unsupported translator: unknown" in result.output
     assert "Use --translator libretranslate." in result.output
     assert "Traceback" not in result.output
+
+
+def test_translate_command_asks_before_overwriting_existing_output_and_cancels(tmp_path):
+    epub_path = tmp_path / "book.epub"
+    output_path = tmp_path / "book-pt.epub"
+    epub_path.write_bytes(b"not a real epub")
+    output_path.write_text("already here", encoding="utf-8")
+
+    result = runner.invoke(app, ["translate", str(epub_path), "--output", str(output_path)], input="n\n")
+
+    assert result.exit_code == 1
+    assert "Output path:" in result.output
+    assert str(output_path) in result.output
+    assert "Translated EPUB already exists." in result.output
+    assert "Overwrite existing translated EPUB?" in result.output
+    assert "Canceled:" in result.output
+    assert "existing output was not changed." in result.output
+    assert output_path.read_text(encoding="utf-8") == "already here"
+    assert "Traceback" not in result.output
+
+
+def test_translate_command_continues_when_existing_output_is_confirmed(tmp_path):
+    epub_path = tmp_path / "book.epub"
+    output_path = tmp_path / "book-pt.epub"
+    epub_path.write_bytes(b"not a real epub")
+    output_path.write_text("already here", encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        ["translate", str(epub_path), "--output", str(output_path), "--translator", "unknown"],
+        input="y\n",
+    )
+
+    assert result.exit_code == 1
+    assert "Overwrite existing translated EPUB?" in result.output
+    assert "Translator error:" in result.output
+    assert "Unsupported translator: unknown" in result.output
+    assert output_path.read_text(encoding="utf-8") == "already here"
+    assert "Traceback" not in result.output


### PR DESCRIPTION
## Objetivo

Permitir que o usuário decida durante a execução se deseja sobrescrever o EPUB traduzido quando o caminho de saída já existir.

## O que mudou

- O comando translate agora mostra o caminho de saída calculado quando o arquivo já existe.
- Sem --overwrite, a CLI pergunta se deve sobrescrever o EPUB existente.
- Resposta negativa cancela antes da tradução e preserva a saída existente.
- Resposta positiva continua o fluxo normal.
- A documentação explica que --overwrite pula a pergunta.

## Fora do escopo

- Não muda a regra de nomes de saída.
- Não altera leitura, tradução ou escrita estrutural de EPUB.
- Não inclui arquivos locais não relacionados do checkout.

## Validação/testes

- uv run pytest tests/test_cli.py
- uv run pytest

## Issue relacionada

Closes #2
