### PR TITLE
Mostrar relatorio da traducao e oferecer Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,11 @@ uv run ayvu translate livro.epub \
   --dry-run
 ```
 
+Ao final da tradução, o Ayvu mostra um relatório no terminal com o EPUB original,
+idiomas, saída calculada, capítulos processados, textos traduzidos, cache e erros.
+Também pergunta se deve salvar esse relatório em Markdown em
+`~/Documentos/Livros/Relatorios`.
+
 Extrair texto visível para Markdown:
 
 ```bash

--- a/src/ayvu/cli.py
+++ b/src/ayvu/cli.py
@@ -11,7 +11,7 @@ from rich.table import Table
 
 from .cache import TranslationCache
 from .domain import LanguagePair, OutputPlan, TranslationOptions
-from .epub_io import extract_markdown, inspect_epub, translate_epub
+from .epub_io import TranslationReport, extract_markdown, inspect_epub, translate_epub
 from .glossary import GlossaryError, load_glossary
 from .translator import LibreTranslateTranslator, TranslatorError, create_translator
 from .validation import validate_output_epub
@@ -198,14 +198,8 @@ def translate(
                 on_text_processed=progress_view.text_processed,
             )
 
-    _print_report(
-        report.chapters_processed,
-        report.texts_translated,
-        report.texts_from_cache,
-        report.errors,
-        output_path,
-        dry_run,
-    )
+    _print_report(report, dry_run)
+    _offer_markdown_report(report, dry_run)
 
     if not dry_run:
         validation = validate_output_epub(output_path)
