### PR TITLE
Mostrar pasta padrão de saída antes da tradução

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,13 +98,16 @@ uv run ayvu translate livro.epub \
 
 Antes de iniciar a tradução, o Ayvu verifica internamente o par de idiomas, o glossário, o cache, o EPUB de entrada e, em traduções reais, o tradutor configurado. Se algo impedir a execução, o comando falha cedo com uma mensagem curta e um próximo passo.
 
-Sem `--output`, a saída é criada ao lado do arquivo original usando o idioma de destino:
+Sem `--output`, o Ayvu mostra a pasta padrão de saída, o nome calculado para o EPUB traduzido
+e pergunta se você deseja manter esse local antes de iniciar a tradução. Por padrão, o arquivo
+traduzido é salvo em:
 
 ```text
-livro-pt.epub
+~/Documentos/Livros/Traduzidos/livro-pt.epub
 ```
 
-Para escolher manualmente o caminho da saída:
+Se preferir outro caminho, responda não à pergunta e informe o caminho desejado. Para escolher
+manualmente o caminho da saída sem passar por essa pergunta, use `--output`:
 
 ```bash
 uv run ayvu translate livro.epub \

--- a/docs/relatorio-tecnico.md
+++ b/docs/relatorio-tecnico.md
@@ -96,6 +96,10 @@ ayvu translate game.epub \
   --glossary glossary.json
 ```
 
