### PR TITLE
Tratar interrupção com Ctrl+C durante a tradução

### DIFF
--- a/src/ayvu/cli.py
+++ b/src/ayvu/cli.py
@@ -9,7 +9,7 @@ from rich.progress import BarColumn, Progress, SpinnerColumn, TaskProgressColumn
 from rich.table import Table
 
 from .cache import TranslationCache
-from .cli_progress import TranslationProgress
+from .cli_progress import TranslationProgress, TranslationProgressSnapshot
 from .domain import LanguagePair, OutputPlan, TranslationOptions
 from .epub_io import TranslationReport, extract_markdown, inspect_epub, translate_epub
 from .preflight import PreflightError, run_translation_preflight
@@ -110,28 +110,38 @@ def translate(
         console.print(exc.next_step)
         raise typer.Exit(code=1) from exc
 
-    with Progress(
-        SpinnerColumn(),
-        TextColumn("[progress.description]{task.description}"),
-        BarColumn(),
-        TaskProgressColumn(),
-        TimeElapsedColumn(),
-        console=console,
-    ) as progress:
-        progress_view = TranslationProgress(progress, dry_run=dry_run)
+    progress_view: TranslationProgress | None = None
+    try:
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(),
+            TaskProgressColumn(),
+            TimeElapsedColumn(),
+            console=console,
+        ) as progress:
+            progress_view = TranslationProgress(progress, dry_run=dry_run)
 
-        with TranslationCache(cache_path) as cache:
-            report = translate_epub(
-                epub_path,
-                output_path,
-                translator=preflight.translator,
-                cache=cache,
-                options=translation_options,
-                glossary=preflight.glossary,
-                on_chapter_start=progress_view.chapter_started,
-                on_chapter_done=progress_view.chapter_done,
-                on_text_processed=progress_view.text_processed,
-            )
+            with TranslationCache(cache_path) as cache:
+                report = translate_epub(
+                    epub_path,
+                    output_path,
+                    translator=preflight.translator,
+                    cache=cache,
+                    options=translation_options,
+                    glossary=preflight.glossary,
+                    on_chapter_start=progress_view.chapter_started,
+                    on_chapter_done=progress_view.chapter_done,
+                    on_text_processed=progress_view.text_processed,
+                )
+    except KeyboardInterrupt as exc:
+        _print_interrupted_translation(
+            snapshot=progress_view.snapshot() if progress_view else None,
+            output_path=output_path,
+            cache_path=cache_path,
+            dry_run=dry_run,
+        )
+        raise typer.Exit(code=1) from exc
 
     _print_report(report, dry_run)
     _offer_markdown_report(report, dry_run)
@@ -177,6 +187,47 @@ def _print_report(report: TranslationReport, dry_run: bool) -> None:
 
     for error in report.errors:
         console.print(f"[yellow]Error:[/yellow] {error}")
+
+
+def _print_interrupted_translation(
+    snapshot: TranslationProgressSnapshot | None,
+    output_path: Path,
+    cache_path: Path,
+    dry_run: bool,
+) -> None:
+    console.print("[yellow]Translation interrupted by user.[/yellow]")
+    console.print("Cached translations saved before the interruption can be reused with the same --cache path.")
+    console.print(f"Cache path: {cache_path}")
+    console.print(_interrupted_output_message(output_path, dry_run))
+
+    if snapshot is None:
+        return
+
+    table = Table(title="Partial translation progress")
+    table.add_column("Metric")
+    table.add_column("Value")
+    table.add_row("Chapters processed", _partial_chapter_value(snapshot))
+    table.add_row("Texts processed", str(snapshot.texts_processed))
+    table.add_row("Texts translated", str(snapshot.texts_translated))
+    table.add_row("Texts from cache", str(snapshot.texts_from_cache))
+    table.add_row("Texts dry-run", str(snapshot.texts_dry_run))
+    table.add_row("Text errors", str(snapshot.text_errors))
+    table.add_row("Current chapter", snapshot.current_chapter or "-")
+    console.print(table)
+
+
+def _partial_chapter_value(snapshot: TranslationProgressSnapshot) -> str:
+    if snapshot.total_chapters is None:
+        return str(snapshot.chapters_processed)
+    return f"{snapshot.chapters_processed}/{snapshot.total_chapters}"
+
+
+def _interrupted_output_message(output_path: Path, dry_run: bool) -> str:
+    if dry_run:
+        return "Dry run interrupted; no translated EPUB was expected."
+    if output_path.exists():
+        return f"Translated EPUB may be incomplete: {output_path}"
+    return f"Translated EPUB was not written: {output_path}"
 
 
 def _offer_markdown_report(report: TranslationReport, dry_run: bool) -> None:

--- a/src/ayvu/cli_progress.py
+++ b/src/ayvu/cli_progress.py
@@ -5,6 +5,18 @@ from dataclasses import dataclass
 from rich.progress import Progress
 
 
+@dataclass(frozen=True)
+class TranslationProgressSnapshot:
+    chapters_processed: int
+    total_chapters: int | None
+    current_chapter: str | None
+    texts_processed: int
+    texts_translated: int
+    texts_from_cache: int
+    texts_dry_run: int
+    text_errors: int
+
+
 @dataclass
 class TextProgressCounters:
     translated: int = 0
@@ -42,10 +54,15 @@ class TranslationProgress:
         self._progress = progress
         self._dry_run = dry_run
         self._counters = TextProgressCounters()
+        self._chapters_processed = 0
+        self._total_chapters: int | None = None
+        self._current_chapter: str | None = None
         self._chapter_task = progress.add_task("Chapters", total=None)
         self._text_task = progress.add_task("Texts", total=None)
 
     def chapter_started(self, index: int, total: int, name: str) -> None:
+        self._total_chapters = total
+        self._current_chapter = name
         self._progress.update(
             self._chapter_task,
             total=total,
@@ -53,6 +70,9 @@ class TranslationProgress:
         )
 
     def chapter_done(self, index: int, total: int, name: str, _stats: object) -> None:
+        self._chapters_processed += 1
+        self._total_chapters = total
+        self._current_chapter = name
         self._progress.advance(self._chapter_task)
         self._progress.update(self._chapter_task, description=self._chapter_description(index, total, name))
 
@@ -60,6 +80,18 @@ class TranslationProgress:
         self._counters.record(status)
         self._progress.advance(self._text_task)
         self._progress.update(self._text_task, description=self._text_description())
