### PR TITLE
Criar testes com EPUB mínimo gerado por código

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+
+import pytest
+from ebooklib import epub
+
+
+MINIMAL_PNG = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="
+)
+
+
+@pytest.fixture
+def minimal_epub_path(tmp_path: Path) -> Path:
+    path = tmp_path / "minimal.epub"
+    book = epub.EpubBook()
+    book.set_identifier("ayvu-minimal-test")
+    book.set_title("Minimal Test Book")
+    book.set_language("en")
+    book.add_author("Ayvu Tests")
+
+    chapter_one = epub.EpubHtml(title="Chapter One", file_name="text/chapter1.xhtml", lang="en")
+    chapter_one.content = """
+    <h1>Chapter One</h1>
+    <p>Hello reader. Visit <a href="chapter2.xhtml#answer">chapter two</a>.</p>
+    <p><img src="../images/pixel.png" alt="Pixel" /></p>
+    """
+
+    chapter_two = epub.EpubHtml(title="Chapter Two", file_name="text/chapter2.xhtml", lang="en")
+    chapter_two.content = """
+    <h1 id="answer">Chapter Two</h1>
+    <p>Goodbye reader.</p>
+    """
+
+    image = epub.EpubItem(
+        uid="pixel",
+        file_name="images/pixel.png",
+        media_type="image/png",
+        content=MINIMAL_PNG,
+    )
+
+    book.add_item(chapter_one)
+    book.add_item(chapter_two)
+    book.add_item(image)
+    book.add_item(epub.EpubNcx())
+    book.add_item(epub.EpubNav())
+    book.toc = (
+        epub.Link("text/chapter1.xhtml", "Chapter One", "chapter-one"),
+        epub.Link("text/chapter2.xhtml", "Chapter Two", "chapter-two"),
+    )
+    book.spine = ["nav", chapter_one, chapter_two]
+
+    epub.write_epub(str(path), book)
+    return path

--- a/tests/test_epub_io.py
+++ b/tests/test_epub_io.py
@@ -1,7 +1,10 @@
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
+from zipfile import ZipFile
 
 from ebooklib import ITEM_DOCUMENT
 
+from ayvu.cache import TranslationCache
+from ayvu.domain import LanguagePair, TranslationOptions
 from ayvu.epub_io import (
     EpubDocument,
     EpubReplacements,
@@ -9,6 +12,9 @@ from ayvu.epub_io import (
     TranslationReport,
     _document_entries,
     _document_zip_path,
+    extract_markdown,
+    inspect_epub,
+    translate_epub,
 )
 
 
@@ -32,6 +38,15 @@ class FakeItem:
 class FakeZip:
     def read(self, filename: str) -> bytes:
         return f"original:{filename}".encode("utf-8")
+
+
+class PrefixTranslator:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, str]] = []
+
+    def translate(self, text: str, source: str, target: str) -> str:
+        self.calls.append((text, source, target))
+        return f"PT:{text}"
 
 
 def test_document_zip_path_for_root_opf():
@@ -86,3 +101,73 @@ def test_translation_report_records_preformatted_errors():
     report.record_error("text/chapter.xhtml: bad html")
 
     assert report.errors == ["text/chapter.xhtml: bad html"]
+
+
+def test_inspect_epub_reads_minimal_generated_epub(minimal_epub_path: Path):
+    info = inspect_epub(minimal_epub_path)
+
+    assert info.path == minimal_epub_path
+    assert info.title == "Minimal Test Book"
+    assert info.authors == ["Ayvu Tests"]
+    assert info.language == "en"
+    assert info.document_count >= 2
+    assert info.item_count >= 4
+
+
+def test_extract_markdown_reads_visible_text_from_minimal_generated_epub(
+    minimal_epub_path: Path,
+    tmp_path: Path,
+):
+    output_dir = tmp_path / "extracted"
+
+    written = extract_markdown(minimal_epub_path, output_dir)
+
+    extracted = "\n".join(path.read_text(encoding="utf-8") for path in written)
+    assert written
+    assert all(path.parent == output_dir for path in written)
+    assert "Chapter One" in extracted
+    assert "Hello reader. Visit" in extracted
+    assert "chapter two" in extracted
+    assert "Chapter Two" in extracted
+    assert "Goodbye reader." in extracted
+
+
+def test_translate_epub_translates_minimal_generated_epub_without_mutating_input(
+    minimal_epub_path: Path,
+    tmp_path: Path,
+):
+    output_path = tmp_path / "minimal-pt.epub"
+    translator = PrefixTranslator()
+    original_bytes = minimal_epub_path.read_bytes()
+    options = TranslationOptions(language_pair=LanguagePair(source="en", target="pt"))
+
+    with TranslationCache(tmp_path / "cache.sqlite") as cache:
+        report = translate_epub(
+            minimal_epub_path,
+            output_path,
+            translator=translator,
+            cache=cache,
+            options=options,
+        )
+
+    assert output_path.exists()
+    assert minimal_epub_path.read_bytes() == original_bytes
+    assert report.input_path == minimal_epub_path
+    assert report.output_path == output_path
+    assert report.detected_language == "en"
+    assert report.target_language == "pt"
+    assert report.chapters_processed >= 2
+    assert report.texts_translated >= 5
+    assert report.errors == []
+    assert translator.calls
+
+    with ZipFile(output_path) as output_epub:
+        names = output_epub.namelist()
+        chapter_name = next(name for name in names if name.endswith("text/chapter1.xhtml"))
+        chapter = output_epub.read(chapter_name).decode("utf-8")
+        assert any(name.endswith("images/pixel.png") for name in names)
+
+    assert "PT:Hello reader. Visit" in chapter
+    assert "PT:chapter two" in chapter
+    assert "chapter2.xhtml#answer" in chapter
+    assert "../images/pixel.png" in chapter

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+from ayvu.validation import validate_output_epub
+
+
+def test_validate_output_epub_accepts_minimal_generated_epub(minimal_epub_path: Path):
+    result = validate_output_epub(minimal_epub_path)
+
+    assert result.ok
+    assert result.warnings == []
+    assert result.document_count >= 2


### PR DESCRIPTION
## Objetivo

Criar cobertura com EPUB mínimo gerado por código, sem depender de arquivos reais de usuário.

## O que mudou

- Adicionada fixture `minimal_epub_path` que gera um EPUB temporário com dois XHTMLs, link interno e imagem referenciada.
- Adicionados testes para `inspect_epub`, `extract_markdown` e `translate_epub` usando o EPUB gerado.
- Adicionado teste básico de `validate_output_epub` com o mesmo EPUB mínimo.

## Fora do escopo

- Não altera código de produção.
- Não adiciona arquivos `.epub` versionados.
- Não muda comportamento da CLI.

## Validação/testes

- `uv run pytest` com 69 passed.
- `git diff --cached --check` sem problemas antes do commit.

Closes #18