### PR TITLE
Criar preview guiado de tradução

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,22 @@ uv run ayvu translate livro.epub \
   --cache .cache/traducoes.sqlite
 ```
 
+Gerar um preview traduzido:
+
+```bash
+uv run ayvu --preview livro.epub
+```
+
+O preview traduz os primeiros documentos internos do EPUB, preserva o restante da estrutura e
+salva por padrão em:
+
+```text
+~/Documentos/Livros/Preview/livro-preview.epub
+```
+
+Ao executar apenas `uv run ayvu`, o Ayvu também oferece a opção de gerar preview antes de
+mostrar a ajuda dos comandos técnicos.
+
 Antes de iniciar a tradução, o Ayvu verifica internamente o par de idiomas, o glossário, o cache, o EPUB de entrada e, em traduções reais, o tradutor configurado. Se algo impedir a execução, o comando falha cedo com uma mensagem curta e um próximo passo.
 
 Sem `--output`, o Ayvu mostra a pasta padrão de saída, o nome calculado para o EPUB traduzido

--- a/docs/relatorio-tecnico.md
+++ b/docs/relatorio-tecnico.md
@@ -83,6 +83,15 @@ Testar o LibreTranslate local:
 ayvu test-translator --url http://localhost:5000
 ```
 
+Gerar preview traduzido:
+
+```bash
+ayvu --preview game.epub
+```
+
+O preview traduz uma amostra inicial de documentos internos do EPUB e salva o
+resultado em `~/Documentos/Livros/Preview/<nome>-preview.epub`.
+
 Traduzir:
 
 ```bash

--- a/src/ayvu/cli.py
+++ b/src/ayvu/cli.py
@@ -10,7 +10,13 @@ from rich.table import Table
 
 from .cache import TranslationCache
 from .cli_progress import TranslationProgress, TranslationProgressSnapshot
-from .domain import LanguagePair, OutputPlan, TranslationOptions, default_translated_books_dir
+from .domain import (
+    LanguagePair,
+    OutputPlan,
+    TranslationOptions,
+    default_preview_books_dir,
+    default_translated_books_dir,
+)
 from .epub_io import TranslationReport, extract_markdown, inspect_epub, translate_epub
 from .preflight import PreflightError, run_translation_preflight
 from .resume import (
@@ -27,16 +33,31 @@ from .validation import validate_output_epub
 
 app = typer.Typer(help="Translate local EPUB files with a local HTTP translator.")
 console = Console()
+DEFAULT_PREVIEW_DOCUMENT_LIMIT = 12
 
 
 @app.callback(invoke_without_command=True)
-def main(ctx: typer.Context) -> None:
+def main(
+    ctx: typer.Context,
+    preview: Optional[Path] = typer.Option(
+        None,
+        "--preview",
+        help="Generate a translated EPUB preview with default settings.",
+    ),
+) -> None:
     """Translate local EPUB files with a local HTTP translator."""
     if ctx.invoked_subcommand is not None:
         return
 
+    if preview is not None:
+        _run_preview(preview)
+        return
+
     scan = _print_processing_translation_states(ResumeStateStore(default_processing_dir()))
     if _offer_detected_translation_resume(scan.running):
+        return
+
+    if _offer_guided_preview():
         return
 
     console.print(ctx.get_help())
@@ -236,6 +257,91 @@ def _run_translation(
             raise typer.Exit(code=1)
 
 
+def _run_preview(
+    epub_path: Path,
+    source: str = "en",
+    target: str = "pt",
+    translator_name: str = "libretranslate",
+    url: str = "http://localhost:5000",
+    cache_path: Path = Path(".cache/traducoes.sqlite"),
+    glossary_path: Path | None = None,
+    timeout: float = 30.0,
+    retries: int = 2,
+    chunk_limit: int = 3000,
+    max_documents: int = DEFAULT_PREVIEW_DOCUMENT_LIMIT,
+) -> None:
+    epub_path = epub_path.expanduser()
+    _ensure_preview_input_exists(epub_path)
+
+    language_pair = LanguagePair(source=source, target=target)
+    translation_options = TranslationOptions(
+        language_pair=language_pair,
+        chunk_limit=chunk_limit,
+        max_documents=max_documents,
+    )
+    output_plan = OutputPlan.for_preview(
+        epub_path,
+        default_dir=default_preview_books_dir(),
+    )
+    output_path = output_plan.path
+    _print_preview_output_location(output_path, max_documents)
+
+    if output_plan.blocks_existing_file(overwrite=False):
+        if not _confirm_existing_preview_overwrite(output_path):
+            console.print("[red]Canceled:[/red] existing preview was not changed.")
+            raise typer.Exit(code=1)
+
+    try:
+        preflight = run_translation_preflight(
+            epub_path=epub_path,
+            cache_path=cache_path,
+            glossary_path=glossary_path,
+            translator_name=translator_name,
+            url=url,
+            timeout=timeout,
+            retries=retries,
+            language_pair=language_pair,
+            dry_run=False,
+        )
+    except PreflightError as exc:
+        console.print(f"[red]Environment check failed:[/red] {exc}")
+        console.print(exc.next_step)
+        raise typer.Exit(code=1) from exc
+
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        TaskProgressColumn(),
+        TimeElapsedColumn(),
+        console=console,
+    ) as progress:
+        progress_view = TranslationProgress(progress, dry_run=False)
+        with TranslationCache(cache_path) as cache:
+            report = translate_epub(
+                epub_path,
+                output_path,
+                translator=preflight.translator,
+                cache=cache,
+                options=translation_options,
+                glossary=preflight.glossary,
+                on_chapter_start=progress_view.chapter_started,
+                on_chapter_done=progress_view.chapter_done,
+                on_text_processed=progress_view.text_processed,
+            )
+
+    _print_report(report, dry_run=False)
+    validation = validate_output_epub(output_path)
+    if validation.ok:
+        console.print(f"[green]Preview saved to:[/green] {output_path}")
+        console.print(f"[green]Validation OK:[/green] {validation.document_count} XHTML/HTML documents found.")
+        return
+
+    for warning in validation.warnings:
+        console.print(f"[yellow]Warning:[/yellow] {warning}")
+    raise typer.Exit(code=1)
+
+
 @app.command()
 def extract(
     epub_path: Path = typer.Argument(..., exists=True, dir_okay=False, readable=True),
@@ -320,6 +426,15 @@ def _print_processing_translation_states(store: ResumeStateStore) -> ResumeState
     if scan.invalid:
         _print_invalid_resume_states(scan.invalid)
     return scan
+
+
+def _offer_guided_preview() -> bool:
+    if not typer.confirm("Generate a translation preview?", default=False):
+        return False
+
+    epub_path = Path(typer.prompt("EPUB path")).expanduser()
+    _run_preview(epub_path)
+    return True
 
 
 def _offer_detected_translation_resume(states: tuple[TranslationResumeState, ...]) -> bool:
@@ -517,6 +632,20 @@ def _report_output_value(report: TranslationReport, dry_run: bool) -> str:
     return _display_optional_path(report.output_path)
 
 
+def _ensure_preview_input_exists(epub_path: Path) -> None:
+    if epub_path.is_file():
+        return
+    console.print(f"[red]Preview EPUB was not found:[/red] {epub_path}")
+    console.print("Choose a valid local EPUB file.")
+    raise typer.Exit(code=1)
+
+
+def _print_preview_output_location(output_path: Path, max_documents: int) -> None:
+    console.print(f"[yellow]Preview output folder:[/yellow] {output_path.parent}")
+    console.print(f"[yellow]Preview EPUB name:[/yellow] {output_path.name}")
+    console.print(f"Preview will translate up to {max_documents} EPUB documents.")
+
+
 def _confirm_default_output_location(output_plan: OutputPlan, input_path: Path) -> OutputPlan:
     if output_plan.explicit_output or output_plan.dry_run:
         return output_plan
@@ -557,6 +686,12 @@ def _confirm_existing_output_overwrite(output_path: Path) -> bool:
     console.print(f"[yellow]Output path:[/yellow] {output_path}")
     console.print("[yellow]Translated EPUB already exists.[/yellow]")
     return typer.confirm("Overwrite existing translated EPUB?", default=False)
+
+
+def _confirm_existing_preview_overwrite(output_path: Path) -> bool:
+    console.print(f"[yellow]Preview output path:[/yellow] {output_path}")
+    console.print("[yellow]Preview EPUB already exists.[/yellow]")
+    return typer.confirm("Overwrite existing preview EPUB?", default=False)
 
 
 if __name__ == "__main__":

--- a/src/ayvu/domain.py
+++ b/src/ayvu/domain.py
@@ -46,6 +46,19 @@ class OutputPlan:
         output_path = output_dir / f"{input_path.stem}-{language_pair.target_label}.epub"
         return cls(path=output_path, dry_run=dry_run)
 
+    @classmethod
+    def for_preview(
+        cls,
+        input_path: Path,
+        explicit_output: Path | None = None,
+        default_dir: Path | None = None,
+    ) -> "OutputPlan":
+        if explicit_output is not None:
+            return cls(path=explicit_output, explicit_output=True)
+
+        output_dir = default_dir or default_preview_books_dir()
+        return cls(path=output_dir / f"{input_path.stem}-preview.epub")
+
     def with_path(self, path: Path) -> "OutputPlan":
         return OutputPlan(path=path, dry_run=self.dry_run, explicit_output=self.explicit_output)
 
@@ -61,12 +74,17 @@ def default_translated_books_dir() -> Path:
     return Path.home() / "Documentos" / "Livros" / "Traduzidos"
 
 
+def default_preview_books_dir() -> Path:
+    return Path.home() / "Documentos" / "Livros" / "Preview"
+
+
 @dataclass(frozen=True)
 class TranslationOptions:
     language_pair: LanguagePair
     dry_run: bool = False
     fail_fast: bool = False
     chunk_limit: int = 3000
+    max_documents: int | None = None
 
     @property
     def source(self) -> str:

--- a/src/ayvu/epub_io.py
+++ b/src/ayvu/epub_io.py
@@ -135,7 +135,7 @@ def translate_epub(
     opf_base_path = _get_opf_base_path(source_path)
     replacements = EpubReplacements()
 
-    documents = _document_entries(book, opf_base_path)
+    documents = _limited_documents(_document_entries(book, opf_base_path), options.max_documents)
     total_documents = len(documents)
 
     with ZipFile(source_path, "r") as source_epub:
@@ -233,6 +233,12 @@ def _document_entries(book: epub.EpubBook, opf_base_path: PurePosixPath) -> list
         name = item.get_name()
         documents.append(EpubDocument(name=name, archive_path=_document_zip_path(opf_base_path, name)))
     return documents
+
+
+def _limited_documents(documents: list[EpubDocument], max_documents: int | None) -> list[EpubDocument]:
+    if max_documents is None:
+        return documents
+    return documents[:max(0, max_documents)]
 
 
 def _copy_epub_with_replacements(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,13 @@ from types import SimpleNamespace
 
 from typer.testing import CliRunner
 
-from ayvu.cli import _offer_markdown_report, _render_markdown_report, _save_markdown_report, app
+from ayvu.cli import (
+    DEFAULT_PREVIEW_DOCUMENT_LIMIT,
+    _offer_markdown_report,
+    _render_markdown_report,
+    _save_markdown_report,
+    app,
+)
 from ayvu.domain import LanguagePair, OutputPlan, TranslationOptions
 from ayvu.epub_io import TranslationReport
 from ayvu.preflight import PreflightError
@@ -62,6 +68,15 @@ def test_output_plan_dry_run_does_not_block_existing_output(tmp_path):
     assert not plan.blocks_existing_file(overwrite=False)
 
 
+def test_output_plan_uses_preview_suffix_in_default_preview_dir():
+    default_dir = Path("Documentos/Livros/Preview")
+
+    plan = OutputPlan.for_preview(Path("books/livro.epub"), default_dir=default_dir)
+
+    assert plan.path == Path("Documentos/Livros/Preview/livro-preview.epub")
+    assert not plan.explicit_output
+
+
 def test_translation_options_exposes_language_pair_values():
     language_pair = LanguagePair(source="en", target="pt")
 
@@ -92,7 +107,7 @@ def test_root_command_shows_processing_translation_state(tmp_path, monkeypatch):
     ResumeStateStore(processing_dir).save(state)
     monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: processing_dir)
 
-    result = runner.invoke(app, [], input="n\n")
+    result = runner.invoke(app, [], input="n\nn\n")
 
     assert result.exit_code == 0
     assert "Translations in progress were found." in result.output
@@ -102,6 +117,7 @@ def test_root_command_shows_processing_translation_state(tmp_path, monkeypatch):
     assert "cache.sqlite" in result.output
     assert "Continue detected translation?" in result.output
     assert "Detected translation was not resumed." in result.output
+    assert "Generate a translation preview?" in result.output
     assert "Usage:" in result.output
 
 
@@ -184,25 +200,106 @@ def test_root_command_reports_invalid_processing_state(tmp_path, monkeypatch):
     (processing_dir / "bad.ayvu-state.json").write_text("{bad", encoding="utf-8")
     monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: processing_dir)
 
-    result = runner.invoke(app, [])
+    result = runner.invoke(app, [], input="n\n")
 
     assert result.exit_code == 0
     assert "Invalid processing state files were found." in result.output
     assert "bad.ayvu-state.json" in result.output
     assert "not valid JSON" in result.output
     assert "Restart the translation" in result.output
+    assert "Generate a translation preview?" in result.output
     assert "Usage:" in result.output
 
 
 def test_root_command_without_processing_state_has_no_processing_noise(tmp_path, monkeypatch):
     monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: tmp_path / "missing")
 
-    result = runner.invoke(app, [])
+    result = runner.invoke(app, [], input="n\n")
 
     assert result.exit_code == 0
+    assert "Generate a translation preview?" in result.output
     assert "Usage:" in result.output
     assert "Translations in progress were found." not in result.output
     assert "Invalid processing state files were found." not in result.output
+
+
+def test_root_command_generates_guided_preview_when_confirmed(tmp_path, monkeypatch):
+    epub_path = tmp_path / "book.epub"
+    preview_dir = tmp_path / "Preview"
+    epub_path.write_bytes(b"fake epub")
+    calls: dict[str, object] = {}
+
+    def fake_translate(input_path: Path, output_path: Path, **kwargs: object) -> TranslationReport:
+        calls["input_path"] = input_path
+        calls["output_path"] = output_path
+        calls["options"] = kwargs["options"]
+        return TranslationReport(output_path=output_path, input_path=input_path, target_language="pt")
+
+    monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: tmp_path / "missing")
+    monkeypatch.setattr("ayvu.cli.default_preview_books_dir", lambda: preview_dir)
+    monkeypatch.setattr(
+        "ayvu.cli.run_translation_preflight",
+        lambda **_kwargs: SimpleNamespace(translator=object(), glossary=None),
+    )
+    monkeypatch.setattr("ayvu.cli.TranslationCache", lambda _path: FakeCache())
+    monkeypatch.setattr("ayvu.cli.translate_epub", fake_translate)
+    monkeypatch.setattr("ayvu.cli.validate_output_epub", lambda _path: ValidationResult(ok=True, document_count=1))
+
+    result = runner.invoke(app, [], input=f"y\n{epub_path}\n")
+
+    options = calls["options"]
+    assert result.exit_code == 0
+    assert "Generate a translation preview?" in result.output
+    assert "EPUB path" in result.output
+    assert "Preview output folder:" in result.output
+    assert "Preview EPUB name:" in result.output
+    assert "Preview saved to:" in result.output
+    assert calls["input_path"] == epub_path
+    assert calls["output_path"] == preview_dir / "book-preview.epub"
+    assert options.max_documents == DEFAULT_PREVIEW_DOCUMENT_LIMIT
+    assert "Usage:" not in result.output
+
+
+def test_preview_option_generates_preview_with_default_settings(tmp_path, monkeypatch):
+    epub_path = tmp_path / "book.epub"
+    preview_dir = tmp_path / "Preview"
+    epub_path.write_bytes(b"fake epub")
+    calls: dict[str, object] = {}
+
+    def fake_preflight(**kwargs: object) -> object:
+        calls["preflight"] = kwargs
+        return SimpleNamespace(translator=object(), glossary=None)
+
+    def fake_translate(input_path: Path, output_path: Path, **kwargs: object) -> TranslationReport:
+        calls["input_path"] = input_path
+        calls["output_path"] = output_path
+        calls["options"] = kwargs["options"]
+        return TranslationReport(output_path=output_path, input_path=input_path, target_language="pt")
+
+    monkeypatch.setattr("ayvu.cli.default_preview_books_dir", lambda: preview_dir)
+    monkeypatch.setattr("ayvu.cli.run_translation_preflight", fake_preflight)
+    monkeypatch.setattr("ayvu.cli.TranslationCache", lambda _path: FakeCache())
+    monkeypatch.setattr("ayvu.cli.translate_epub", fake_translate)
+    monkeypatch.setattr("ayvu.cli.validate_output_epub", lambda _path: ValidationResult(ok=True, document_count=1))
+
+    result = runner.invoke(app, ["--preview", str(epub_path)])
+
+    preflight = calls["preflight"]
+    options = calls["options"]
+    assert result.exit_code == 0
+    assert "Preview output folder:" in result.output
+    assert str(preview_dir) in result.output
+    assert "book-preview.epub" in result.output
+    assert "Preview saved to:" in result.output
+    assert calls["input_path"] == epub_path
+    assert calls["output_path"] == preview_dir / "book-preview.epub"
+    assert preflight["epub_path"] == epub_path
+    assert preflight["cache_path"] == Path(".cache/traducoes.sqlite")
+    assert preflight["translator_name"] == "libretranslate"
+    assert preflight["url"] == "http://localhost:5000"
+    assert options.source == "en"
+    assert options.target == "pt"
+    assert options.max_documents == DEFAULT_PREVIEW_DOCUMENT_LIMIT
 
 
 def test_translate_command_stops_when_preflight_fails(tmp_path, monkeypatch):

--- a/tests/test_epub_io.py
+++ b/tests/test_epub_io.py
@@ -171,3 +171,34 @@ def test_translate_epub_translates_minimal_generated_epub_without_mutating_input
     assert "PT:chapter two" in chapter
     assert "chapter2.xhtml#answer" in chapter
     assert "../images/pixel.png" in chapter
+
+
+def test_translate_epub_limits_documents_for_preview(minimal_epub_path: Path, tmp_path: Path):
+    output_path = tmp_path / "minimal-preview.epub"
+    translator = PrefixTranslator()
+    options = TranslationOptions(
+        language_pair=LanguagePair(source="en", target="pt"),
+        max_documents=1,
+    )
+
+    with TranslationCache(tmp_path / "cache.sqlite") as cache:
+        report = translate_epub(
+            minimal_epub_path,
+            output_path,
+            translator=translator,
+            cache=cache,
+            options=options,
+        )
+
+    assert report.chapters_processed == 1
+
+    with ZipFile(output_path) as output_epub:
+        names = output_epub.namelist()
+        chapter_one_name = next(name for name in names if name.endswith("text/chapter1.xhtml"))
+        chapter_two_name = next(name for name in names if name.endswith("text/chapter2.xhtml"))
+        chapter_one = output_epub.read(chapter_one_name).decode("utf-8")
+        chapter_two = output_epub.read(chapter_two_name).decode("utf-8")
+
+    assert "PT:Hello reader. Visit" in chapter_one
+    assert "PT:Goodbye reader." not in chapter_two
+    assert "Goodbye reader." in chapter_two


### PR DESCRIPTION
## Objetivo
Criar um preview guiado de tradução para o usuário experimentar o fluxo sem traduzir o EPUB inteiro.

## O que mudou
- Adicionado `ayvu --preview livro.epub` com padrões de preview.
- Adicionado convite no comando raiz para gerar preview antes de exibir o help.
- Preview salva em `~/Documentos/Livros/Preview` com sufixo `-preview.epub`.
- Preview limita a tradução aos primeiros documentos internos e preserva o restante do EPUB.
- Documentação e testes foram atualizados para cobrir o novo fluxo.

## Fora do escopo
- Menu guiado completo.
- Seleção interativa de idiomas.
- Configuração avançada do tradutor durante o preview.
- Remover ou truncar partes não traduzidas do EPUB.

## Validação
- `git diff --check`
- `uv run pytest` com 75 testes passando.
- `uv run ayvu --help` validado durante a implementação.

Closes #36