### PR TITLE
Separar responsabilidades do LibreTranslateTranslator

### DIFF
--- a/src/ayvu/translator.py
+++ b/src/ayvu/translator.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from typing import Protocol
 
 import requests
 
@@ -24,6 +25,57 @@ class Translator(ABC):
         raise NotImplementedError
 
 
+class HttpSession(Protocol):
+    def post(self, url: str, *, json: dict[str, str], timeout: float) -> requests.Response:
+        pass
+
+
+@dataclass(frozen=True)
+class LibreTranslatePayload:
+    text: str
+    source: str
+    target: str
+
+    def as_json(self) -> dict[str, str]:
+        return {
+            "q": self.text,
+            "source": self.source,
+            "target": self.target,
+            "format": "text",
+        }
+
+
+@dataclass(frozen=True)
+class RetryPolicy:
+    retries: int
+
+    @property
+    def max_attempts(self) -> int:
+        return max(1, self.retries + 1)
+
+    def attempts(self) -> range:
+        return range(1, self.max_attempts + 1)
+
+    def can_retry(self, attempt: int) -> bool:
+        return attempt < self.max_attempts
+
+    def delay_for(self, attempt: int) -> float:
+        return 0.5 * attempt
+
+
+class LibreTranslateResponseParser:
+    def parse(self, response: requests.Response) -> str:
+        try:
+            data = response.json()
+        except ValueError as exc:
+            raise TranslatorError("LibreTranslate response was not valid JSON") from exc
+
+        translated = data.get("translatedText") if isinstance(data, dict) else None
+        if not isinstance(translated, str):
+            raise TranslatorError("LibreTranslate response did not include translatedText")
+        return translated
+
+
 @dataclass
 class LibreTranslateTranslator(Translator):
     url: str = "http://localhost:5000"
@@ -32,37 +84,28 @@ class LibreTranslateTranslator(Translator):
 
     def __post_init__(self) -> None:
         self.endpoint = self._normalize_endpoint(self.url)
-        self.session = requests.Session()
+        self.session: HttpSession = requests.Session()
+        self.retry_policy = RetryPolicy(self.retries)
+        self.response_parser = LibreTranslateResponseParser()
 
     def translate(self, text: str, source: str, target: str) -> str:
         if not text:
             return text
 
-        payload = {
-            "q": text,
-            "source": source,
-            "target": target,
-            "format": "text",
-        }
+        payload = LibreTranslatePayload(text=text, source=source, target=target)
         last_error: Exception | None = None
-        attempts = max(1, self.retries + 1)
 
-        for attempt in range(1, attempts + 1):
+        for attempt in self.retry_policy.attempts():
             try:
-                response = self.session.post(self.endpoint, json=payload, timeout=self.timeout)
-                if response.status_code >= 500 and attempt < attempts:
-                    time.sleep(0.5 * attempt)
+                response = self._post(payload)
+                if self._should_retry_response(response, attempt):
+                    self._wait_before_retry(attempt)
                     continue
                 response.raise_for_status()
-                data = response.json()
-                translated = data.get("translatedText")
-                if not isinstance(translated, str):
-                    raise TranslatorError("LibreTranslate response did not include translatedText")
-                return translated
+                return self.response_parser.parse(response)
             except requests.exceptions.ConnectionError as exc:
                 last_error = exc
-                if attempt < attempts:
-                    time.sleep(0.5 * attempt)
+                if self._retry_after_exception(attempt):
                     continue
                 raise TranslatorError(
                     f"Could not connect to LibreTranslate at {self.endpoint}. "
@@ -70,22 +113,41 @@ class LibreTranslateTranslator(Translator):
                 ) from exc
             except requests.exceptions.Timeout as exc:
                 last_error = exc
-                if attempt < attempts:
-                    time.sleep(0.5 * attempt)
+                if self._retry_after_exception(attempt):
                     continue
                 raise TranslatorError(f"LibreTranslate request timed out after {self.timeout} seconds") from exc
             except requests.exceptions.HTTPError as exc:
-                raise TranslatorError(
-                    f"LibreTranslate HTTP error {response.status_code}: {response.text[:300]}"
-                ) from exc
+                raise self._http_error(exc) from exc
             except requests.exceptions.RequestException as exc:
                 last_error = exc
-                if attempt < attempts:
-                    time.sleep(0.5 * attempt)
+                if self._retry_after_exception(attempt):
                     continue
                 raise TranslatorError(f"LibreTranslate request failed: {exc}") from exc
 
         raise TranslatorError(f"LibreTranslate request failed: {last_error}")