+
+    def snapshot(self) -> TranslationProgressSnapshot:
+        return TranslationProgressSnapshot(
+            chapters_processed=self._chapters_processed,
+            total_chapters=self._total_chapters,
+            current_chapter=self._current_chapter,
+            texts_processed=self._counters.processed,
+            texts_translated=self._counters.translated,
+            texts_from_cache=self._counters.cache,
+            texts_dry_run=self._counters.dry_run,
+            text_errors=self._counters.error,
+        )
 
     def _chapter_description(self, index: int, total: int, name: str) -> str:
         return f"Chapters {index}/{total}: {_shorten(name)}"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -232,6 +232,58 @@ def test_translate_command_offers_and_saves_markdown_report(tmp_path, monkeypatc
     assert str(epub_path) in report_path.read_text(encoding="utf-8")
 
 
+def test_translate_command_handles_keyboard_interrupt_cleanly(tmp_path, monkeypatch):
+    epub_path = tmp_path / "book.epub"
+    output_path = tmp_path / "book-pt.epub"
+    cache_path = tmp_path / "cache.sqlite"
+    epub_path.write_bytes(b"fake epub")
+
+    def interrupt_translation(*_args: object, **kwargs: object) -> TranslationReport:
+        kwargs["on_chapter_start"](1, 3, "chapter-one.xhtml")
+        kwargs["on_text_processed"]("translated")
+        kwargs["on_text_processed"]("cache")
+        kwargs["on_text_processed"]("error")
+        kwargs["on_chapter_done"](1, 3, "chapter-one.xhtml", object())
+        kwargs["on_chapter_start"](2, 3, "chapter-two.xhtml")
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(
+        "ayvu.cli.run_translation_preflight",
+        lambda **_kwargs: SimpleNamespace(translator=object(), glossary=None),
+    )
+    monkeypatch.setattr("ayvu.cli.TranslationCache", lambda _path: FakeCache())
+    monkeypatch.setattr("ayvu.cli.translate_epub", interrupt_translation)
+
+    result = runner.invoke(
+        app,
+        [
+            "translate",
+            str(epub_path),
+            "--output",
+            str(output_path),
+            "--cache",
+            str(cache_path),
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Translation interrupted by user." in result.output
+    assert "Partial translation progress" in result.output
+    assert "Chapters processed" in result.output
+    assert "1/3" in result.output
+    assert "Texts processed" in result.output
+    assert "3" in result.output
+    assert "Texts translated" in result.output
+    assert "Texts from cache" in result.output
+    assert "Text errors" in result.output
+    assert "chapter-two.xhtml" in result.output
+    assert "Cached translations saved before the interruption can be reused" in result.output
+    assert str(cache_path) in result.output
+    assert "Translated EPUB was not written:" in result.output
+    assert "Traceback" not in result.output
+    assert not output_path.exists()
+
+
 class FakeCache:
     def __enter__(self) -> "FakeCache":
         return self

--- a/tests/test_cli_progress.py
+++ b/tests/test_cli_progress.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ayvu.cli_progress import TextProgressCounters
+from ayvu.cli_progress import TextProgressCounters, TranslationProgress
 
 
 def test_text_progress_counters_track_known_statuses():
@@ -23,3 +23,32 @@ def test_text_progress_counters_reject_unknown_status():
 
     with pytest.raises(ValueError, match="Unknown text progress status"):
         counters.record("unknown")
+
+
+def test_translation_progress_snapshot_tracks_partial_state():
+    class FakeProgress:
+        def add_task(self, _description: str, total: object = None) -> int:
+            return 1
+
+        def update(self, *_args: object, **_kwargs: object) -> None:
+            return None
+
+        def advance(self, *_args: object, **_kwargs: object) -> None:
+            return None
+
+    progress = TranslationProgress(FakeProgress(), dry_run=False)
+
+    progress.chapter_started(1, 2, "chapter-one.xhtml")
+    progress.text_processed("translated")
+    progress.text_processed("cache")
+    progress.chapter_done(1, 2, "chapter-one.xhtml", object())
+    progress.chapter_started(2, 2, "chapter-two.xhtml")
+
+    snapshot = progress.snapshot()
+
+    assert snapshot.chapters_processed == 1
+    assert snapshot.total_chapters == 2
+    assert snapshot.current_chapter == "chapter-two.xhtml"
+    assert snapshot.texts_processed == 2
+    assert snapshot.texts_translated == 1
+    assert snapshot.texts_from_cache == 1


### PR DESCRIPTION
Objetivo: encerrar ayvu translate de forma limpa quando o usuario interromper a traducao com Ctrl+C. O que mudou: a CLI captura KeyboardInterrupt durante translate_epub; a saida informa que a traducao foi interrompida pelo usuario, sem traceback; a CLI mostra resumo parcial com capitulos processados, textos processados, textos traduzidos, textos vindos do cache, dry-run e erros; informa o caminho do cache para reaproveitar traducoes ja salvas; informa se o EPUB traduzido nao foi gravado ou se pode estar incompleto; TranslationProgress passou a expor um snapshot de progresso para relatorios parciais. Fora do escopo: nao foi alterado o formato do relatorio final de traducoes concluidas; nao foi implementada retomada automatica de livros parcialmente traduzidos; nao houve mudanca na estrutura de EPUB, cache ou tradutor HTTP. Validacao/testes: uv run pytest com 43 passed; git diff --cached --check sem problemas. Closes #16