### PR TITLE
Persistir estado de tradução em andamento

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,11 @@ uv run ayvu translate livro.epub \
 
 Trechos já traduzidos serão reaproveitados automaticamente.
 
+Durante traduções reais, o Ayvu também grava um estado local da execução em
+`~/Documentos/Livros/Processando`. Esse arquivo registra os caminhos e opções
+necessários para uma retomada futura. Ele não substitui o cache e não é apagado
+automaticamente.
+
 ## Testes
 
 ```bash

--- a/src/ayvu/cli.py
+++ b/src/ayvu/cli.py
@@ -13,6 +13,12 @@ from .cli_progress import TranslationProgress
 from .domain import LanguagePair, OutputPlan, TranslationOptions
 from .epub_io import TranslationReport, extract_markdown, inspect_epub, translate_epub
 from .preflight import PreflightError, run_translation_preflight
+from .resume import (
+    ResumeStateError,
+    ResumeStateStore,
+    TranslationResumeState,
+    default_processing_dir,
+)
 from .translator import LibreTranslateTranslator, TranslatorError
 from .validation import validate_output_epub
 
@@ -110,6 +116,22 @@ def translate(
         console.print(exc.next_step)
         raise typer.Exit(code=1) from exc
 
+    resume_store: ResumeStateStore | None = None
+    resume_state: TranslationResumeState | None = None
+    if not dry_run:
+        resume_store, resume_state = _save_running_resume_state(
+            epub_path=epub_path,
+            output_path=output_path,
+            cache_path=cache_path,
+            translator_name=translator_name,
+            url=url,
+            glossary_path=glossary_path,
+            options=translation_options,
+            overwrite=overwrite,
+            timeout=timeout,
+            retries=retries,
+        )
+
     with Progress(
         SpinnerColumn(),
         TextColumn("[progress.description]{task.description}"),
@@ -140,6 +162,8 @@ def translate(
         validation = validate_output_epub(output_path)
         if validation.ok:
             console.print(f"[green]Validation OK:[/green] {validation.document_count} XHTML/HTML documents found.")
+            if resume_store and resume_state:
+                _mark_resume_state_completed(resume_store, resume_state)
         else:
             for warning in validation.warnings:
                 console.print(f"[yellow]Warning:[/yellow] {warning}")
@@ -177,6 +201,50 @@ def _print_report(report: TranslationReport, dry_run: bool) -> None:
 
     for error in report.errors:
         console.print(f"[yellow]Error:[/yellow] {error}")
+
+
+def _save_running_resume_state(
+    epub_path: Path,
+    output_path: Path,
+    cache_path: Path,
+    translator_name: str,
+    url: str,
+    glossary_path: Path | None,
+    options: TranslationOptions,
+    overwrite: bool,
+    timeout: float,
+    retries: int,
+) -> tuple[ResumeStateStore, TranslationResumeState]:
+    store = ResumeStateStore(default_processing_dir())
+    state = TranslationResumeState.create(
+        input_path=epub_path,
+        output_path=output_path,
+        cache_path=cache_path,
+        translator_name=translator_name,
+        url=url,
+        glossary_path=glossary_path,
+        options=options,
+        overwrite=overwrite,
+        timeout=timeout,
+        retries=retries,
+    )
+    _save_resume_state(store, state)
+    return store, state
+
+
+def _mark_resume_state_completed(store: ResumeStateStore, state: TranslationResumeState) -> None:
+    _save_resume_state(store, state.mark_completed())
+
+
+def _save_resume_state(store: ResumeStateStore, state: TranslationResumeState) -> None:
+    try:
+        store.save(state)
+    except (OSError, ResumeStateError) as exc:
+        console.print(f"[red]Resume state check failed:[/red] {exc}")
+        console.print(
+            "Choose a writable processing directory or fix permissions for Documentos/Livros/Processando."
+        )
+        raise typer.Exit(code=1) from exc
 
 
 def _offer_markdown_report(report: TranslationReport, dry_run: bool) -> None:

--- a/src/ayvu/cli.py
+++ b/src/ayvu/cli.py
@@ -16,6 +16,7 @@ from .preflight import PreflightError, run_translation_preflight
 from .resume import (
     InvalidResumeState,
     ResumeStateError,
+    ResumeStateScan,
     ResumeStateStore,
     TranslationResumeState,
     default_processing_dir,
@@ -34,7 +35,10 @@ def main(ctx: typer.Context) -> None:
     if ctx.invoked_subcommand is not None:
         return
 
-    _print_processing_translation_states(ResumeStateStore(default_processing_dir()))
+    scan = _print_processing_translation_states(ResumeStateStore(default_processing_dir()))
+    if _offer_detected_translation_resume(scan.running):
+        return
+
     console.print(ctx.get_help())
 
 
@@ -95,6 +99,40 @@ def translate(
     chunk_limit: int = typer.Option(3000, "--chunk-limit", help="Maximum characters sent per request."),
 ) -> None:
     """Translate EPUB visible text while preserving EPUB structure."""
+    _run_translation(
+        epub_path=epub_path,
+        output=output,
+        source=source,
+        target=target,
+        translator_name=translator_name,
+        url=url,
+        cache_path=cache_path,
+        glossary_path=glossary_path,
+        dry_run=dry_run,
+        fail_fast=fail_fast,
+        overwrite=overwrite,
+        timeout=timeout,
+        retries=retries,
+        chunk_limit=chunk_limit,
+    )
+
+
+def _run_translation(
+    epub_path: Path,
+    output: Path | None,
+    source: str,
+    target: str,
+    translator_name: str,
+    url: str,
+    cache_path: Path,
+    glossary_path: Path | None,
+    dry_run: bool,
+    fail_fast: bool,
+    overwrite: bool,
+    timeout: float,
+    retries: int,
+    chunk_limit: int,
+) -> None:
     language_pair = LanguagePair(source=source, target=target)
     translation_options = TranslationOptions(
         language_pair=language_pair,
@@ -214,15 +252,58 @@ def _print_report(report: TranslationReport, dry_run: bool) -> None:
         console.print(f"[yellow]Error:[/yellow] {error}")
 
 
-def _print_processing_translation_states(store: ResumeStateStore) -> None:
+def _print_processing_translation_states(store: ResumeStateStore) -> ResumeStateScan:
     scan = store.scan()
     if not scan.has_findings:
-        return
+        return scan
 
     if scan.running:
         _print_running_resume_states(scan.running)
     if scan.invalid:
         _print_invalid_resume_states(scan.invalid)
+    return scan
+
+
+def _offer_detected_translation_resume(states: tuple[TranslationResumeState, ...]) -> bool:
+    if not states:
+        return False
+    if len(states) > 1:
+        console.print("Multiple translations are in progress; automatic selection is not available yet.")
+        return False
+
+    state = states[0]
+    if not typer.confirm("Continue detected translation?", default=False):
+        console.print("Detected translation was not resumed. Processing files were left unchanged.")
+        return False
+
+    console.print(f"[green]Resuming translation:[/green] {state.input_path.name} -> {state.output_path.name}")
+    _resume_translation(state)
+    return True
+
+
+def _resume_translation(state: TranslationResumeState) -> None:
+    try:
+        _run_translation(
+            epub_path=state.input_path,
+            output=state.output_path,
+            source=state.source,
+            target=state.target,
+            translator_name=state.translator_name,
+            url=state.url,
+            cache_path=state.cache_path,
+            glossary_path=state.glossary_path,
+            dry_run=False,
+            fail_fast=state.fail_fast,
+            overwrite=state.overwrite,
+            timeout=state.timeout,
+            retries=state.retries,
+            chunk_limit=state.chunk_limit,
+        )
+    except typer.Exit:
+        console.print(
+            "Could not resume detected translation. Check the message above and restart the translation if needed."
+        )
+        raise
 
 
 def _print_running_resume_states(states: tuple[TranslationResumeState, ...]) -> None:

--- a/src/ayvu/cli.py
+++ b/src/ayvu/cli.py
@@ -14,6 +14,7 @@ from .domain import LanguagePair, OutputPlan, TranslationOptions
 from .epub_io import TranslationReport, extract_markdown, inspect_epub, translate_epub
 from .preflight import PreflightError, run_translation_preflight
 from .resume import (
+    InvalidResumeState,
     ResumeStateError,
     ResumeStateStore,
     TranslationResumeState,
@@ -25,6 +26,16 @@ from .validation import validate_output_epub
 
 app = typer.Typer(help="Translate local EPUB files with a local HTTP translator.")
 console = Console()
+
+
+@app.callback(invoke_without_command=True)
+def main(ctx: typer.Context) -> None:
+    """Translate local EPUB files with a local HTTP translator."""
+    if ctx.invoked_subcommand is not None:
+        return
+
+    _print_processing_translation_states(ResumeStateStore(default_processing_dir()))
+    console.print(ctx.get_help())
 
 
 @app.command()
@@ -201,6 +212,45 @@ def _print_report(report: TranslationReport, dry_run: bool) -> None:
 
     for error in report.errors:
         console.print(f"[yellow]Error:[/yellow] {error}")
+
+
+def _print_processing_translation_states(store: ResumeStateStore) -> None:
+    scan = store.scan()
+    if not scan.has_findings:
+        return
+
+    if scan.running:
+        _print_running_resume_states(scan.running)
+    if scan.invalid:
+        _print_invalid_resume_states(scan.invalid)
+
+
+def _print_running_resume_states(states: tuple[TranslationResumeState, ...]) -> None:
+    console.print("[yellow]Translations in progress were found.[/yellow]")
+    table = Table(title="Processing translations")
+    table.add_column("Original EPUB")
+    table.add_column("Output")
+    table.add_column("Target")
+    table.add_column("Cache")
+    for state in states:
+        table.add_row(
+            state.input_path.name,
+            state.output_path.name,
+            state.target,
+            state.cache_path.name,
+        )
+    console.print(table)
+
+
+def _print_invalid_resume_states(states: tuple[InvalidResumeState, ...]) -> None:
+    console.print("[yellow]Invalid processing state files were found.[/yellow]")
+    table = Table(title="Invalid processing states")
+    table.add_column("State file")
+    table.add_column("Problem")
+    for state in states:
+        table.add_row(state.path.name, _single_line(state.message))
+    console.print(table)
+    console.print("Restart the translation if the state file cannot be fixed.")
 
 
 def _save_running_resume_state(

--- a/src/ayvu/resume.py
+++ b/src/ayvu/resume.py
@@ -12,10 +12,27 @@ from .domain import TranslationOptions
 RESUME_STATE_VERSION = 1
 RUNNING_STATUS = "running"
 COMPLETED_STATUS = "completed"
+STATE_FILE_PATTERN = "*.ayvu-state.json"
 
 
 class ResumeStateError(ValueError):
     pass
+
+
+@dataclass(frozen=True)
+class InvalidResumeState:
+    path: Path
+    message: str
+
+
+@dataclass(frozen=True)
+class ResumeStateScan:
+    running: tuple[TranslationResumeState, ...]
+    invalid: tuple[InvalidResumeState, ...]
+
+    @property
+    def has_findings(self) -> bool:
+        return bool(self.running or self.invalid)
 
 
 @dataclass(frozen=True)
@@ -144,6 +161,24 @@ class ResumeStateStore:
             return TranslationResumeState.from_dict(data)
         except ResumeStateError as exc:
             raise ResumeStateError(f"Invalid resume state file {path}: {exc}") from exc
+
+    def scan(self) -> ResumeStateScan:
+        if not self.processing_dir.exists():
+            return ResumeStateScan(running=(), invalid=())
+
+        running: list[TranslationResumeState] = []
+        invalid: list[InvalidResumeState] = []
+        for path in sorted(self.processing_dir.glob(STATE_FILE_PATTERN)):
+            try:
+                state = self.load(path)
+            except ResumeStateError as exc:
+                invalid.append(InvalidResumeState(path=path, message=str(exc)))
+                continue
+
+            if state.status == RUNNING_STATUS:
+                running.append(state)
+
+        return ResumeStateScan(running=tuple(running), invalid=tuple(invalid))
 
 
 def default_processing_dir() -> Path:

--- a/src/ayvu/resume.py
+++ b/src/ayvu/resume.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, replace
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from .domain import TranslationOptions
+
+
+RESUME_STATE_VERSION = 1
+RUNNING_STATUS = "running"
+COMPLETED_STATUS = "completed"
+
+
+class ResumeStateError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class TranslationResumeState:
+    version: int
+    status: str
+    input_path: Path
+    output_path: Path
+    cache_path: Path
+    source: str
+    target: str
+    translator_name: str
+    url: str
+    glossary_path: Path | None
+    fail_fast: bool
+    overwrite: bool
+    timeout: float
+    retries: int
+    chunk_limit: int
+    created_at: str
+    updated_at: str
+
+    @classmethod
+    def create(
+        cls,
+        input_path: Path,
+        output_path: Path,
+        cache_path: Path,
+        translator_name: str,
+        url: str,
+        glossary_path: Path | None,
+        options: TranslationOptions,
+        overwrite: bool,
+        timeout: float,
+        retries: int,
+    ) -> "TranslationResumeState":
+        now = _utc_now()
+        return cls(
+            version=RESUME_STATE_VERSION,
+            status=RUNNING_STATUS,
+            input_path=_absolute_path(input_path),
+            output_path=_absolute_path(output_path),
+            cache_path=_absolute_path(cache_path),
+            source=options.source,
+            target=options.target,
+            translator_name=translator_name,
+            url=url,
+            glossary_path=_absolute_path(glossary_path) if glossary_path else None,
+            fail_fast=options.fail_fast,
+            overwrite=overwrite,
+            timeout=timeout,
+            retries=retries,
+            chunk_limit=options.chunk_limit,
+            created_at=now,
+            updated_at=now,
+        )
+
+    @classmethod
+    def from_dict(cls, data: object) -> "TranslationResumeState":
+        if not isinstance(data, dict):
+            raise ResumeStateError("Resume state JSON must be an object.")
+
+        version = _required_int(data, "version")
+        if version != RESUME_STATE_VERSION:
+            raise ResumeStateError(f"Unsupported resume state version: {version}.")
+
+        status = _required_text(data, "status")
+        if status not in (RUNNING_STATUS, COMPLETED_STATUS):
+            raise ResumeStateError(f"Unsupported resume state status: {status}.")
+
+        return cls(
+            version=version,
+            status=status,
+            input_path=Path(_required_text(data, "input_path")),
+            output_path=Path(_required_text(data, "output_path")),
+            cache_path=Path(_required_text(data, "cache_path")),
+            source=_required_text(data, "source"),
+            target=_required_text(data, "target"),
+            translator_name=_required_text(data, "translator_name"),
+            url=_required_text(data, "url"),
+            glossary_path=_optional_path(data, "glossary_path"),
+            fail_fast=_required_bool(data, "fail_fast"),
+            overwrite=_required_bool(data, "overwrite"),
+            timeout=_required_number(data, "timeout"),
+            retries=_required_int(data, "retries"),
+            chunk_limit=_required_int(data, "chunk_limit"),
+            created_at=_required_text(data, "created_at"),
+            updated_at=_required_text(data, "updated_at"),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        for key in ("input_path", "output_path", "cache_path", "glossary_path"):
+            value = data[key]
+            data[key] = str(value) if value is not None else None
+        return data
+
+    def mark_completed(self) -> "TranslationResumeState":
+        return replace(self, status=COMPLETED_STATUS, updated_at=_utc_now())
+
+
+@dataclass(frozen=True)
+class ResumeStateStore:
+    processing_dir: Path
+
+    def state_path_for(self, state: TranslationResumeState) -> Path:
+        filename = f"{_safe_filename_part(state.input_path.stem)}-{_safe_filename_part(state.target)}.ayvu-state.json"
+        return self.processing_dir / filename
+
+    def save(self, state: TranslationResumeState) -> Path:
+        self.processing_dir.mkdir(parents=True, exist_ok=True)
+        path = self.state_path_for(state)
+        path.write_text(json.dumps(state.to_dict(), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        return path
+
+    def load(self, path: Path) -> TranslationResumeState:
+        try:
+            raw = path.read_text(encoding="utf-8")
+            data = json.loads(raw)
+        except FileNotFoundError as exc:
+            raise ResumeStateError(f"Resume state file not found: {path}") from exc
+        except json.JSONDecodeError as exc:
+            raise ResumeStateError(f"Resume state file is not valid JSON: {path}") from exc
+
+        try:
+            return TranslationResumeState.from_dict(data)
+        except ResumeStateError as exc:
+            raise ResumeStateError(f"Invalid resume state file {path}: {exc}") from exc
+
+
+def default_processing_dir() -> Path:
+    return Path.home() / "Documentos" / "Livros" / "Processando"
+
+
+def _required_text(data: dict[str, object], key: str) -> str:
+    value = _required_value(data, key)
+    if not isinstance(value, str) or not value.strip():
+        raise ResumeStateError(f"Resume state field {key} must be a non-empty string.")
+    return value
+
+
+def _required_int(data: dict[str, object], key: str) -> int:
+    value = _required_value(data, key)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ResumeStateError(f"Resume state field {key} must be an integer.")
+    return value
+
+
+def _required_bool(data: dict[str, object], key: str) -> bool:
+    value = _required_value(data, key)
+    if not isinstance(value, bool):
+        raise ResumeStateError(f"Resume state field {key} must be true or false.")
+    return value
+
+
+def _required_number(data: dict[str, object], key: str) -> float:
+    value = _required_value(data, key)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ResumeStateError(f"Resume state field {key} must be a number.")
+    return float(value)
+
+
+def _required_value(data: dict[str, object], key: str) -> object:
+    if key not in data:
+        raise ResumeStateError(f"Resume state field {key} is required.")
+    return data[key]
+
+
+def _optional_path(data: dict[str, object], key: str) -> Path | None:
+    value = data.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise ResumeStateError(f"Resume state field {key} must be a string or null.")
+    return Path(value)
+
+
+def _safe_filename_part(value: str) -> str:
+    clean = []
+    for char in value.strip():
+        if char.isalnum() or char in ("-", "_"):
+            clean.append(char)
+            continue
+        if char in (" ", "."):
+            clean.append("-")
+
+    filename = "".join(clean).strip("-_")
+    return filename or "translation"
+
+
+def _absolute_path(path: Path) -> Path:
+    return path.expanduser().resolve()
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,7 @@ from ayvu.cli import _offer_markdown_report, _render_markdown_report, _save_mark
 from ayvu.domain import LanguagePair, OutputPlan, TranslationOptions
 from ayvu.epub_io import TranslationReport
 from ayvu.preflight import PreflightError
-from ayvu.resume import COMPLETED_STATUS, ResumeStateStore
+from ayvu.resume import COMPLETED_STATUS, ResumeStateStore, TranslationResumeState
 from ayvu.validation import ValidationResult
 
 
@@ -70,6 +70,61 @@ def test_translate_command_has_clear_error_for_unknown_translator(tmp_path):
     assert "unknown" in result.output
     assert "Use --translator libretranslate." in result.output
     assert "Traceback" not in result.output
+
+
+def test_root_command_shows_processing_translation_state(tmp_path, monkeypatch):
+    processing_dir = tmp_path / "Processando"
+    state = TranslationResumeState.create(
+        input_path=tmp_path / "Original" / "book.epub",
+        output_path=tmp_path / "Traduzidos" / "book-pt.epub",
+        cache_path=tmp_path / "cache.sqlite",
+        translator_name="libretranslate",
+        url="http://localhost:5000",
+        glossary_path=None,
+        options=TranslationOptions(language_pair=LanguagePair(source="en", target="pt")),
+        overwrite=False,
+        timeout=30.0,
+        retries=2,
+    )
+    ResumeStateStore(processing_dir).save(state)
+    monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: processing_dir)
+
+    result = runner.invoke(app, [])
+
+    assert result.exit_code == 0
+    assert "Translations in progress were found." in result.output
+    assert "Processing translations" in result.output
+    assert "book.epub" in result.output
+    assert "book-pt.epub" in result.output
+    assert "cache.sqlite" in result.output
+    assert "Usage:" in result.output
+
+
+def test_root_command_reports_invalid_processing_state(tmp_path, monkeypatch):
+    processing_dir = tmp_path / "Processando"
+    processing_dir.mkdir()
+    (processing_dir / "bad.ayvu-state.json").write_text("{bad", encoding="utf-8")
+    monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: processing_dir)
+
+    result = runner.invoke(app, [])
+
+    assert result.exit_code == 0
+    assert "Invalid processing state files were found." in result.output
+    assert "bad.ayvu-state.json" in result.output
+    assert "not valid JSON" in result.output
+    assert "Restart the translation" in result.output
+    assert "Usage:" in result.output
+
+
+def test_root_command_without_processing_state_has_no_processing_noise(tmp_path, monkeypatch):
+    monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: tmp_path / "missing")
+
+    result = runner.invoke(app, [])
+
+    assert result.exit_code == 0
+    assert "Usage:" in result.output
+    assert "Translations in progress were found." not in result.output
+    assert "Invalid processing state files were found." not in result.output
 
 
 def test_translate_command_stops_when_preflight_fails(tmp_path, monkeypatch):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ from ayvu.cli import _offer_markdown_report, _render_markdown_report, _save_mark
 from ayvu.domain import LanguagePair, OutputPlan, TranslationOptions
 from ayvu.epub_io import TranslationReport
 from ayvu.preflight import PreflightError
+from ayvu.resume import COMPLETED_STATUS, ResumeStateStore
 from ayvu.validation import ValidationResult
 
 
@@ -198,6 +199,7 @@ def test_translate_command_offers_and_saves_markdown_report(tmp_path, monkeypatc
     epub_path = tmp_path / "book.epub"
     output_path = tmp_path / "book-pt.epub"
     reports_dir = tmp_path / "reports"
+    processing_dir = tmp_path / "processing"
     epub_path.write_bytes(b"fake epub")
 
     report = TranslationReport(
@@ -217,10 +219,13 @@ def test_translate_command_offers_and_saves_markdown_report(tmp_path, monkeypatc
     monkeypatch.setattr("ayvu.cli.translate_epub", lambda *_args, **_kwargs: report)
     monkeypatch.setattr("ayvu.cli.validate_output_epub", lambda _path: ValidationResult(ok=True, document_count=1))
     monkeypatch.setattr("ayvu.cli._default_reports_dir", lambda: reports_dir)
+    monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: processing_dir)
 
     result = runner.invoke(app, ["translate", str(epub_path), "--output", str(output_path)], input="y\n")
 
     report_path = reports_dir / "book-pt-report.md"
+    state_path = processing_dir / "book-pt.ayvu-state.json"
+    resume_state = ResumeStateStore(processing_dir).load(state_path)
     assert result.exit_code == 0
     assert "Translation report" in result.output
     assert "Original EPUB" in result.output
@@ -230,6 +235,14 @@ def test_translate_command_offers_and_saves_markdown_report(tmp_path, monkeypatc
     assert report_path.exists()
     assert "- Original EPUB: " in report_path.read_text(encoding="utf-8")
     assert str(epub_path) in report_path.read_text(encoding="utf-8")
+    assert resume_state.status == COMPLETED_STATUS
+    assert resume_state.input_path == epub_path.resolve()
+    assert resume_state.output_path == output_path.resolve()
+    assert resume_state.cache_path == Path(".cache/traducoes.sqlite").resolve()
+    assert resume_state.source == "en"
+    assert resume_state.target == "pt"
+    assert resume_state.translator_name == "libretranslate"
+    assert not resume_state.overwrite
 
 
 class FakeCache:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -74,22 +74,11 @@ def test_translate_command_has_clear_error_for_unknown_translator(tmp_path):
 
 def test_root_command_shows_processing_translation_state(tmp_path, monkeypatch):
     processing_dir = tmp_path / "Processando"
-    state = TranslationResumeState.create(
-        input_path=tmp_path / "Original" / "book.epub",
-        output_path=tmp_path / "Traduzidos" / "book-pt.epub",
-        cache_path=tmp_path / "cache.sqlite",
-        translator_name="libretranslate",
-        url="http://localhost:5000",
-        glossary_path=None,
-        options=TranslationOptions(language_pair=LanguagePair(source="en", target="pt")),
-        overwrite=False,
-        timeout=30.0,
-        retries=2,
-    )
+    state = _resume_state(tmp_path)
     ResumeStateStore(processing_dir).save(state)
     monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: processing_dir)
 
-    result = runner.invoke(app, [])
+    result = runner.invoke(app, [], input="n\n")
 
     assert result.exit_code == 0
     assert "Translations in progress were found." in result.output
@@ -97,7 +86,82 @@ def test_root_command_shows_processing_translation_state(tmp_path, monkeypatch):
     assert "book.epub" in result.output
     assert "book-pt.epub" in result.output
     assert "cache.sqlite" in result.output
+    assert "Continue detected translation?" in result.output
+    assert "Detected translation was not resumed." in result.output
     assert "Usage:" in result.output
+
+
+def test_root_command_resumes_detected_translation_when_confirmed(tmp_path, monkeypatch):
+    processing_dir = tmp_path / "Processando"
+    state = _resume_state(tmp_path)
+    report = TranslationReport(
+        chapters_processed=1,
+        texts_translated=2,
+        output_path=state.output_path,
+        input_path=state.input_path,
+        detected_language=state.source,
+        target_language=state.target,
+    )
+    calls: dict[str, object] = {}
+    ResumeStateStore(processing_dir).save(state)
+
+    def fake_preflight(**kwargs: object) -> object:
+        calls["preflight"] = kwargs
+        return SimpleNamespace(translator=object(), glossary=None)
+
+    def fake_translate(*_args: object, **kwargs: object) -> TranslationReport:
+        calls["translation_options"] = kwargs["options"]
+        return report
+
+    monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: processing_dir)
+    monkeypatch.setattr("ayvu.cli.run_translation_preflight", fake_preflight)
+    monkeypatch.setattr("ayvu.cli.TranslationCache", lambda _path: FakeCache())
+    monkeypatch.setattr("ayvu.cli.translate_epub", fake_translate)
+    monkeypatch.setattr("ayvu.cli.validate_output_epub", lambda _path: ValidationResult(ok=True, document_count=1))
+    monkeypatch.setattr("ayvu.cli._offer_markdown_report", lambda *_args, **_kwargs: None)
+
+    result = runner.invoke(app, [], input="y\n")
+
+    preflight = calls["preflight"]
+    options = calls["translation_options"]
+    saved_state = ResumeStateStore(processing_dir).load(processing_dir / "book-pt.ayvu-state.json")
+    assert result.exit_code == 0
+    assert "Continue detected translation?" in result.output
+    assert "Resuming translation:" in result.output
+    assert "Translation report" in result.output
+    assert "Usage:" not in result.output
+    assert preflight["epub_path"] == state.input_path
+    assert preflight["cache_path"] == state.cache_path
+    assert preflight["glossary_path"] == state.glossary_path
+    assert preflight["translator_name"] == state.translator_name
+    assert preflight["url"] == state.url
+    assert preflight["timeout"] == state.timeout
+    assert preflight["retries"] == state.retries
+    assert options.source == state.source
+    assert options.target == state.target
+    assert options.chunk_limit == state.chunk_limit
+    assert saved_state.status == COMPLETED_STATUS
+
+
+def test_root_command_reports_resume_failure_without_traceback(tmp_path, monkeypatch):
+    processing_dir = tmp_path / "Processando"
+    ResumeStateStore(processing_dir).save(_resume_state(tmp_path))
+    monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: processing_dir)
+    monkeypatch.setattr(
+        "ayvu.cli.run_translation_preflight",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            PreflightError("EPUB check failed: missing file", "Choose a valid EPUB.")
+        ),
+    )
+
+    result = runner.invoke(app, [], input="y\n")
+
+    assert result.exit_code == 1
+    assert "Continue detected translation?" in result.output
+    assert "Environment check failed:" in result.output
+    assert "EPUB check failed: missing file" in result.output
+    assert "Could not resume detected translation." in result.output
+    assert "Traceback" not in result.output
 
 
 def test_root_command_reports_invalid_processing_state(tmp_path, monkeypatch):
@@ -306,3 +370,21 @@ class FakeCache:
 
     def __exit__(self, _exc_type: object, _exc: object, _traceback: object) -> None:
         return None
+
+
+def _resume_state(tmp_path: Path) -> TranslationResumeState:
+    return TranslationResumeState.create(
+        input_path=tmp_path / "Original" / "book.epub",
+        output_path=tmp_path / "Traduzidos" / "book-pt.epub",
+        cache_path=tmp_path / "cache.sqlite",
+        translator_name="libretranslate",
+        url="http://localhost:5000",
+        glossary_path=None,
+        options=TranslationOptions(
+            language_pair=LanguagePair(source="en", target="pt"),
+            chunk_limit=1500,
+        ),
+        overwrite=False,
+        timeout=30.0,
+        retries=2,
+    )

--- a/tests/test_resume.py
+++ b/tests/test_resume.py
@@ -1,0 +1,90 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from ayvu.domain import LanguagePair, TranslationOptions
+from ayvu.resume import (
+    COMPLETED_STATUS,
+    RESUME_STATE_VERSION,
+    RUNNING_STATUS,
+    ResumeStateError,
+    ResumeStateStore,
+    TranslationResumeState,
+)
+
+
+def make_state(tmp_path: Path) -> TranslationResumeState:
+    return TranslationResumeState.create(
+        input_path=tmp_path / "Original" / "book.epub",
+        output_path=tmp_path / "Traduzidos" / "book-pt.epub",
+        cache_path=tmp_path / "cache.sqlite",
+        translator_name="libretranslate",
+        url="http://localhost:5000",
+        glossary_path=tmp_path / "glossary.json",
+        options=TranslationOptions(
+            language_pair=LanguagePair(source="en", target="pt"),
+            dry_run=False,
+            fail_fast=True,
+            chunk_limit=1200,
+        ),
+        overwrite=True,
+        timeout=9.5,
+        retries=3,
+    )
+
+
+def test_resume_state_round_trip(tmp_path):
+    store = ResumeStateStore(tmp_path / "Processando")
+    state = make_state(tmp_path)
+
+    path = store.save(state)
+    loaded = store.load(path)
+
+    assert path.name == "book-pt.ayvu-state.json"
+    assert loaded == state
+    assert loaded.status == RUNNING_STATUS
+    assert loaded.version == RESUME_STATE_VERSION
+    assert loaded.source == "en"
+    assert loaded.target == "pt"
+    assert loaded.fail_fast
+    assert loaded.overwrite
+    assert loaded.chunk_limit == 1200
+    assert loaded.timeout == 9.5
+    assert loaded.retries == 3
+
+
+def test_resume_state_can_be_marked_completed(tmp_path):
+    state = make_state(tmp_path)
+
+    completed = state.mark_completed()
+
+    assert state.status == RUNNING_STATUS
+    assert completed.status == COMPLETED_STATUS
+    assert completed.created_at == state.created_at
+
+
+def test_resume_state_load_reports_invalid_json(tmp_path):
+    path = tmp_path / "bad.ayvu-state.json"
+    path.write_text("{bad", encoding="utf-8")
+    store = ResumeStateStore(tmp_path)
+
+    with pytest.raises(ResumeStateError) as error:
+        store.load(path)
+
+    assert "Resume state file is not valid JSON" in str(error.value)
+    assert str(path) in str(error.value)
+
+
+def test_resume_state_load_reports_missing_required_field(tmp_path):
+    path = tmp_path / "missing.ayvu-state.json"
+    data = make_state(tmp_path).to_dict()
+    data.pop("cache_path")
+    path.write_text(json.dumps(data), encoding="utf-8")
+    store = ResumeStateStore(tmp_path)
+
+    with pytest.raises(ResumeStateError) as error:
+        store.load(path)
+
+    assert "Invalid resume state file" in str(error.value)
+    assert "cache_path is required" in str(error.value)

--- a/tests/test_resume.py
+++ b/tests/test_resume.py
@@ -14,10 +14,10 @@ from ayvu.resume import (
 )
 
 
-def make_state(tmp_path: Path) -> TranslationResumeState:
+def make_state(tmp_path: Path, stem: str = "book") -> TranslationResumeState:
     return TranslationResumeState.create(
-        input_path=tmp_path / "Original" / "book.epub",
-        output_path=tmp_path / "Traduzidos" / "book-pt.epub",
+        input_path=tmp_path / "Original" / f"{stem}.epub",
+        output_path=tmp_path / "Traduzidos" / f"{stem}-pt.epub",
         cache_path=tmp_path / "cache.sqlite",
         translator_name="libretranslate",
         url="http://localhost:5000",
@@ -88,3 +88,29 @@ def test_resume_state_load_reports_missing_required_field(tmp_path):
 
     assert "Invalid resume state file" in str(error.value)
     assert "cache_path is required" in str(error.value)
+
+
+def test_resume_state_scan_finds_running_and_invalid_states(tmp_path):
+    store = ResumeStateStore(tmp_path / "Processando")
+    running = make_state(tmp_path, "running-book")
+    completed = make_state(tmp_path, "completed-book").mark_completed()
+    store.save(running)
+    store.save(completed)
+    bad_path = store.processing_dir / "bad.ayvu-state.json"
+    bad_path.write_text("{bad", encoding="utf-8")
+
+    scan = store.scan()
+
+    assert scan.running == (running,)
+    assert len(scan.invalid) == 1
+    assert scan.invalid[0].path == bad_path
+    assert "not valid JSON" in scan.invalid[0].message
+    assert scan.has_findings
+
+
+def test_resume_state_scan_ignores_missing_processing_dir(tmp_path):
+    scan = ResumeStateStore(tmp_path / "missing").scan()
+
+    assert scan.running == ()
+    assert scan.invalid == ()
+    assert not scan.has_findings


### PR DESCRIPTION
Objetivo: criar a base persistida para retomada futura de traducoes interrompidas, sem implementar deteccao no startup nem retomada automatica. O que mudou: criado src/ayvu/resume.py com TranslationResumeState, ResumeStateStore e validacao de JSON; o estado usa versao de schema, status running/completed e caminhos absolutos para entrada, saida, cache e glossario; a CLI grava estado em Documentos/Livros/Processando antes de traducoes reais; a CLI marca o estado como completed apos validacao bem-sucedida do EPUB gerado; falhas de escrita do estado exibem mensagem clara; README documenta o arquivo local de estado; testes cobrem leitura, escrita, validacao de JSON invalido, campo ausente e integracao da CLI. Fora do escopo: nao detecta estados ao iniciar o Ayvu; nao pergunta se o usuario deseja continuar; nao executa retomada automaticamente; nao move nem apaga arquivos da pasta Processando. Validacao/testes: uv run pytest com 45 passed; git diff --cached --check sem problemas. Closes #32. Refs #17