+
+    def _post(self, payload: LibreTranslatePayload) -> requests.Response:
+        return self.session.post(self.endpoint, json=payload.as_json(), timeout=self.timeout)
+
+    def _should_retry_response(self, response: requests.Response, attempt: int) -> bool:
+        return response.status_code >= 500 and self.retry_policy.can_retry(attempt)
+
+    def _retry_after_exception(self, attempt: int) -> bool:
+        if not self.retry_policy.can_retry(attempt):
+            return False
+
+        self._wait_before_retry(attempt)
+        return True
+
+    def _wait_before_retry(self, attempt: int) -> None:
+        time.sleep(self.retry_policy.delay_for(attempt))
+
+    @staticmethod
+    def _http_error(exc: requests.exceptions.HTTPError) -> TranslatorError:
+        response = exc.response
+        if response is None:
+            return TranslatorError(f"LibreTranslate HTTP error: {exc}")
+        return TranslatorError(f"LibreTranslate HTTP error {response.status_code}: {response.text[:300]}")
 
     @staticmethod
     def _normalize_endpoint(url: str) -> str:

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import requests
+import pytest
+
+from ayvu.translator import LibreTranslateTranslator, TranslatorError
+
+
+class FakeSession:
+    def __init__(self, responses: list[requests.Response | requests.exceptions.RequestException]) -> None:
+        self.responses = responses
+        self.posts: list[tuple[str, dict[str, str], float]] = []
+
+    def post(self, url: str, *, json: dict[str, str], timeout: float) -> requests.Response:
+        self.posts.append((url, json, timeout))
+        response = self.responses.pop(0)
+        if isinstance(response, requests.exceptions.RequestException):
+            raise response
+        return response
+
+
+def make_response(status_code: int, body: str) -> requests.Response:
+    response = requests.Response()
+    response.status_code = status_code
+    response._content = body.encode("utf-8")
+    response.url = "http://localhost:5000/translate"
+    return response
+
+
+def test_libretranslate_posts_payload_and_parses_response() -> None:
+    session = FakeSession([make_response(200, '{"translatedText": "Ola"}')])
+    translator = LibreTranslateTranslator(url="http://localhost:5000/", timeout=3.0, retries=0)
+    translator.session = session
+
+    result = translator.translate("Hello", "en", "pt")
+
+    assert result == "Ola"
+    assert session.posts == [
+        (
+            "http://localhost:5000/translate",
+            {"q": "Hello", "source": "en", "target": "pt", "format": "text"},
+            3.0,
+        )
+    ]
+
+
+def test_libretranslate_returns_empty_text_without_http_call() -> None:
+    session = FakeSession([])
+    translator = LibreTranslateTranslator(retries=0)
+    translator.session = session
+
+    assert translator.translate("", "en", "pt") == ""
+    assert session.posts == []
+
+
+def test_libretranslate_retries_5xx_before_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    sleeps: list[float] = []
+    session = FakeSession(
+        [
+            make_response(503, "temporarily unavailable"),
+            make_response(200, '{"translatedText": "Tudo certo"}'),
+        ]
+    )
+    translator = LibreTranslateTranslator(retries=1)
+    translator.session = session
+    monkeypatch.setattr("ayvu.translator.time.sleep", lambda delay: sleeps.append(delay))
+
+    result = translator.translate("All right", "en", "pt")
+
+    assert result == "Tudo certo"
+    assert len(session.posts) == 2
+    assert sleeps == [0.5]
+
+
+def test_libretranslate_reports_http_error() -> None:
+    session = FakeSession([make_response(400, "bad language pair")])
+    translator = LibreTranslateTranslator(retries=0)
+    translator.session = session
+
+    with pytest.raises(TranslatorError) as error:
+        translator.translate("Hello", "en", "xx")
+
+    assert "LibreTranslate HTTP error 400: bad language pair" in str(error.value)
+
+
+def test_libretranslate_reports_invalid_json_response() -> None:
+    session = FakeSession([make_response(200, "not-json")])
+    translator = LibreTranslateTranslator(retries=0)
+    translator.session = session
+
+    with pytest.raises(TranslatorError) as error:
+        translator.translate("Hello", "en", "pt")
+
+    assert "LibreTranslate response was not valid JSON" in str(error.value)
+
+
+def test_libretranslate_reports_missing_translated_text() -> None:
+    session = FakeSession([make_response(200, '{"translatedText": 42}')])
+    translator = LibreTranslateTranslator(retries=0)
+    translator.session = session
+
+    with pytest.raises(TranslatorError) as error:
+        translator.translate("Hello", "en", "pt")
+
+    assert "LibreTranslate response did not include translatedText" in str(error.value)
+
+
+def test_libretranslate_reports_connection_error_after_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    sleeps: list[float] = []
+    session = FakeSession(
+        [
+            requests.exceptions.ConnectionError("refused"),
+            requests.exceptions.ConnectionError("refused"),
+        ]
+    )
+    translator = LibreTranslateTranslator(url="http://localhost:5000", retries=1)
+    translator.session = session
+    monkeypatch.setattr("ayvu.translator.time.sleep", lambda delay: sleeps.append(delay))
+
+    with pytest.raises(TranslatorError) as error:
+        translator.translate("Hello", "en", "pt")
+
+    assert "Could not connect to LibreTranslate at http://localhost:5000/translate" in str(error.value)
+    assert len(session.posts) == 2
+    assert sleeps == [0.5]
+
+
+def test_libretranslate_reports_timeout() -> None:
+    session = FakeSession([requests.exceptions.Timeout("slow")])
+    translator = LibreTranslateTranslator(timeout=1.5, retries=0)
+    translator.session = session
+
+    with pytest.raises(TranslatorError) as error:
+        translator.translate("Hello", "en", "pt")
+
+    assert "LibreTranslate request timed out after 1.5 seconds" in str(error.value)


### PR DESCRIPTION
Objetivo: separar responsabilidades internas do backend LibreTranslate sem alterar o contrato publico de traducao. O que mudou: extraida a montagem do payload para um objeto dedicado; extraida a politica de retry/backoff; extraido o parsing da resposta; mantidas mensagens claras para conexao indisponivel, timeout, erro HTTP e resposta invalida; adicionados testes unitarios com sessoes fake, sem LibreTranslate real. Fora do escopo: nao foi adicionado novo backend; nao houve mudanca na interface Translator.translate(text, source, target); nao houve alteracao de comandos, flags ou formato publico da CLI. Validacao/testes: uv run pytest com 49 passed; git diff --check sem problemas. Closes #12