### PR TITLE
Extrair progresso da CLI para modulo dedicado

### DIFF
--- a/src/ayvu/cli.py
+++ b/src/ayvu/cli.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
@@ -10,6 +9,7 @@ from rich.progress import BarColumn, Progress, SpinnerColumn, TaskProgressColumn
 from rich.table import Table
 
 from .cache import TranslationCache
+from .cli_progress import TranslationProgress
 from .domain import LanguagePair, OutputPlan, TranslationOptions
 from .epub_io import TranslationReport, extract_markdown, inspect_epub, translate_epub
 from .preflight import PreflightError, run_translation_preflight
@@ -19,74 +19,6 @@ from .validation import validate_output_epub
 
 app = typer.Typer(help="Translate local EPUB files with a local HTTP translator.")
 console = Console()
-
-
-@dataclass
-class TextProgressCounters:
-    translated: int = 0
-    cache: int = 0
-    dry_run: int = 0
-    error: int = 0
-
-    def record(self, status: str) -> None:
-        if status == "translated":
-            self.translated += 1
-            return
-        if status == "cache":
-            self.cache += 1
-            return
-        if status == "dry_run":
-            self.dry_run += 1
-            return
-        if status == "error":
-            self.error += 1
-            return
-        raise ValueError(f"Unknown text progress status: {status}")
-
-    @property
-    def processed(self) -> int:
-        return self.translated + self.cache + self.dry_run + self.error
-
-    def new_count(self, dry_run: bool) -> int:
-        if dry_run:
-            return self.dry_run
-        return self.translated
-
-
-class TranslationProgress:
-    def __init__(self, progress: Progress, dry_run: bool) -> None:
-        self._progress = progress
-        self._dry_run = dry_run
-        self._counters = TextProgressCounters()
-        self._chapter_task = progress.add_task("Chapters", total=None)
-        self._text_task = progress.add_task("Texts", total=None)
-
-    def chapter_started(self, index: int, total: int, name: str) -> None:
-        self._progress.update(
-            self._chapter_task,
-            total=total,
-            description=self._chapter_description(index, total, name),
-        )
-
-    def chapter_done(self, index: int, total: int, name: str, _stats: object) -> None:
-        self._progress.advance(self._chapter_task)
-        self._progress.update(self._chapter_task, description=self._chapter_description(index, total, name))
-
-    def text_processed(self, status: str) -> None:
-        self._counters.record(status)
-        self._progress.advance(self._text_task)
-        self._progress.update(self._text_task, description=self._text_description())
-
-    def _chapter_description(self, index: int, total: int, name: str) -> str:
-        return f"Chapters {index}/{total}: {_shorten(name)}"
-
-    def _text_description(self) -> str:
-        new_label = "would translate" if self._dry_run else "new"
-        new_count = self._counters.new_count(self._dry_run)
-        return (
-            f"Texts {self._counters.processed} | {new_label} {new_count} | "
-            f"cache {self._counters.cache} | errors {self._counters.error}"
-        )
 
 
 @app.command()
@@ -336,12 +268,6 @@ def _confirm_existing_output_overwrite(output_path: Path) -> bool:
     console.print(f"[yellow]Output path:[/yellow] {output_path}")
     console.print("[yellow]Translated EPUB already exists.[/yellow]")
     return typer.confirm("Overwrite existing translated EPUB?", default=False)
-
-
-def _shorten(text: str, max_length: int = 50) -> str:
-    if len(text) <= max_length:
-        return text
-    return text[: max_length - 3] + "..."
 
 
 if __name__ == "__main__":

