### PR TITLE
Permitir retomar tradução detectada em Processando

### DIFF
--- a/src/ayvu/cli.py
+++ b/src/ayvu/cli.py
@@ -16,6 +16,7 @@ from .preflight import PreflightError, run_translation_preflight
 from .resume import (
     InvalidResumeState,
     ResumeStateError,
+    ResumeStateScan,
     ResumeStateStore,
     TranslationResumeState,
     default_processing_dir,
@@ -34,7 +35,10 @@ def main(ctx: typer.Context) -> None:
     if ctx.invoked_subcommand is not None:
         return
 
-    _print_processing_translation_states(ResumeStateStore(default_processing_dir()))
+    scan = _print_processing_translation_states(ResumeStateStore(default_processing_dir()))
+    if _offer_detected_translation_resume(scan.running):
+        return
+
     console.print(ctx.get_help())
 
 
@@ -95,6 +99,40 @@ def translate(
     chunk_limit: int = typer.Option(3000, "--chunk-limit", help="Maximum characters sent per request."),
 ) -> None:
     """Translate EPUB visible text while preserving EPUB structure."""
+    _run_translation(
+        epub_path=epub_path,
+        output=output,
+        source=source,
+        target=target,
+        translator_name=translator_name,
+        url=url,
+        cache_path=cache_path,
+        glossary_path=glossary_path,
+        dry_run=dry_run,
+        fail_fast=fail_fast,
+        overwrite=overwrite,
+        timeout=timeout,
+        retries=retries,
+        chunk_limit=chunk_limit,
+    )
+
+
+def _run_translation(
+    epub_path: Path,
+    output: Path | None,
+    source: str,
+    target: str,
+    translator_name: str,
+    url: str,
+    cache_path: Path,
+    glossary_path: Path | None,
+    dry_run: bool,
+    fail_fast: bool,
+    overwrite: bool,
+    timeout: float,
+    retries: int,
+    chunk_limit: int,
+) -> None:
     language_pair = LanguagePair(source=source, target=target)
     translation_options = TranslationOptions(
         language_pair=language_pair,
@@ -214,15 +252,58 @@ def _print_report(report: TranslationReport, dry_run: bool) -> None:
         console.print(f"[yellow]Error:[/yellow] {error}")
 
 
-def _print_processing_translation_states(store: ResumeStateStore) -> None:
+def _print_processing_translation_states(store: ResumeStateStore) -> ResumeStateScan:
     scan = store.scan()
     if not scan.has_findings:
-        return
+        return scan
 
     if scan.running:
         _print_running_resume_states(scan.running)
     if scan.invalid:
         _print_invalid_resume_states(scan.invalid)
+    return scan
+
+
+def _offer_detected_translation_resume(states: tuple[TranslationResumeState, ...]) -> bool:
+    if not states:
+        return False
+    if len(states) > 1:
+        console.print("Multiple translations are in progress; automatic selection is not available yet.")
+        return False
+
+    state = states[0]
+    if not typer.confirm("Continue detected translation?", default=False):
+        console.print("Detected translation was not resumed. Processing files were left unchanged.")
+        return False
+
+    console.print(f"[green]Resuming translation:[/green] {state.input_path.name} -> {state.output_path.name}")
+    _resume_translation(state)
+    return True
+
+
+def _resume_translation(state: TranslationResumeState) -> None:
+    try:
+        _run_translation(
+            epub_path=state.input_path,
+            output=state.output_path,
+            source=state.source,
+            target=state.target,
+            translator_name=state.translator_name,
+            url=state.url,
+            cache_path=state.cache_path,
+            glossary_path=state.glossary_path,
+            dry_run=False,
+            fail_fast=state.fail_fast,
+            overwrite=state.overwrite,
+            timeout=state.timeout,
+            retries=state.retries,
+            chunk_limit=state.chunk_limit,
+        )
+    except typer.Exit:
+        console.print(
+            "Could not resume detected translation. Check the message above and restart the translation if needed."
+        )
+        raise
 
 
 def _print_running_resume_states(states: tuple[TranslationResumeState, ...]) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -74,22 +74,11 @@ def test_translate_command_has_clear_error_for_unknown_translator(tmp_path):
 
 def test_root_command_shows_processing_translation_state(tmp_path, monkeypatch):
     processing_dir = tmp_path / "Processando"
-    state = TranslationResumeState.create(
-        input_path=tmp_path / "Original" / "book.epub",
-        output_path=tmp_path / "Traduzidos" / "book-pt.epub",
-        cache_path=tmp_path / "cache.sqlite",
-        translator_name="libretranslate",
-        url="http://localhost:5000",
-        glossary_path=None,
-        options=TranslationOptions(language_pair=LanguagePair(source="en", target="pt")),
-        overwrite=False,
-        timeout=30.0,
-        retries=2,
-    )
+    state = _resume_state(tmp_path)
     ResumeStateStore(processing_dir).save(state)
     monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: processing_dir)
 
-    result = runner.invoke(app, [])
+    result = runner.invoke(app, [], input="n\n")
 
     assert result.exit_code == 0
     assert "Translations in progress were found." in result.output
@@ -97,7 +86,82 @@ def test_root_command_shows_processing_translation_state(tmp_path, monkeypatch):
     assert "book.epub" in result.output
     assert "book-pt.epub" in result.output
     assert "cache.sqlite" in result.output
+    assert "Continue detected translation?" in result.output
+    assert "Detected translation was not resumed." in result.output
     assert "Usage:" in result.output
+
+
+def test_root_command_resumes_detected_translation_when_confirmed(tmp_path, monkeypatch):
+    processing_dir = tmp_path / "Processando"
+    state = _resume_state(tmp_path)
+    report = TranslationReport(
+        chapters_processed=1,
+        texts_translated=2,
+        output_path=state.output_path,
+        input_path=state.input_path,
+        detected_language=state.source,
+        target_language=state.target,
+    )
+    calls: dict[str, object] = {}
+    ResumeStateStore(processing_dir).save(state)
+
+    def fake_preflight(**kwargs: object) -> object:
+        calls["preflight"] = kwargs
+        return SimpleNamespace(translator=object(), glossary=None)
+
+    def fake_translate(*_args: object, **kwargs: object) -> TranslationReport:
+        calls["translation_options"] = kwargs["options"]
+        return report
+
+    monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: processing_dir)
+    monkeypatch.setattr("ayvu.cli.run_translation_preflight", fake_preflight)
+    monkeypatch.setattr("ayvu.cli.TranslationCache", lambda _path: FakeCache())
+    monkeypatch.setattr("ayvu.cli.translate_epub", fake_translate)
+    monkeypatch.setattr("ayvu.cli.validate_output_epub", lambda _path: ValidationResult(ok=True, document_count=1))
+    monkeypatch.setattr("ayvu.cli._offer_markdown_report", lambda *_args, **_kwargs: None)
+
+    result = runner.invoke(app, [], input="y\n")
+
+    preflight = calls["preflight"]
+    options = calls["translation_options"]
+    saved_state = ResumeStateStore(processing_dir).load(processing_dir / "book-pt.ayvu-state.json")
+    assert result.exit_code == 0
+    assert "Continue detected translation?" in result.output
+    assert "Resuming translation:" in result.output
+    assert "Translation report" in result.output
+    assert "Usage:" not in result.output
+    assert preflight["epub_path"] == state.input_path
+    assert preflight["cache_path"] == state.cache_path
+    assert preflight["glossary_path"] == state.glossary_path
+    assert preflight["translator_name"] == state.translator_name
+    assert preflight["url"] == state.url
+    assert preflight["timeout"] == state.timeout
+    assert preflight["retries"] == state.retries
+    assert options.source == state.source
+    assert options.target == state.target
+    assert options.chunk_limit == state.chunk_limit
+    assert saved_state.status == COMPLETED_STATUS
+
+
+def test_root_command_reports_resume_failure_without_traceback(tmp_path, monkeypatch):
+    processing_dir = tmp_path / "Processando"
+    ResumeStateStore(processing_dir).save(_resume_state(tmp_path))
+    monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: processing_dir)
+    monkeypatch.setattr(
+        "ayvu.cli.run_translation_preflight",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            PreflightError("EPUB check failed: missing file", "Choose a valid EPUB.")
+        ),
+    )
+
+    result = runner.invoke(app, [], input="y\n")
+
+    assert result.exit_code == 1
+    assert "Continue detected translation?" in result.output
+    assert "Environment check failed:" in result.output
+    assert "EPUB check failed: missing file" in result.output
+    assert "Could not resume detected translation." in result.output
+    assert "Traceback" not in result.output
 
 
 def test_root_command_reports_invalid_processing_state(tmp_path, monkeypatch):