+Quando `--output` nao e informado em uma traducao real, o Ayvu mostra a pasta
+padrao `~/Documentos/Livros/Traduzidos`, o nome calculado do EPUB traduzido e
+pergunta se o usuario deseja manter esse local antes de iniciar a traducao.
+
 Rodar em modo dry-run:
 
 ```bash

--- a/src/ayvu/cli.py
+++ b/src/ayvu/cli.py
@@ -10,7 +10,7 @@ from rich.table import Table
 
 from .cache import TranslationCache
 from .cli_progress import TranslationProgress, TranslationProgressSnapshot
-from .domain import LanguagePair, OutputPlan, TranslationOptions
+from .domain import LanguagePair, OutputPlan, TranslationOptions, default_translated_books_dir
 from .epub_io import TranslationReport, extract_markdown, inspect_epub, translate_epub
 from .preflight import PreflightError, run_translation_preflight
 from .resume import (
@@ -140,7 +140,14 @@ def _run_translation(
         fail_fast=fail_fast,
         chunk_limit=chunk_limit,
     )
-    output_plan = OutputPlan.for_translation(epub_path, output, language_pair, dry_run=dry_run)
+    output_plan = OutputPlan.for_translation(
+        epub_path,
+        output,
+        language_pair,
+        dry_run=dry_run,
+        default_dir=default_translated_books_dir(),
+    )
+    output_plan = _confirm_default_output_location(output_plan, epub_path)
     output_path = output_plan.path
 
     if output_plan.blocks_existing_file(overwrite):
@@ -508,6 +515,38 @@ def _report_output_value(report: TranslationReport, dry_run: bool) -> str:
     if dry_run:
         return "(dry run, no file written)"
     return _display_optional_path(report.output_path)
+
+
+def _confirm_default_output_location(output_plan: OutputPlan, input_path: Path) -> OutputPlan:
+    if output_plan.explicit_output or output_plan.dry_run:
+        return output_plan
+
+    output_path = output_plan.path
+    console.print(f"[yellow]Default output folder:[/yellow] {output_path.parent}")
+    console.print(f"[yellow]Translated EPUB name:[/yellow] {output_path.name}")
+    console.print(_original_epub_location_message(input_path))
+
+    if typer.confirm("Keep this output location?", default=True):
+        return output_plan
+
+    return output_plan.with_path(_prompt_output_path(output_path))
+
+
+def _original_epub_location_message(input_path: Path) -> str:
+    if input_path.parent.name == "Original":
+        return f"Original EPUB stays in Original: {input_path}"
+    return f"Original EPUB remains unchanged: {input_path}"
+
+
+def _prompt_output_path(default_path: Path) -> Path:
+    raw_path = typer.prompt("Output EPUB path", default=str(default_path))
+    output_path = Path(raw_path).expanduser()
+    if not output_path.name:
+        console.print("[red]Canceled:[/red] output path was not changed.")
+        raise typer.Exit(code=1)
+    if output_path.suffix.lower() != ".epub":
+        return output_path.with_suffix(".epub")
+    return output_path
 
 
 def _single_line(value: str) -> str:

--- a/src/ayvu/domain.py
+++ b/src/ayvu/domain.py
@@ -28,6 +28,7 @@ class LanguagePair:
 class OutputPlan:
     path: Path
     dry_run: bool = False
+    explicit_output: bool = False
 
     @classmethod
     def for_translation(
@@ -36,12 +37,17 @@ class OutputPlan:
         explicit_output: Path | None,
         language_pair: LanguagePair,
         dry_run: bool = False,
+        default_dir: Path | None = None,
     ) -> "OutputPlan":
         if explicit_output is not None:
-            return cls(path=explicit_output, dry_run=dry_run)
+            return cls(path=explicit_output, dry_run=dry_run, explicit_output=True)
 
-        output_path = input_path.with_name(f"{input_path.stem}-{language_pair.target_label}.epub")
+        output_dir = default_dir or default_translated_books_dir()
+        output_path = output_dir / f"{input_path.stem}-{language_pair.target_label}.epub"
         return cls(path=output_path, dry_run=dry_run)
+
+    def with_path(self, path: Path) -> "OutputPlan":
+        return OutputPlan(path=path, dry_run=self.dry_run, explicit_output=self.explicit_output)
 
     def blocks_existing_file(self, overwrite: bool) -> bool:
         if self.dry_run:
@@ -49,6 +55,10 @@ class OutputPlan:
         if overwrite:
             return False
         return self.path.exists()
+
+
+def default_translated_books_dir() -> Path:
+    return Path.home() / "Documentos" / "Livros" / "Traduzidos"
 
 
 @dataclass(frozen=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,22 +21,36 @@ def test_output_plan_keeps_explicit_output():
     plan = OutputPlan.for_translation(Path("livro.epub"), output, language_pair)
 
     assert plan.path == output
+    assert plan.explicit_output
 
 
-def test_output_plan_uses_target_suffix_next_to_input():
+def test_output_plan_uses_target_suffix_in_default_output_dir():
     language_pair = LanguagePair(source="en", target="pt-BR")
+    default_dir = Path("Documentos/Livros/Traduzidos")
 
-    plan = OutputPlan.for_translation(Path("books/livro.epub"), None, language_pair)
+    plan = OutputPlan.for_translation(
+        Path("books/livro.epub"),
+        None,
+        language_pair,
+        default_dir=default_dir,
+    )
 
-    assert plan.path == Path("books/livro-pt-BR.epub")
+    assert plan.path == Path("Documentos/Livros/Traduzidos/livro-pt-BR.epub")
+    assert not plan.explicit_output
 
 
 def test_output_plan_uses_translated_suffix_when_target_is_blank():
     language_pair = LanguagePair(source="en", target=" ")
+    default_dir = Path("Documentos/Livros/Traduzidos")
 
-    plan = OutputPlan.for_translation(Path("books/livro.epub"), None, language_pair)
+    plan = OutputPlan.for_translation(
+        Path("books/livro.epub"),
+        None,
+        language_pair,
+        default_dir=default_dir,
+    )
 
-    assert plan.path == Path("books/livro-translated.epub")
+    assert plan.path == Path("Documentos/Livros/Traduzidos/livro-translated.epub")
 
 
 def test_output_plan_dry_run_does_not_block_existing_output(tmp_path):
@@ -194,6 +208,7 @@ def test_root_command_without_processing_state_has_no_processing_noise(tmp_path,
 def test_translate_command_stops_when_preflight_fails(tmp_path, monkeypatch):
     epub_path = tmp_path / "book.epub"
     epub_path.write_bytes(b"fake epub")
+    monkeypatch.setattr("ayvu.cli.default_translated_books_dir", lambda: tmp_path / "Traduzidos")
 
     def fail_preflight(**_kwargs: object) -> object:
         raise PreflightError("Cache check failed: no write permission", "Choose a writable cache path.")
@@ -204,13 +219,94 @@ def test_translate_command_stops_when_preflight_fails(tmp_path, monkeypatch):
     monkeypatch.setattr("ayvu.cli.run_translation_preflight", fail_preflight)
     monkeypatch.setattr("ayvu.cli.translate_epub", fail_translate)
 
-    result = runner.invoke(app, ["translate", str(epub_path)])
+    result = runner.invoke(app, ["translate", str(epub_path)], input="y\n")
 
     assert result.exit_code == 1
+    assert "Default output folder:" in result.output
+    assert "Keep this output location?" in result.output
     assert "Environment check failed:" in result.output
     assert "Cache check failed: no write permission" in result.output
     assert "Choose a writable cache path." in result.output
     assert "Traceback" not in result.output
+
+
+def test_translate_command_confirms_default_output_location(tmp_path, monkeypatch):
+    original_dir = tmp_path / "Original"
+    epub_path = original_dir / "book.epub"
+    output_dir = tmp_path / "Traduzidos"
+    processing_dir = tmp_path / "Processando"
+    epub_path.parent.mkdir()
+    epub_path.write_bytes(b"fake epub")
+    calls: dict[str, Path] = {}
+
+    def fake_translate(input_path: Path, output_path: Path, **_kwargs: object) -> TranslationReport:
+        calls["input_path"] = input_path
+        calls["output_path"] = output_path
+        return TranslationReport(
+            output_path=output_path,
+            input_path=input_path,
+            detected_language="en",
+            target_language="pt",
+        )
+
+    monkeypatch.setattr("ayvu.cli.default_translated_books_dir", lambda: output_dir)
+    monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: processing_dir)
+    monkeypatch.setattr(
+        "ayvu.cli.run_translation_preflight",
+        lambda **_kwargs: SimpleNamespace(translator=object(), glossary=None),
+    )
+    monkeypatch.setattr("ayvu.cli.TranslationCache", lambda _path: FakeCache())
+    monkeypatch.setattr("ayvu.cli.translate_epub", fake_translate)
+    monkeypatch.setattr("ayvu.cli.validate_output_epub", lambda _path: ValidationResult(ok=True, document_count=1))
+    monkeypatch.setattr("ayvu.cli._offer_markdown_report", lambda *_args, **_kwargs: None)
+
+    result = runner.invoke(app, ["translate", str(epub_path)], input="y\n")
+
+    output_path = output_dir / "book-pt.epub"
+    state_path = processing_dir / "book-pt.ayvu-state.json"
+    resume_state = ResumeStateStore(processing_dir).load(state_path)
+    assert result.exit_code == 0
+    assert "Default output folder:" in result.output
+    assert str(output_dir) in result.output
+    assert "Translated EPUB name:" in result.output
+    assert "book-pt.epub" in result.output
+    assert "Original EPUB stays in Original:" in result.output
+    assert "Keep this output location?" in result.output
+    assert calls["input_path"] == epub_path
+    assert calls["output_path"] == output_path
+    assert resume_state.output_path == output_path.resolve()
+
+
+def test_translate_command_allows_custom_output_path_from_default_prompt(tmp_path, monkeypatch):
+    epub_path = tmp_path / "book.epub"
+    output_dir = tmp_path / "Traduzidos"
+    custom_output = tmp_path / "Escolhidos" / "custom-name"
+    processing_dir = tmp_path / "Processando"
+    epub_path.write_bytes(b"fake epub")
+    calls: dict[str, Path] = {}
+
+    def fake_translate(_input_path: Path, output_path: Path, **_kwargs: object) -> TranslationReport:
+        calls["output_path"] = output_path
+        return TranslationReport(output_path=output_path, input_path=epub_path, target_language="pt")
+
+    monkeypatch.setattr("ayvu.cli.default_translated_books_dir", lambda: output_dir)
+    monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: processing_dir)
+    monkeypatch.setattr(
+        "ayvu.cli.run_translation_preflight",
+        lambda **_kwargs: SimpleNamespace(translator=object(), glossary=None),
+    )
+    monkeypatch.setattr("ayvu.cli.TranslationCache", lambda _path: FakeCache())
+    monkeypatch.setattr("ayvu.cli.translate_epub", fake_translate)
+    monkeypatch.setattr("ayvu.cli.validate_output_epub", lambda _path: ValidationResult(ok=True, document_count=1))
+    monkeypatch.setattr("ayvu.cli._offer_markdown_report", lambda *_args, **_kwargs: None)
+
+    result = runner.invoke(app, ["translate", str(epub_path)], input=f"n\n{custom_output}\n")
+
+    output_path = custom_output.with_suffix(".epub")
+    assert result.exit_code == 0
+    assert "Keep this output location?" in result.output
+    assert "Output EPUB path" in result.output
+    assert calls["output_path"] == output_path
 
 
 def test_translate_command_asks_before_overwriting_existing_output_and_cancels(tmp_path):


### PR DESCRIPTION
## Objetivo

Mostrar a pasta padrão de saída antes de iniciar uma tradução real sem `--output`, permitindo manter o local calculado ou informar outro caminho.

## O que mudou

- `OutputPlan` passa a calcular a saída padrão em `~/Documentos/Livros/Traduzidos` quando não há `--output`.
- A CLI mostra pasta padrão, nome calculado do EPUB traduzido e local do EPUB original antes de iniciar a tradução.
- Se o usuário não quiser manter o padrão, a CLI solicita outro caminho de saída.
- A confirmação de sobrescrita continua sendo aplicada depois da escolha final de saída.
- README e relatório técnico foram atualizados com o novo comportamento.

## Fora do escopo

- Não cria fluxo completo de biblioteca ou movimentação de originais.
- Não implementa a escolha amigável de novo nome quando já existe arquivo, que continua sendo escopo da #45.
- Não altera `--output`, que continua sendo o caminho explícito para uso técnico.

## Validação/testes

- `uv run pytest` com 71 passed.
- `git diff --cached --check` sem problemas antes do commit.

Closes #19