### PR TITLE
Verificar ambiente internamente antes da tradução

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,9 @@ livro-extraido/
 # Local configuration and private glossary
 .codex
 glossary.json
+AGENTS.md
+AGENTS-Geral.md
+docs/*
+
+# Personal Ayvu workspace
+.ayvu-pessoal/

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ uv run ayvu translate livro.epub \
   --cache .cache/traducoes.sqlite
 ```
 
+Antes de iniciar a tradução, o Ayvu verifica internamente o par de idiomas, o glossário, o cache, o EPUB de entrada e, em traduções reais, o tradutor configurado. Se algo impedir a execução, o comando falha cedo com uma mensagem curta e um próximo passo.
+
 Sem `--output`, a saída é criada ao lado do arquivo original usando o idioma de destino:
 
 ```text

--- a/src/ayvu/cache.py
+++ b/src/ayvu/cache.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import sqlite3
+from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -80,6 +81,46 @@ class TranslationCache:
             ),
         )
         self.connection.commit()
+
+    def verify_writable(self) -> None:
+        original_text = "__ayvu_cache_write_check__"
+        self.connection.execute("SAVEPOINT ayvu_cache_write_check")
+        try:
+            self.connection.execute(
+                """
+                INSERT INTO translations (
+                    source_lang,
+                    target_lang,
+                    original_text_hash,
+                    original_text,
+                    translated_text
+                )
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    "ayvu",
+                    "ayvu",
+                    text_hash(original_text),
+                    original_text,
+                    original_text,
+                ),
+            )
+        except sqlite3.Error:
+            self._rollback_write_check(ignore_errors=True)
+            raise
+
+        self._rollback_write_check(ignore_errors=False)
+
+    def _rollback_write_check(self, ignore_errors: bool) -> None:
+        if ignore_errors:
+            with suppress(sqlite3.Error):
+                self.connection.execute("ROLLBACK TO SAVEPOINT ayvu_cache_write_check")
+            with suppress(sqlite3.Error):
+                self.connection.execute("RELEASE SAVEPOINT ayvu_cache_write_check")
+            return
+
+        self.connection.execute("ROLLBACK TO SAVEPOINT ayvu_cache_write_check")
+        self.connection.execute("RELEASE SAVEPOINT ayvu_cache_write_check")
 
     def close(self) -> None:
         self.connection.close()

--- a/src/ayvu/cli.py
+++ b/src/ayvu/cli.py
@@ -12,8 +12,8 @@ from rich.table import Table
 from .cache import TranslationCache
 from .domain import LanguagePair, OutputPlan, TranslationOptions
 from .epub_io import TranslationReport, extract_markdown, inspect_epub, translate_epub
-from .glossary import GlossaryError, load_glossary
-from .translator import LibreTranslateTranslator, TranslatorError, create_translator
+from .preflight import PreflightError, run_translation_preflight
+from .translator import LibreTranslateTranslator, TranslatorError
 from .validation import validate_output_epub
 
 
@@ -162,17 +162,20 @@ def translate(
             raise typer.Exit(code=1)
 
     try:
-        glossary = load_glossary(glossary_path)
-    except GlossaryError as exc:
-        console.print(f"[red]Glossary error:[/red] {exc}")
-        console.print("Create the file, pass the correct path, or remove --glossary to run without one.")
-        raise typer.Exit(code=1) from exc
-
-    try:
-        translator = create_translator(translator_name, url=url, timeout=timeout, retries=retries)
-    except TranslatorError as exc:
-        console.print(f"[red]Translator error:[/red] {exc}")
-        console.print("Use --translator libretranslate.")
+        preflight = run_translation_preflight(
+            epub_path=epub_path,
+            cache_path=cache_path,
+            glossary_path=glossary_path,
+            translator_name=translator_name,
+            url=url,
+            timeout=timeout,
+            retries=retries,
+            language_pair=language_pair,
+            dry_run=dry_run,
+        )
+    except PreflightError as exc:
+        console.print(f"[red]Environment check failed:[/red] {exc}")
+        console.print(exc.next_step)
         raise typer.Exit(code=1) from exc
 
     with Progress(
@@ -189,10 +192,10 @@ def translate(
             report = translate_epub(
                 epub_path,
                 output_path,
-                translator=translator,
+                translator=preflight.translator,
                 cache=cache,
                 options=translation_options,
-                glossary=glossary,
+                glossary=preflight.glossary,
                 on_chapter_start=progress_view.chapter_started,
                 on_chapter_done=progress_view.chapter_done,
                 on_text_processed=progress_view.text_processed,

--- a/src/ayvu/domain.py
+++ b/src/ayvu/domain.py
@@ -4,6 +4,10 @@ from dataclasses import dataclass
 from pathlib import Path
 
 
+class LanguagePairError(ValueError):
+    pass
+
+
 @dataclass(frozen=True)
 class LanguagePair:
     source: str
@@ -12,6 +16,12 @@ class LanguagePair:
     @property
     def target_label(self) -> str:
         return self.target.strip() or "translated"
+
+    def validate_for_translation(self) -> None:
+        if not self.source.strip():
+            raise LanguagePairError("source language is required")
+        if not self.target.strip():
+            raise LanguagePairError("target language is required")
 
 
 @dataclass(frozen=True)

--- a/src/ayvu/preflight.py
+++ b/src/ayvu/preflight.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+
+from .cache import TranslationCache
+from .domain import LanguagePair, LanguagePairError
+from .epub_io import inspect_epub
+from .glossary import Glossary, GlossaryError, load_glossary
+from .translator import Translator, TranslatorError, create_translator
+
+
+class PreflightError(RuntimeError):
+    def __init__(self, message: str, next_step: str) -> None:
+        super().__init__(message)
+        self.next_step = next_step
+
+
+@dataclass(frozen=True)
+class TranslationPreflightResult:
+    translator: Translator
+    glossary: Glossary
+
+
+def run_translation_preflight(
+    epub_path: Path,
+    cache_path: Path,
+    glossary_path: Path | None,
+    translator_name: str,
+    url: str,
+    timeout: float,
+    retries: int,
+    language_pair: LanguagePair,
+    dry_run: bool,
+) -> TranslationPreflightResult:
+    _check_language_pair(language_pair)
+    glossary = _load_checked_glossary(glossary_path)
+    translator = _create_checked_translator(translator_name, url, timeout, retries)
+    _check_cache(cache_path)
+    _check_epub(epub_path)
+    if not dry_run:
+        _check_translator(translator, language_pair, url)
+    return TranslationPreflightResult(translator=translator, glossary=glossary)
+
+
+def _check_language_pair(language_pair: LanguagePair) -> None:
+    try:
+        language_pair.validate_for_translation()
+    except LanguagePairError as exc:
+        raise PreflightError(
+            f"Language pair check failed: {exc}.",
+            "Use non-empty language codes with --source and --target, for example --source en --target pt.",
+        ) from exc
+
+
+def _load_checked_glossary(glossary_path: Path | None) -> Glossary:
+    try:
+        return load_glossary(glossary_path)
+    except GlossaryError as exc:
+        raise PreflightError(
+            f"Glossary check failed: {exc}",
+            "Create the file, pass the correct path, or remove --glossary to run without one.",
+        ) from exc
+
+
+def _create_checked_translator(name: str, url: str, timeout: float, retries: int) -> Translator:
+    try:
+        return create_translator(name, url=url, timeout=timeout, retries=retries)
+    except TranslatorError as exc:
+        raise PreflightError(
+            f"Translator check failed: {exc}",
+            "Use --translator libretranslate.",
+        ) from exc
+
+
+def _check_cache(cache_path: Path) -> None:
+    try:
+        with TranslationCache(cache_path) as cache:
+            cache.verify_writable()
+    except (OSError, sqlite3.Error) as exc:
+        raise PreflightError(
+            f"Cache check failed: could not create or write cache at {cache_path}: {exc}",
+            "Choose a writable cache path with --cache or fix permissions for the cache directory.",
+        ) from exc
+
+
+def _check_epub(epub_path: Path) -> None:
+    try:
+        inspect_epub(epub_path)
+    except Exception as exc:
+        raise PreflightError(
+            f"EPUB check failed: could not read {epub_path}: {exc}",
+            "Confirm the file is a valid readable EPUB and try again.",
+        ) from exc
+
+
+def _check_translator(translator: Translator, language_pair: LanguagePair, url: str) -> None:
+    try:
+        translator.translate("Hello world", language_pair.source, language_pair.target)
+    except Exception as exc:
+        raise PreflightError(
+            f"Translator check failed: {exc}",
+            f"Start LibreTranslate at {url}, check --url, and confirm the language pair is available.",
+        ) from exc

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -22,3 +22,11 @@ def test_cache_is_language_specific(tmp_path):
         cache.set(_cache_key("Hello", "en", "pt"), "Olá")
 
         assert cache.get(_cache_key("Hello", "en", "es")) is None
+
+
+def test_cache_writable_check_does_not_persist_probe(tmp_path):
+    cache_path = tmp_path / "translations.sqlite"
+    with TranslationCache(cache_path) as cache:
+        cache.verify_writable()
+
+        assert cache.get(_cache_key("__ayvu_cache_write_check__", "ayvu", "ayvu")) is None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from typer.testing import CliRunner
@@ -6,6 +7,7 @@ from typer.testing import CliRunner
 from ayvu.cli import TextProgressCounters, _offer_markdown_report, _render_markdown_report, _save_markdown_report, app
 from ayvu.domain import LanguagePair, OutputPlan, TranslationOptions
 from ayvu.epub_io import TranslationReport
+from ayvu.preflight import PreflightError
 from ayvu.validation import ValidationResult
 
 
@@ -84,9 +86,33 @@ def test_translate_command_has_clear_error_for_unknown_translator(tmp_path):
     result = runner.invoke(app, ["translate", str(epub_path), "--translator", "unknown", "--dry-run"])
 
     assert result.exit_code == 1
-    assert "Translator error:" in result.output
-    assert "Unsupported translator: unknown" in result.output
+    assert "Environment check failed:" in result.output
+    assert "Translator check failed:" in result.output
+    assert "Unsupported translator:" in result.output
+    assert "unknown" in result.output
     assert "Use --translator libretranslate." in result.output
+    assert "Traceback" not in result.output
+
+
+def test_translate_command_stops_when_preflight_fails(tmp_path, monkeypatch):
+    epub_path = tmp_path / "book.epub"
+    epub_path.write_bytes(b"fake epub")
+
+    def fail_preflight(**_kwargs: object) -> object:
+        raise PreflightError("Cache check failed: no write permission", "Choose a writable cache path.")
+
+    def fail_translate(*_args: object, **_kwargs: object) -> TranslationReport:
+        raise AssertionError("translation should not start when preflight fails")
+
+    monkeypatch.setattr("ayvu.cli.run_translation_preflight", fail_preflight)
+    monkeypatch.setattr("ayvu.cli.translate_epub", fail_translate)
+
+    result = runner.invoke(app, ["translate", str(epub_path)])
+
+    assert result.exit_code == 1
+    assert "Environment check failed:" in result.output
+    assert "Cache check failed: no write permission" in result.output
+    assert "Choose a writable cache path." in result.output
     assert "Traceback" not in result.output
 
 
@@ -123,8 +149,10 @@ def test_translate_command_continues_when_existing_output_is_confirmed(tmp_path)
 
     assert result.exit_code == 1
     assert "Overwrite existing translated EPUB?" in result.output
-    assert "Translator error:" in result.output
-    assert "Unsupported translator: unknown" in result.output
+    assert "Environment check failed:" in result.output
+    assert "Translator check failed:" in result.output
+    assert "Unsupported translator:" in result.output
+    assert "unknown" in result.output
     assert output_path.read_text(encoding="utf-8") == "already here"
     assert "Traceback" not in result.output
 
@@ -204,8 +232,10 @@ def test_translate_command_offers_and_saves_markdown_report(tmp_path, monkeypatc
         detected_language="en",
         target_language="pt",
     )
-    monkeypatch.setattr("ayvu.cli.load_glossary", lambda _path: None)
-    monkeypatch.setattr("ayvu.cli.create_translator", lambda *_args, **_kwargs: object())
+    monkeypatch.setattr(
+        "ayvu.cli.run_translation_preflight",
+        lambda **_kwargs: SimpleNamespace(translator=object(), glossary=None),
+    )
     monkeypatch.setattr("ayvu.cli.TranslationCache", lambda _path: FakeCache())
     monkeypatch.setattr("ayvu.cli.translate_epub", lambda *_args, **_kwargs: report)
     monkeypatch.setattr("ayvu.cli.validate_output_epub", lambda _path: ValidationResult(ok=True, document_count=1))

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1,0 +1,132 @@
+import pytest
+
+from ayvu.cache import CacheKey, TranslationCache
+from ayvu.domain import LanguagePair
+from ayvu.preflight import PreflightError, run_translation_preflight
+from ayvu.translator import TranslatorError
+
+
+class FakeTranslator:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, str]] = []
+
+    def translate(self, text: str, source: str, target: str) -> str:
+        self.calls.append((text, source, target))
+        return text
+
+
+class FailingTranslator:
+    def translate(self, _text: str, _source: str, _target: str) -> str:
+        raise TranslatorError("language pair is not available")
+
+
+def raise_bad_epub(_path: object) -> object:
+    raise ValueError("bad epub")
+
+
+def test_preflight_checks_cache_epub_and_translator(monkeypatch, tmp_path):
+    translator = FakeTranslator()
+    cache_path = tmp_path / "cache.sqlite"
+    monkeypatch.setattr("ayvu.preflight.create_translator", lambda *_args, **_kwargs: translator)
+    monkeypatch.setattr("ayvu.preflight.inspect_epub", lambda _path: object())
+
+    result = run_translation_preflight(
+        epub_path=tmp_path / "book.epub",
+        cache_path=cache_path,
+        glossary_path=None,
+        translator_name="libretranslate",
+        url="http://localhost:5000",
+        timeout=1.0,
+        retries=0,
+        language_pair=LanguagePair(source="en", target="pt"),
+        dry_run=False,
+    )
+
+    probe_key = CacheKey(
+        text="__ayvu_cache_write_check__",
+        language_pair=LanguagePair(source="ayvu", target="ayvu"),
+    )
+    with TranslationCache(cache_path) as cache:
+        assert cache.get(probe_key) is None
+    assert result.translator is translator
+    assert translator.calls == [("Hello world", "en", "pt")]
+
+
+def test_preflight_dry_run_skips_translator_probe(monkeypatch, tmp_path):
+    translator = FakeTranslator()
+    monkeypatch.setattr("ayvu.preflight.create_translator", lambda *_args, **_kwargs: translator)
+    monkeypatch.setattr("ayvu.preflight.inspect_epub", lambda _path: object())
+
+    run_translation_preflight(
+        epub_path=tmp_path / "book.epub",
+        cache_path=tmp_path / "cache.sqlite",
+        glossary_path=None,
+        translator_name="libretranslate",
+        url="http://localhost:5000",
+        timeout=1.0,
+        retries=0,
+        language_pair=LanguagePair(source="en", target="pt"),
+        dry_run=True,
+    )
+
+    assert translator.calls == []
+
+
+def test_preflight_rejects_blank_language_pair(tmp_path):
+    with pytest.raises(PreflightError) as error:
+        run_translation_preflight(
+            epub_path=tmp_path / "book.epub",
+            cache_path=tmp_path / "cache.sqlite",
+            glossary_path=None,
+            translator_name="libretranslate",
+            url="http://localhost:5000",
+            timeout=1.0,
+            retries=0,
+            language_pair=LanguagePair(source="en", target=" "),
+            dry_run=True,
+        )
+
+    assert "Language pair check failed" in str(error.value)
+    assert "--source and --target" in error.value.next_step
+
+
+def test_preflight_reports_translator_probe_failure(monkeypatch, tmp_path):
+    monkeypatch.setattr("ayvu.preflight.create_translator", lambda *_args, **_kwargs: FailingTranslator())
+    monkeypatch.setattr("ayvu.preflight.inspect_epub", lambda _path: object())
+
+    with pytest.raises(PreflightError) as error:
+        run_translation_preflight(
+            epub_path=tmp_path / "book.epub",
+            cache_path=tmp_path / "cache.sqlite",
+            glossary_path=None,
+            translator_name="libretranslate",
+            url="http://localhost:5000",
+            timeout=1.0,
+            retries=0,
+            language_pair=LanguagePair(source="en", target="pt"),
+            dry_run=False,
+        )
+
+    assert "Translator check failed" in str(error.value)
+    assert "language pair is available" in error.value.next_step
+
+
+def test_preflight_reports_epub_failure(monkeypatch, tmp_path):
+    monkeypatch.setattr("ayvu.preflight.create_translator", lambda *_args, **_kwargs: FakeTranslator())
+    monkeypatch.setattr("ayvu.preflight.inspect_epub", raise_bad_epub)
+
+    with pytest.raises(PreflightError) as error:
+        run_translation_preflight(
+            epub_path=tmp_path / "book.epub",
+            cache_path=tmp_path / "cache.sqlite",
+            glossary_path=None,
+            translator_name="libretranslate",
+            url="http://localhost:5000",
+            timeout=1.0,
+            retries=0,
+            language_pair=LanguagePair(source="en", target="pt"),
+            dry_run=False,
+        )
+
+    assert "EPUB check failed" in str(error.value)
+    assert "valid readable EPUB" in error.value.next_step


### PR DESCRIPTION
## Objetivo

Adicionar uma checagem interna antes de iniciar `ayvu translate`, para falhar cedo quando o ambiente não estiver pronto.

## O que mudou

- Adiciona um preflight para validar par de idiomas, glossário, cache, EPUB de entrada e tradutor configurado.
- Verifica escrita real no cache SQLite sem persistir o registro de teste.
- Faz `translate` parar antes do progresso e da tradução quando a checagem falha, com mensagem clara e próximo passo.
- Mantém `--dry-run` sem probe de rede do tradutor, porque nesse modo não há chamadas reais de tradução.
- Documenta o comportamento no README.
- Inclui no `.gitignore` os arquivos locais combinados: `AGENTS.md`, `AGENTS-Geral.md`, `docs/*` e `.ayvu-pessoal/`.

## Fora do escopo

- Não adiciona comando novo de diagnóstico.
- Não tenta iniciar ou gerenciar o LibreTranslate automaticamente.
- Não altera o formato do EPUB gerado nem o fluxo de cache de traduções reais.

## Validação e testes

- `uv run pytest`: 41 passed
- `git diff --check`: sem problemas

Closes #4