--- a/src/ayvu/cli_progress.py
+++ b/src/ayvu/cli_progress.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from rich.progress import Progress
+
+
+@dataclass
+class TextProgressCounters:
+    translated: int = 0
+    cache: int = 0
+    dry_run: int = 0
+    error: int = 0
+
+    def record(self, status: str) -> None:
+        if status == "translated":
+            self.translated += 1
+            return
+        if status == "cache":
+            self.cache += 1
+            return
+        if status == "dry_run":
+            self.dry_run += 1
+            return
+        if status == "error":
+            self.error += 1
+            return
+        raise ValueError(f"Unknown text progress status: {status}")
+
+    @property
+    def processed(self) -> int:
+        return self.translated + self.cache + self.dry_run + self.error
+
+    def new_count(self, dry_run: bool) -> int:
+        if dry_run:
+            return self.dry_run
+        return self.translated
+
+
+class TranslationProgress:
+    def __init__(self, progress: Progress, dry_run: bool) -> None:
+        self._progress = progress
+        self._dry_run = dry_run
+        self._counters = TextProgressCounters()
+        self._chapter_task = progress.add_task("Chapters", total=None)
+        self._text_task = progress.add_task("Texts", total=None)
+
+    def chapter_started(self, index: int, total: int, name: str) -> None:
+        self._progress.update(
+            self._chapter_task,
+            total=total,
+            description=self._chapter_description(index, total, name),
+        )
+
+    def chapter_done(self, index: int, total: int, name: str, _stats: object) -> None:
+        self._progress.advance(self._chapter_task)
+        self._progress.update(self._chapter_task, description=self._chapter_description(index, total, name))
+
+    def text_processed(self, status: str) -> None:
+        self._counters.record(status)
+        self._progress.advance(self._text_task)
+        self._progress.update(self._text_task, description=self._text_description())
+
+    def _chapter_description(self, index: int, total: int, name: str) -> str:
+        return f"Chapters {index}/{total}: {_shorten(name)}"
+
+    def _text_description(self) -> str:
+        new_label = "would translate" if self._dry_run else "new"
+        new_count = self._counters.new_count(self._dry_run)
+        return (
+            f"Texts {self._counters.processed} | {new_label} {new_count} | "
+            f"cache {self._counters.cache} | errors {self._counters.error}"
+        )
+
+
+def _shorten(text: str, max_length: int = 50) -> str:
+    if len(text) <= max_length:
+        return text
+    return text[: max_length - 3] + "..."

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,10 +1,9 @@
 from pathlib import Path
 from types import SimpleNamespace
 
-import pytest
 from typer.testing import CliRunner
 
-from ayvu.cli import TextProgressCounters, _offer_markdown_report, _render_markdown_report, _save_markdown_report, app
+from ayvu.cli import _offer_markdown_report, _render_markdown_report, _save_markdown_report, app
 from ayvu.domain import LanguagePair, OutputPlan, TranslationOptions
 from ayvu.epub_io import TranslationReport
 from ayvu.preflight import PreflightError
@@ -55,28 +54,6 @@ def test_translation_options_exposes_language_pair_values():
 
     assert options.source == "en"
     assert options.target == "pt"
-
-
-def test_text_progress_counters_track_known_statuses():
-    counters = TextProgressCounters()
-
-    counters.record("translated")
-    counters.record("cache")
-    counters.record("dry_run")
-    counters.record("error")
-
-    assert counters.processed == 4
-    assert counters.new_count(dry_run=False) == 1
-    assert counters.new_count(dry_run=True) == 1
-    assert counters.cache == 1
-    assert counters.error == 1
-
-
-def test_text_progress_counters_reject_unknown_status():
-    counters = TextProgressCounters()
-
-    with pytest.raises(ValueError, match="Unknown text progress status"):
-        counters.record("unknown")
 
 
 def test_translate_command_has_clear_error_for_unknown_translator(tmp_path):

--- a/tests/test_cli_progress.py
+++ b/tests/test_cli_progress.py
@@ -1,0 +1,25 @@
+import pytest
+
+from ayvu.cli_progress import TextProgressCounters
+
+
+def test_text_progress_counters_track_known_statuses():
+    counters = TextProgressCounters()
+
+    counters.record("translated")
+    counters.record("cache")
+    counters.record("dry_run")
+    counters.record("error")
+
+    assert counters.processed == 4
+    assert counters.new_count(dry_run=False) == 1
+    assert counters.new_count(dry_run=True) == 1
+    assert counters.cache == 1
+    assert counters.error == 1
+
+
+def test_text_progress_counters_reject_unknown_status():
+    counters = TextProgressCounters()
+
+    with pytest.raises(ValueError, match="Unknown text progress status"):
+        counters.record("unknown")


### PR DESCRIPTION
## Objetivo

Separar as classes de progresso da CLI para um modulo dedicado, mantendo `cli.py` focado em comandos, argumentos, mensagens e orquestracao.

## O que mudou

- Cria `src/ayvu/cli_progress.py` para concentrar `TextProgressCounters` e `TranslationProgress`.
- Mantem `cli.py` apenas importando e usando `TranslationProgress` durante `ayvu translate`.
- Move os testes dos contadores de progresso para `tests/test_cli_progress.py`.
- Remove o helper de encurtamento que era usado apenas pelo progresso de dentro de `cli.py`.

## Fora do escopo

- Nao altera comandos, flags ou texto publico da CLI.
- Nao muda traducao, cache, preflight, relatorio ou validacao de EPUB.

## Validacao e testes

- `uv run pytest`: 41 passed
- `git diff --check`: sem problemas
- `uv run ayvu --help`: comandos publicos preservados

Closes #11