@@ -306,3 +370,21 @@ class FakeCache:
 
     def __exit__(self, _exc_type: object, _exc: object, _traceback: object) -> None:
         return None
+
+
+def _resume_state(tmp_path: Path) -> TranslationResumeState:
+    return TranslationResumeState.create(
+        input_path=tmp_path / "Original" / "book.epub",
+        output_path=tmp_path / "Traduzidos" / "book-pt.epub",
+        cache_path=tmp_path / "cache.sqlite",
+        translator_name="libretranslate",
+        url="http://localhost:5000",
+        glossary_path=None,
+        options=TranslationOptions(
+            language_pair=LanguagePair(source="en", target="pt"),
+            chunk_limit=1500,
+        ),
+        overwrite=False,
+        timeout=30.0,
+        retries=2,
+    )


### PR DESCRIPTION
Objetivo: permitir que o usuario retome uma traducao detectada em Documentos/Livros/Processando usando o cache e os parametros salvos no estado. O que mudou: a CLI pergunta se deseja continuar quando encontra exatamente um estado running; resposta nao mantem os arquivos intactos e mostra a ajuda; resposta sim chama o fluxo existente de traducao com os parametros persistidos; falhas esperadas de preflight/retomada explicam o motivo sem traceback; multiplos estados continuam apenas detectados, sem UI de escolha. Fora do escopo: criacao do estado de retomada, feita na #32; deteccao sem prompt, feita na #30; mover ou apagar arquivos da pasta Processando; interface completa para escolher entre muitos trabalhos. Validacao/testes: uv run pytest com 52 passed; git diff --cached --check sem problemas. Closes #31. Refs #17. Stacked on #34 / feat/detect-processing-translations.