### PR TITLE
Adicionar GitHub Actions para rodar testes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,29 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install dependencies
+        run: uv sync --extra dev --frozen
+
+      - name: Run tests
+        run: uv run pytest


### PR DESCRIPTION
Objetivo: adicionar CI basico no GitHub Actions para rodar a suite de testes automaticamente. O que mudou: criado workflow Tests em .github/workflows/tests.yml; o workflow roda em pushes para main; roda em pull requests; configura Python 3.11; instala dependencias de desenvolvimento com uv sync --extra dev --frozen; executa uv run pytest. Fora do escopo: nao foram alterados testes ou codigo de producao; nao foram adicionados jobs de release, lint ou build de pacote. Validacao/testes: uv run pytest com 41 passed; git diff --check sem problemas. Closes #14