@@ -232,26 +226,107 @@ def extract(
     console.print(f"[green]Extracted {len(written)} Markdown files to[/green] {output}")
 
 
-def _print_report(
-    chapters_processed: int,
-    translated: int,
-    from_cache: int,
-    errors: list[str],
-    output: Path,
-    dry_run: bool,
-) -> None:
+def _print_report(report: TranslationReport, dry_run: bool) -> None:
     table = Table(title="Translation report")
     table.add_column("Metric")
     table.add_column("Value")
-    table.add_row("Chapters processed", str(chapters_processed))
-    table.add_row("Texts translated", str(translated))
-    table.add_row("Texts from cache", str(from_cache))
-    table.add_row("Errors", str(len(errors)))
-    table.add_row("Output", str(output) if not dry_run else "(dry run, no file written)")
+    table.add_row("Original EPUB", _display_optional_path(report.input_path))
+    table.add_row("Detected language", report.detected_language or "-")
+    table.add_row("Translated language", report.target_language or "-")
+    table.add_row("Output", _report_output_value(report, dry_run))
+    table.add_row("Chapters processed", str(report.chapters_processed))
+    table.add_row("Texts translated", str(report.texts_translated))
+    table.add_row("Texts from cache", str(report.texts_from_cache))
+    table.add_row("Errors", str(len(report.errors)))
     console.print(table)
 
-    for error in errors:
+    for error in report.errors:
         console.print(f"[yellow]Error:[/yellow] {error}")
+
+
+def _offer_markdown_report(report: TranslationReport, dry_run: bool) -> None:
+    if not typer.confirm("Save translation report as Markdown?", default=False):
+        return
+
+    path = _save_markdown_report(report, dry_run)
+    console.print(f"[green]Report saved to:[/green] {path}")
+
+
+def _save_markdown_report(report: TranslationReport, dry_run: bool) -> Path:
+    directory = _default_reports_dir()
+    directory.mkdir(parents=True, exist_ok=True)
+    path = _next_available_report_path(directory, _report_filename_stem(report))
+    path.write_text(_render_markdown_report(report, dry_run), encoding="utf-8")
+    return path
+
+
+def _render_markdown_report(report: TranslationReport, dry_run: bool) -> str:
+    lines = [
+        "# Translation report",
+        "",
+        f"- Original EPUB: {_display_optional_path(report.input_path)}",
+        f"- Detected language: {report.detected_language or '-'}",
+        f"- Translated language: {report.target_language or '-'}",
+        f"- Output: {_report_output_value(report, dry_run)}",
+        f"- Chapters processed: {report.chapters_processed}",
+        f"- Texts translated: {report.texts_translated}",
+        f"- Texts from cache: {report.texts_from_cache}",
+        f"- Errors: {len(report.errors)}",
+    ]
+
+    if report.errors:
+        lines.extend(["", "## Errors"])
+        lines.extend(f"- {_single_line(error)}" for error in report.errors)
+
+    return "\n".join(lines) + "\n"
+
+
+def _default_reports_dir() -> Path:
+    return Path.home() / "Documentos" / "Livros" / "Relatorios"
+
+
+def _next_available_report_path(directory: Path, stem: str) -> Path:
+    path = directory / f"{stem}.md"
+    index = 2
+    while path.exists():
+        path = directory / f"{stem}-{index}.md"
+        index += 1
+    return path
+
+
+def _report_filename_stem(report: TranslationReport) -> str:
+    source = _safe_filename_part(report.input_path.stem if report.input_path else "translation")
+    target = _safe_filename_part(report.target_language or "translated")
+    return f"{source}-{target}-report"
+
+
+def _safe_filename_part(value: str) -> str:
+    clean = []
+    for char in value.strip():
+        if char.isalnum() or char in ("-", "_"):
+            clean.append(char)
+            continue
+        if char in (" ", "."):
+            clean.append("-")
+
+    filename = "".join(clean).strip("-_")
+    return filename or "translation"
+
+
+def _display_optional_path(path: Path | None) -> str:
+    if path is None:
+        return "-"
+    return str(path)
+
+
+def _report_output_value(report: TranslationReport, dry_run: bool) -> str:
+    if dry_run:
+        return "(dry run, no file written)"
+    return _display_optional_path(report.output_path)
+
+
+def _single_line(value: str) -> str:
+    return " ".join(value.split())
 
 
 def _confirm_existing_output_overwrite(output_path: Path) -> bool:

--- a/src/ayvu/epub_io.py
+++ b/src/ayvu/epub_io.py
@@ -39,6 +39,9 @@ class TranslationReport:
     texts_skipped: int = 0
     errors: list[str] = field(default_factory=list)
     output_path: Path | None = None
+    input_path: Path | None = None
+    detected_language: str | None = None
+    target_language: str | None = None
 
     def record_missing_document(self, document: "EpubDocument") -> str:
         message = f"{document.name}: document not found in EPUB archive at {document.archive_path}"
@@ -108,7 +111,12 @@ def translate_epub(
     source_path = Path(input_path)
     destination_path = Path(output_path)
     book = epub.read_epub(str(source_path))
-    report = TranslationReport(output_path=destination_path)
+    report = TranslationReport(
+        output_path=destination_path,
+        input_path=source_path,
+        detected_language=_first_metadata(book, "DC", "language"),
+        target_language=options.target,
+    )
     opf_base_path = _get_opf_base_path(source_path)
     replacements = EpubReplacements()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,8 +3,10 @@ from pathlib import Path
 import pytest
 from typer.testing import CliRunner
 
-from ayvu.cli import TextProgressCounters, app
+from ayvu.cli import TextProgressCounters, _offer_markdown_report, _render_markdown_report, _save_markdown_report, app
 from ayvu.domain import LanguagePair, OutputPlan, TranslationOptions
+from ayvu.epub_io import TranslationReport
+from ayvu.validation import ValidationResult
 
 
 runner = CliRunner()
@@ -125,3 +127,107 @@ def test_translate_command_continues_when_existing_output_is_confirmed(tmp_path)
     assert "Unsupported translator: unknown" in result.output
     assert output_path.read_text(encoding="utf-8") == "already here"
     assert "Traceback" not in result.output
+
+
+def test_render_markdown_report_includes_translation_context():
+    report = TranslationReport(
+        chapters_processed=2,
+        texts_translated=3,
+        texts_from_cache=1,
+        errors=["chapter.xhtml: failed\nwhile translating"],
+        output_path=Path("books/book-pt.epub"),
+        input_path=Path("books/book.epub"),
+        detected_language="en",
+        target_language="pt",
+    )
+
+    markdown = _render_markdown_report(report, dry_run=False)
+
+    assert "# Translation report" in markdown
+    assert "- Original EPUB: books/book.epub" in markdown
+    assert "- Detected language: en" in markdown
+    assert "- Translated language: pt" in markdown
+    assert "- Output: books/book-pt.epub" in markdown
+    assert "- Chapters processed: 2" in markdown
+    assert "- Texts translated: 3" in markdown
+    assert "- Texts from cache: 1" in markdown
+    assert "- Errors: 1" in markdown
+    assert "- chapter.xhtml: failed while translating" in markdown
+
+
+def test_save_markdown_report_uses_default_reports_dir_without_overwriting(tmp_path, monkeypatch):
+    reports_dir = tmp_path / "reports"
+    report = TranslationReport(
+        output_path=Path("book-pt.epub"),
+        input_path=Path("book.epub"),
+        target_language="pt",
+    )
+    monkeypatch.setattr("ayvu.cli._default_reports_dir", lambda: reports_dir)
+
+    first_path = _save_markdown_report(report, dry_run=False)
+    second_path = _save_markdown_report(report, dry_run=False)
+
+    assert first_path == reports_dir / "book-pt-report.md"
+    assert second_path == reports_dir / "book-pt-report-2.md"
+    assert first_path.read_text(encoding="utf-8").startswith("# Translation report")
+    assert second_path.read_text(encoding="utf-8").startswith("# Translation report")
+
+
+def test_offer_markdown_report_does_not_save_when_declined(monkeypatch):
+    saved = False
+
+    def fake_save_report(_report: TranslationReport, _dry_run: bool) -> Path:
+        nonlocal saved
+        saved = True
+        return Path("report.md")
+
+    monkeypatch.setattr("ayvu.cli.typer.confirm", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr("ayvu.cli._save_markdown_report", fake_save_report)
+
+    _offer_markdown_report(TranslationReport(), dry_run=False)
+
+    assert not saved
+
+
+def test_translate_command_offers_and_saves_markdown_report(tmp_path, monkeypatch):
+    epub_path = tmp_path / "book.epub"
+    output_path = tmp_path / "book-pt.epub"
+    reports_dir = tmp_path / "reports"
+    epub_path.write_bytes(b"fake epub")
+
+    report = TranslationReport(
+        chapters_processed=1,
+        texts_translated=2,
+        texts_from_cache=1,
+        output_path=output_path,
+        input_path=epub_path,
+        detected_language="en",
+        target_language="pt",
+    )
+    monkeypatch.setattr("ayvu.cli.load_glossary", lambda _path: None)
+    monkeypatch.setattr("ayvu.cli.create_translator", lambda *_args, **_kwargs: object())
+    monkeypatch.setattr("ayvu.cli.TranslationCache", lambda _path: FakeCache())
+    monkeypatch.setattr("ayvu.cli.translate_epub", lambda *_args, **_kwargs: report)
+    monkeypatch.setattr("ayvu.cli.validate_output_epub", lambda _path: ValidationResult(ok=True, document_count=1))
+    monkeypatch.setattr("ayvu.cli._default_reports_dir", lambda: reports_dir)
+
+    result = runner.invoke(app, ["translate", str(epub_path), "--output", str(output_path)], input="y\n")
+
+    report_path = reports_dir / "book-pt-report.md"
+    assert result.exit_code == 0
+    assert "Translation report" in result.output
+    assert "Original EPUB" in result.output
+    assert "Detected language" in result.output
+    assert "Save translation report as Markdown?" in result.output
+    assert "Report saved to:" in result.output
+    assert report_path.exists()
+    assert "- Original EPUB: " in report_path.read_text(encoding="utf-8")
+    assert str(epub_path) in report_path.read_text(encoding="utf-8")
+
+
+class FakeCache:
+    def __enter__(self) -> "FakeCache":
+        return self
+
+    def __exit__(self, _exc_type: object, _exc: object, _traceback: object) -> None:
+        return None


### PR DESCRIPTION
## Objetivo

Mostrar um relatorio claro ao final de ayvu translate e permitir salvar esse resultado em Markdown.

## O que mudou

- O relatorio final agora inclui EPUB original, idioma detectado, idioma traduzido, caminho de saida, capitulos processados, textos traduzidos, textos vindos do cache e erros.
- O comando pergunta se o usuario deseja salvar o relatorio como Markdown.
- Quando confirmado, o Markdown e salvo em ~/Documentos/Livros/Relatorios sem sobrescrever relatorios existentes.
- O README documenta o novo comportamento.
- A suite cobre renderizacao do Markdown, salvamento, recusa do salvamento e o fluxo da CLI com fakes.

## Fora do escopo

- Nao altera o formato do EPUB gerado.
- Nao muda tradutor, cache, glossario ou validacao de EPUB.
- Nao inclui arquivos locais fora do escopo, como AGENTS.md, docs locais ou .gitignore.

## Validacao e testes

- uv run pytest: 34 passed
- git diff --check: sem problemas

Closes #3