### PR TITLE
Separar erros estruturais do TranslationReport

### DIFF
--- a/src/ayvu/epub_io.py
+++ b/src/ayvu/epub_io.py
@@ -31,6 +31,32 @@ class EpubInfo:
     item_count: int
 
 
+@dataclass(frozen=True)
+class EpubDocument:
+    name: str
+    archive_path: str
+
+
+@dataclass(frozen=True)
+class EpubStructureError:
+    document: EpubDocument
+    detail: str
+
+    @classmethod
+    def missing_document(cls, document: EpubDocument) -> "EpubStructureError":
+        return cls(
+            document=document,
+            detail=f"document not found in EPUB archive at {document.archive_path}",
+        )
+
+    @classmethod
+    def chapter_error(cls, document: EpubDocument, exc: Exception) -> "EpubStructureError":
+        return cls(document=document, detail=str(exc))
+
+    def as_message(self) -> str:
+        return f"{self.document.name}: {self.detail}"
+
+
 @dataclass
 class TranslationReport:
     chapters_processed: int = 0
@@ -43,10 +69,8 @@ class TranslationReport:
     detected_language: str | None = None
     target_language: str | None = None
 
-    def record_missing_document(self, document: "EpubDocument") -> str:
-        message = f"{document.name}: document not found in EPUB archive at {document.archive_path}"
+    def record_error(self, message: str) -> None:
         self.errors.append(message)
-        return message
 
     def record_chapter(self, stats: HtmlTranslationStats) -> None:
         self.texts_translated += stats.translated
@@ -54,15 +78,6 @@ class TranslationReport:
         self.texts_skipped += stats.skipped
         self.errors.extend(stats.errors)
         self.chapters_processed += 1
-
-    def record_chapter_error(self, document: "EpubDocument", exc: Exception) -> None:
-        self.errors.append(f"{document.name}: {exc}")
-
-
-@dataclass(frozen=True)
-class EpubDocument:
-    name: str
-    archive_path: str
 
 
 @dataclass
@@ -128,7 +143,7 @@ def translate_epub(
 
         for index, document in enumerate(documents, start=1):
             if document.archive_path not in archive_names:
-                report.record_missing_document(document)
+                report.record_error(EpubStructureError.missing_document(document).as_message())
                 if options.fail_fast:
                     raise FileNotFoundError(document.archive_path)
                 continue
@@ -155,7 +170,7 @@ def translate_epub(
                 if on_chapter_done:
                     on_chapter_done(index, total_documents, document.name, stats)
             except Exception as exc:
-                report.record_chapter_error(document, exc)
+                report.record_error(EpubStructureError.chapter_error(document, exc).as_message())
                 if options.fail_fast:
                     raise
 

--- a/tests/test_epub_io.py
+++ b/tests/test_epub_io.py
@@ -2,7 +2,14 @@ from pathlib import PurePosixPath
 
 from ebooklib import ITEM_DOCUMENT
 
-from ayvu.epub_io import EpubReplacements, _document_entries, _document_zip_path
+from ayvu.epub_io import (
+    EpubDocument,
+    EpubReplacements,
+    EpubStructureError,
+    TranslationReport,
+    _document_entries,
+    _document_zip_path,
+)
 
 
 class FakeBook:
@@ -53,3 +60,29 @@ def test_epub_replacements_return_replacement_or_original_content():
 
     assert replacements.content_for("chapter.xhtml", FakeZip()) == b"translated"
     assert replacements.content_for("style.css", FakeZip()) == b"original:style.css"
+
+
+def test_epub_structure_error_formats_missing_document_message():
+    document = EpubDocument(name="text/chapter.xhtml", archive_path="OEBPS/text/chapter.xhtml")
+
+    error = EpubStructureError.missing_document(document)
+
+    assert error.as_message() == (
+        "text/chapter.xhtml: document not found in EPUB archive at OEBPS/text/chapter.xhtml"
+    )
+
+
+def test_epub_structure_error_formats_chapter_error_message():
+    document = EpubDocument(name="text/chapter.xhtml", archive_path="OEBPS/text/chapter.xhtml")
+
+    error = EpubStructureError.chapter_error(document, ValueError("bad html"))
+
+    assert error.as_message() == "text/chapter.xhtml: bad html"
+
+
+def test_translation_report_records_preformatted_errors():
+    report = TranslationReport()
+
+    report.record_error("text/chapter.xhtml: bad html")
+
+    assert report.errors == ["text/chapter.xhtml: bad html"]


### PR DESCRIPTION
Objetivo: separar a formatacao de erros estruturais da acumulacao de metricas feita por TranslationReport. O que mudou: criado EpubStructureError para representar e formatar mensagens estruturais de documento ausente e erro de capitulo; TranslationReport passou a registrar mensagens prontas com record_error, mantendo a acumulacao de metricas em record_chapter; translate_epub passou a montar mensagens estruturais fora do relatorio; adicionados testes para preservar as mensagens atuais. Fora do escopo: nao houve mudanca no formato publico do relatorio da CLI; nao houve mudanca no fluxo de traducao, cache, EPUB ou validacao; nao houve refatoracao ampla de translate_epub. Validacao/testes: uv run pytest com 44 passed; git diff --check sem problemas. Closes #13