### PR TITLE
Ignorar arquivos locais de agentes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ livro-extraido/
 glossary.json
 AGENTS.md
 AGENTS-Geral.md
+GEMINI.md
+.github/pull_request_template.md
 
 # Personal Ayvu workspace
 .ayvu-pessoal/


### PR DESCRIPTION
## Objetivo

Versionar os ignores para arquivos locais de agentes que não devem aparecer no `git status`.

## O que mudou

- Adicionado `GEMINI.md` ao `.gitignore`.
- Adicionado `.github/pull_request_template.md` ao `.gitignore`, sem ignorar a pasta `.github/` inteira para preservar workflows versionáveis.

## Fora do escopo

- Não altera código de produção.
- Não altera testes.
- Não remove arquivos locais existentes.

## Validação/testes

- `git diff --check` sem problemas.