### PR TITLE
Adicionar LICENSE, CHANGELOG e CONTRIBUTING

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+Todas as mudancas relevantes deste projeto serao registradas neste arquivo.
+
+O formato segue a ideia de uma secao "Nao publicado" para mudancas ainda nao
+lancadas e secoes versionadas quando uma release for publicada.
+
+## Nao publicado
+
+### Adicionado
+
+- Arquivos iniciais de manutencao do projeto: `LICENSE`, `CHANGELOG.md` e
+  `CONTRIBUTING.md`.
+
+## 0.0.1 - Inicial
+
+### Adicionado
+
+- CLI `ayvu` para inspecionar, traduzir e extrair texto visivel de EPUBs
+  locais.
+- Backend HTTP inicial compativel com LibreTranslate.
+- Cache SQLite para reaproveitar traducoes e retomar execucoes interrompidas.
+- Glossario JSON opcional.
+- Validacao basica do EPUB gerado.
+- Relatorio final no terminal e opcao de salvar relatorio em Markdown.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,92 @@
+# Contribuindo com o Ayvu
+
+Obrigado por contribuir com o Ayvu. Este projeto prioriza mudancas pequenas,
+revisaveis e alinhadas ao fluxo de issues, branches, pull requests e releases.
+
+## Escopo do Projeto
+
+O Ayvu e uma CLI para traduzir EPUBs locais usando um tradutor HTTP local
+compativel com LibreTranslate. A ferramenta nunca deve alterar o EPUB original,
+remover DRM, baixar livros ou facilitar distribuicao de conteudo protegido.
+
+## Fluxo de Trabalho
+
+O fluxo padrao esta documentado em
+[`docs/release-workflow.md`](docs/release-workflow.md). Antes de implementar uma
+tarefa, confira se existe uma issue relacionada.
+
+Resumo:
+
+1. Selecione ou crie uma issue para a tarefa.
+2. Crie uma branch curta e descritiva a partir da `main`.
+3. Faca uma mudanca pequena e coerente com a issue.
+4. Abra um pull request para merge na `main`.
+5. Registre a validacao executada no pull request.
+6. Relacione o PR com a issue usando `Refs #N` ou `Closes #N`.
+
+Use nomes de branch com prefixo e descricao curta em kebab-case:
+
+```text
+fix/output-exists-message
+docs/release-workflow
+ci/pytest-github-actions
+feat/internal-environment-check
+refactor/cli-progress-module
+```
+
+## Desenvolvimento Local
+
+Instale as dependencias de desenvolvimento com `uv`:
+
+```bash
+uv sync --extra dev
+```
+
+Rode a suite de testes:
+
+```bash
+uv run pytest
+```
+
+Comandos uteis:
+
+```bash
+uv run ayvu --help
+uv run ayvu inspect livro.epub
+uv run ayvu test-translator --url http://localhost:5000
+```
+
+## Regras de Contribuicao
+
+- Preserve a estrutura interna dos EPUBs.
+- Traduza apenas textos visiveis ao leitor.
+- Nao altere o arquivo EPUB original.
+- Use fakes ou mocks nos testes; nao dependa de um LibreTranslate real na suite
+  automatica.
+- Use `tmp_path` para arquivos temporarios em testes.
+- Nao versione EPUBs, PDFs, caches SQLite, glossarios privados ou arquivos de
+  uso pessoal.
+- Atualize `README.md` ou `docs/` quando mudar comportamento de usuario,
+  comandos, flags, cache, glossario ou formato de saida.
+
+## Pull Requests
+
+Um PR deve explicar:
+
+- objetivo;
+- o que mudou;
+- o que ficou fora do escopo;
+- validacao executada;
+- issue relacionada.
+
+Para mudancas de codigo, rode:
+
+```bash
+uv run pytest
+```
+
+Para mudancas apenas de documentacao, rode pelo menos:
+
+```bash
+git diff --check
+```

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 ayvu contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Objetivo: adicionar arquivos basicos de manutencao para organizar o projeto como software aberto. O que mudou: criado LICENSE com texto MIT, alinhado a licenca declarada no pyproject.toml; criado CHANGELOG.md com secao Nao publicado e registro inicial da versao 0.0.1; criado CONTRIBUTING.md com escopo do projeto, fluxo de issues, branches, PRs e validacao; referenciado docs/release-workflow.md como fonte do fluxo do projeto. Fora do escopo: nao houve mudanca em codigo de producao ou testes; nao houve mudanca em comandos, flags, cache, glossario ou formato de saida; nao foi criada release nem tag. Validacao/testes: git diff --cached --check sem problemas. Closes #15