### PR TITLE
Listar idiomas do LibreTranslate no fluxo guiado

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ Você pode forçar um modo específico usando a opção global `--mode`:
 uv run ayvu --mode common translate livro.epub
 ```
 
+Liste os idiomas disponíveis no LibreTranslate local:
+
+```bash
+uv run ayvu languages --url http://localhost:5000
+```
+
 ## Uso
 
 Inspecionar um EPUB:
@@ -123,7 +129,8 @@ salva por padrão em:
 ```
 
 Ao executar apenas `uv run ayvu`, o Ayvu também oferece a opção de gerar preview antes de
-mostrar a ajuda dos comandos técnicos.
+mostrar a ajuda dos comandos técnicos. Nesse fluxo guiado, o Ayvu mostra o idioma de destino
+padrão `pt` e permite escolher outro código a partir dos idiomas informados pelo LibreTranslate.
 
 Antes de iniciar a tradução, o Ayvu verifica internamente o par de idiomas, o glossário, o cache, o EPUB de entrada e, em traduções reais, o tradutor configurado. Se algo impedir a execução, o comando falha cedo com uma mensagem curta e um próximo passo.
 

--- a/src/ayvu/cli.py
+++ b/src/ayvu/cli.py
@@ -28,12 +28,15 @@ from .resume import (
     TranslationResumeState,
     default_processing_dir,
 )
-from .translator import LibreTranslateTranslator, TranslatorError
+from .translator import LibreTranslateTranslator, TranslatorError, TranslatorLanguage
 from .validation import validate_output_epub
 
 
 app = typer.Typer(help="Translate local EPUB files with a local HTTP translator.")
 console = Console()
+DEFAULT_SOURCE_LANGUAGE = "en"
+DEFAULT_TARGET_LANGUAGE = "pt"
+DEFAULT_TRANSLATOR_URL = "http://localhost:5000"
 DEFAULT_PREVIEW_DOCUMENT_LIMIT = 12
 
 
@@ -97,9 +100,9 @@ def inspect(epub_path: Path = typer.Argument(..., exists=True, dir_okay=False, r
 
 @app.command("test-translator")
 def test_translator(
-    url: str = typer.Option("http://localhost:5000", "--url", help="LibreTranslate base URL or /translate endpoint."),
-    source: str = typer.Option("en", "--source"),
-    target: str = typer.Option("pt", "--target"),
+    url: str = typer.Option(DEFAULT_TRANSLATOR_URL, "--url", help="LibreTranslate base URL or /translate endpoint."),
+    source: str = typer.Option(DEFAULT_SOURCE_LANGUAGE, "--source"),
+    target: str = typer.Option(DEFAULT_TARGET_LANGUAGE, "--target"),
     timeout: float = typer.Option(10.0, "--timeout"),
     retries: int = typer.Option(1, "--retries"),
 ) -> None:
@@ -113,6 +116,24 @@ def test_translator(
     console.print(f"[green]Translator OK:[/green] Hello world -> {translated}")
 
 
+@app.command("languages")
+def languages(
+    url: str = typer.Option(DEFAULT_TRANSLATOR_URL, "--url", help="LibreTranslate base URL or /translate endpoint."),
+    timeout: float = typer.Option(10.0, "--timeout"),
+    retries: int = typer.Option(1, "--retries"),
+) -> None:
+    """List languages reported by the local LibreTranslate server."""
+    translator = LibreTranslateTranslator(url=url, timeout=timeout, retries=retries)
+    try:
+        available_languages = translator.list_languages()
+    except TranslatorError as exc:
+        console.print(f"[red]Language list failed:[/red] {exc}")
+        console.print("Start LibreTranslate, check --url, and try again.")
+        raise typer.Exit(code=1) from exc
+
+    _print_languages(available_languages)
+
+
 @app.command()
 def translate(
     ctx: typer.Context,
@@ -123,10 +144,10 @@ def translate(
         "-o",
         help="Output EPUB path. Defaults to <input-stem>-<target>.epub.",
     ),
-    source: str = typer.Option("en", "--source", help="Source language."),
-    target: str = typer.Option("pt", "--target", help="Target language."),
+    source: str = typer.Option(DEFAULT_SOURCE_LANGUAGE, "--source", help="Source language."),
+    target: str = typer.Option(DEFAULT_TARGET_LANGUAGE, "--target", help="Target language."),
     translator_name: str = typer.Option("libretranslate", "--translator", help="Translator backend."),
-    url: str = typer.Option("http://localhost:5000", "--url", help="Translator base URL."),
+    url: str = typer.Option(DEFAULT_TRANSLATOR_URL, "--url", help="Translator base URL."),
     cache_path: Path = typer.Option(Path(".cache/traducoes.sqlite"), "--cache", help="SQLite cache path."),
     glossary_path: Optional[Path] = typer.Option(None, "--glossary", help="Optional JSON glossary."),
     dry_run: bool = typer.Option(False, "--dry-run", help="Process without writing translated EPUB."),
@@ -279,10 +300,10 @@ def _run_translation(
 
 def _run_preview(
     epub_path: Path,
-    source: str = "en",
-    target: str = "pt",
+    source: str = DEFAULT_SOURCE_LANGUAGE,
+    target: str = DEFAULT_TARGET_LANGUAGE,
     translator_name: str = "libretranslate",
-    url: str = "http://localhost:5000",
+    url: str = DEFAULT_TRANSLATOR_URL,
     cache_path: Path = Path(".cache/traducoes.sqlite"),
     glossary_path: Path | None = None,
     timeout: float = 30.0,
@@ -457,8 +478,59 @@ def _offer_guided_preview(mode: UserMode) -> bool:
         return False
 
     epub_path = Path(typer.prompt("EPUB path")).expanduser()
-    _run_preview(epub_path, mode=mode)
+    target = _choose_guided_target_language(DEFAULT_TARGET_LANGUAGE)
+    _run_preview(epub_path, target=target, mode=mode)
     return True
+
+
+def _choose_guided_target_language(default_target: str) -> str:
+    console.print(f"[yellow]Default target language:[/yellow] {default_target}")
+    if typer.confirm("Use default target language?", default=True):
+        return default_target
+
+    available_languages = _load_languages_for_guided_selection()
+    if available_languages:
+        _print_languages(available_languages)
+    else:
+        console.print("Enter a language code manually.")
+
+    target = typer.prompt("Target language code", default=default_target).strip()
+    return target or default_target
+
+
+def _load_languages_for_guided_selection() -> tuple[TranslatorLanguage, ...]:
+    translator = LibreTranslateTranslator(url=DEFAULT_TRANSLATOR_URL, timeout=10.0, retries=1)
+    try:
+        return translator.list_languages()
+    except TranslatorError as exc:
+        console.print(f"[yellow]Could not list LibreTranslate languages:[/yellow] {exc}")
+        return ()
+
+
+def _print_languages(languages: tuple[TranslatorLanguage, ...]) -> None:
+    table = Table(title="LibreTranslate languages")
+    table.add_column("Language")
+    table.add_column("Code")
+    table.add_column("State")
+    table.add_column("Targets")
+
+    for language in languages:
+        table.add_row(
+            language.name,
+            language.code,
+            language.state,
+            _display_language_targets(language.targets),
+        )
+    console.print(table)
+
+
+def _display_language_targets(targets: tuple[str, ...]) -> str:
+    if not targets:
+        return "-"
+    if len(targets) <= 8:
+        return ", ".join(targets)
+    first_targets = ", ".join(targets[:8])
+    return f"{first_targets} (+{len(targets) - 8})"
 
 
 def _offer_detected_translation_resume(states: tuple[TranslationResumeState, ...], mode: UserMode) -> bool:

--- a/src/ayvu/translator.py
+++ b/src/ayvu/translator.py
@@ -19,6 +19,14 @@ class UnsupportedTranslatorError(TranslatorError):
     pass
 
 
+@dataclass(frozen=True)
+class TranslatorLanguage:
+    code: str
+    name: str
+    targets: tuple[str, ...] = ()
+    state: str = "installed"
+
+
 class Translator(ABC):
     @abstractmethod
     def translate(self, text: str, source: str, target: str) -> str:
@@ -26,6 +34,9 @@ class Translator(ABC):
 
 
 class HttpSession(Protocol):
+    def get(self, url: str, *, timeout: float) -> requests.Response:
+        pass
+
     def post(self, url: str, *, json: dict[str, str], timeout: float) -> requests.Response:
         pass
 
@@ -74,6 +85,35 @@ class LibreTranslateResponseParser:
         if not isinstance(translated, str):
             raise TranslatorError("LibreTranslate response did not include translatedText")
         return translated
+
+
+class LibreTranslateLanguagesParser:
+    def parse(self, response: requests.Response) -> tuple[TranslatorLanguage, ...]:
+        try:
+            data = response.json()
+        except ValueError as exc:
+            raise TranslatorError("LibreTranslate languages response was not valid JSON") from exc
+
+        if not isinstance(data, list):
+            raise TranslatorError("LibreTranslate languages response did not include a language list")
+
+        return tuple(self._parse_language_entry(entry) for entry in data)
+
+    @staticmethod
+    def _parse_language_entry(entry: object) -> TranslatorLanguage:
+        if not isinstance(entry, dict):
+            raise TranslatorError("LibreTranslate language entry was not an object")
+
+        code = entry.get("code")
+        name = entry.get("name")
+        if not isinstance(code, str) or not isinstance(name, str):
+            raise TranslatorError("LibreTranslate language entry did not include code and name")
+
+        targets = entry.get("targets", ())
+        if not isinstance(targets, list):
+            targets = []
+        target_codes = tuple(target for target in targets if isinstance(target, str))
+        return TranslatorLanguage(code=code, name=name, targets=target_codes)
 
 
 @dataclass
@@ -126,8 +166,46 @@ class LibreTranslateTranslator(Translator):
 
         raise TranslatorError(f"LibreTranslate request failed: {last_error}")
 
+    def list_languages(self) -> tuple[TranslatorLanguage, ...]:
+        endpoint = self._normalize_languages_endpoint(self.url)
+        last_error: Exception | None = None
+
+        for attempt in self.retry_policy.attempts():
+            try:
+                response = self._get_languages(endpoint)
+                if self._should_retry_response(response, attempt):
+                    self._wait_before_retry(attempt)
+                    continue
+                response.raise_for_status()
+                return LibreTranslateLanguagesParser().parse(response)
+            except requests.exceptions.ConnectionError as exc:
+                last_error = exc
+                if self._retry_after_exception(attempt):
+                    continue
+                raise TranslatorError(
+                    f"Could not connect to LibreTranslate at {endpoint}. "
+                    "Is the local translation server running?"
+                ) from exc
+            except requests.exceptions.Timeout as exc:
+                last_error = exc
+                if self._retry_after_exception(attempt):
+                    continue
+                raise TranslatorError(f"LibreTranslate languages request timed out after {self.timeout} seconds") from exc
+            except requests.exceptions.HTTPError as exc:
+                raise self._http_error(exc) from exc
+            except requests.exceptions.RequestException as exc:
+                last_error = exc
+                if self._retry_after_exception(attempt):
+                    continue
+                raise TranslatorError(f"LibreTranslate languages request failed: {exc}") from exc
+
+        raise TranslatorError(f"LibreTranslate languages request failed: {last_error}")
+
     def _post(self, payload: LibreTranslatePayload) -> requests.Response:
         return self.session.post(self.endpoint, json=payload.as_json(), timeout=self.timeout)
+
+    def _get_languages(self, endpoint: str) -> requests.Response:
+        return self.session.get(endpoint, timeout=self.timeout)
 
     def _should_retry_response(self, response: requests.Response, attempt: int) -> bool:
         return response.status_code >= 500 and self.retry_policy.can_retry(attempt)
@@ -151,10 +229,18 @@ class LibreTranslateTranslator(Translator):
 
     @staticmethod
     def _normalize_endpoint(url: str) -> str:
+        return f"{LibreTranslateTranslator._normalize_base_url(url)}/translate"
+
+    @staticmethod
+    def _normalize_languages_endpoint(url: str) -> str:
+        return f"{LibreTranslateTranslator._normalize_base_url(url)}/languages"
+
+    @staticmethod
+    def _normalize_base_url(url: str) -> str:
         clean = url.rstrip("/")
         if clean.endswith("/translate"):
-            return clean
-        return f"{clean}/translate"
+            return clean[: -len("/translate")]
+        return clean
 
 
 def create_translator(name: str, url: str, timeout: float = 30.0, retries: int = 2) -> Translator:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,6 +14,7 @@ from ayvu.domain import LanguagePair, OutputPlan, TranslationOptions, UserMode
 from ayvu.epub_io import TranslationReport
 from ayvu.preflight import PreflightError
 from ayvu.resume import COMPLETED_STATUS, ResumeStateStore, TranslationResumeState
+from ayvu.translator import TranslatorError, TranslatorLanguage
 from ayvu.validation import ValidationResult
 
 
@@ -98,6 +99,53 @@ def test_translate_command_has_clear_error_for_unknown_translator(tmp_path):
     assert "Unsupported translator:" in result.output
     assert "unknown" in result.output
     assert "Use --translator libretranslate." in result.output
+    assert "Traceback" not in result.output
+
+
+def test_languages_command_lists_translator_languages(monkeypatch):
+    calls: dict[str, object] = {}
+
+    class FakeLanguageTranslator:
+        def __init__(self, url: str, timeout: float, retries: int) -> None:
+            calls["url"] = url
+            calls["timeout"] = timeout
+            calls["retries"] = retries
+
+        def list_languages(self) -> tuple[TranslatorLanguage, ...]:
+            return (
+                TranslatorLanguage(code="pt", name="Portuguese", targets=("en", "es")),
+                TranslatorLanguage(code="en", name="English", targets=("pt",)),
+            )
+
+    monkeypatch.setattr("ayvu.cli.LibreTranslateTranslator", FakeLanguageTranslator)
+
+    result = runner.invoke(app, ["languages", "--url", "http://localhost:5000", "--timeout", "2", "--retries", "0"])
+
+    assert result.exit_code == 0
+    assert calls == {"url": "http://localhost:5000", "timeout": 2.0, "retries": 0}
+    assert "LibreTranslate languages" in result.output
+    assert "Portuguese" in result.output
+    assert "pt" in result.output
+    assert "installed" in result.output
+    assert "en, es" in result.output
+
+
+def test_languages_command_reports_failure_without_traceback(monkeypatch):
+    class FailingLanguageTranslator:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            return None
+
+        def list_languages(self) -> tuple[TranslatorLanguage, ...]:
+            raise TranslatorError("server unavailable")
+
+    monkeypatch.setattr("ayvu.cli.LibreTranslateTranslator", FailingLanguageTranslator)
+
+    result = runner.invoke(app, ["languages"])
+
+    assert result.exit_code == 1
+    assert "Language list failed:" in result.output
+    assert "server unavailable" in result.output
+    assert "Start LibreTranslate" in result.output
     assert "Traceback" not in result.output
 
 
@@ -274,12 +322,14 @@ def test_root_command_generates_guided_preview_when_confirmed(tmp_path, monkeypa
     monkeypatch.setattr("ayvu.cli.translate_epub", fake_translate)
     monkeypatch.setattr("ayvu.cli.validate_output_epub", lambda _path: ValidationResult(ok=True, document_count=1))
 
-    result = runner.invoke(app, [], input=f"y\n{epub_path}\n")
+    result = runner.invoke(app, [], input=f"y\n{epub_path}\ny\n")
 
     options = calls["options"]
     assert result.exit_code == 0
     assert "Generate a translation preview?" in result.output
     assert "EPUB path" in result.output
+    assert "Default target language:" in result.output
+    assert "Use default target language?" in result.output
     assert "Preview output folder:" in result.output
     assert "Preview EPUB name:" in result.output
     assert "Preview saved to:" in result.output
@@ -287,6 +337,51 @@ def test_root_command_generates_guided_preview_when_confirmed(tmp_path, monkeypa
     assert calls["output_path"] == preview_dir / "book-preview.epub"
     assert options.max_documents == DEFAULT_PREVIEW_DOCUMENT_LIMIT
     assert "Usage:" not in result.output
+
+
+def test_root_command_allows_guided_preview_target_from_languages(tmp_path, monkeypatch):
+    epub_path = tmp_path / "book.epub"
+    preview_dir = tmp_path / "Preview"
+    epub_path.write_bytes(b"fake epub")
+    calls: dict[str, object] = {}
+
+    class FakeLanguageTranslator:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            return None
+
+        def list_languages(self) -> tuple[TranslatorLanguage, ...]:
+            return (
+                TranslatorLanguage(code="pt", name="Portuguese", targets=("en",)),
+                TranslatorLanguage(code="es", name="Spanish", targets=("en",)),
+            )
+
+    def fake_preflight(**kwargs: object) -> object:
+        calls["target"] = kwargs["language_pair"].target
+        return SimpleNamespace(translator=object(), glossary=None)
+
+    def fake_translate(_input_path: Path, _output_path: Path, **kwargs: object) -> TranslationReport:
+        calls["options"] = kwargs["options"]
+        return TranslationReport(output_path=_output_path, input_path=_input_path, target_language="es")
+
+    monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: tmp_path / "missing")
+    monkeypatch.setattr("ayvu.cli.default_preview_books_dir", lambda: preview_dir)
+    monkeypatch.setattr("ayvu.cli.LibreTranslateTranslator", FakeLanguageTranslator)
+    monkeypatch.setattr("ayvu.cli.run_translation_preflight", fake_preflight)
+    monkeypatch.setattr("ayvu.cli.TranslationCache", lambda _path: FakeCache())
+    monkeypatch.setattr("ayvu.cli.translate_epub", fake_translate)
+    monkeypatch.setattr("ayvu.cli.validate_output_epub", lambda _path: ValidationResult(ok=True, document_count=1))
+
+    result = runner.invoke(app, [], input=f"y\n{epub_path}\nn\nes\n")
+
+    options = calls["options"]
+    assert result.exit_code == 0
+    assert "Default target language:" in result.output
+    assert "LibreTranslate languages" in result.output
+    assert "Portuguese" in result.output
+    assert "Spanish" in result.output
+    assert "Target language code" in result.output
+    assert calls["target"] == "es"
+    assert options.target == "es"
 
 
 def test_preview_option_generates_preview_with_default_settings(tmp_path, monkeypatch):

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -7,9 +7,22 @@ from ayvu.translator import LibreTranslateTranslator, TranslatorError
 
 
 class FakeSession:
-    def __init__(self, responses: list[requests.Response | requests.exceptions.RequestException]) -> None:
-        self.responses = responses
+    def __init__(
+        self,
+        responses: list[requests.Response | requests.exceptions.RequestException] | None = None,
+        get_responses: list[requests.Response | requests.exceptions.RequestException] | None = None,
+    ) -> None:
+        self.responses = responses or []
+        self.get_responses = get_responses or []
+        self.gets: list[tuple[str, float]] = []
         self.posts: list[tuple[str, dict[str, str], float]] = []
+
+    def get(self, url: str, *, timeout: float) -> requests.Response:
+        self.gets.append((url, timeout))
+        response = self.get_responses.pop(0)
+        if isinstance(response, requests.exceptions.RequestException):
+            raise response
+        return response
 
     def post(self, url: str, *, json: dict[str, str], timeout: float) -> requests.Response:
         self.posts.append((url, json, timeout))
@@ -134,3 +147,66 @@ def test_libretranslate_reports_timeout() -> None:
         translator.translate("Hello", "en", "pt")
 
     assert "LibreTranslate request timed out after 1.5 seconds" in str(error.value)
+
+
+def test_libretranslate_lists_languages_from_base_url() -> None:
+    session = FakeSession(
+        get_responses=[
+            make_response(
+                200,
+                '[{"code": "en", "name": "English", "targets": ["pt", "es"]},'
+                ' {"code": "pt", "name": "Portuguese", "targets": ["en"]}]',
+            )
+        ]
+    )
+    translator = LibreTranslateTranslator(url="http://localhost:5000/translate", timeout=2.0, retries=0)
+    translator.session = session
+
+    languages = translator.list_languages()
+
+    assert session.gets == [("http://localhost:5000/languages", 2.0)]
+    assert [language.code for language in languages] == ["en", "pt"]
+    assert [language.name for language in languages] == ["English", "Portuguese"]
+    assert languages[0].targets == ("pt", "es")
+    assert languages[0].state == "installed"
+
+
+def test_libretranslate_retries_languages_5xx_before_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    sleeps: list[float] = []
+    session = FakeSession(
+        get_responses=[
+            make_response(503, "temporarily unavailable"),
+            make_response(200, '[{"code": "pt", "name": "Portuguese", "targets": ["en"]}]'),
+        ]
+    )
+    translator = LibreTranslateTranslator(retries=1)
+    translator.session = session
+    monkeypatch.setattr("ayvu.translator.time.sleep", lambda delay: sleeps.append(delay))
+
+    languages = translator.list_languages()
+
+    assert [language.code for language in languages] == ["pt"]
+    assert len(session.gets) == 2
+    assert sleeps == [0.5]
+
+
+def test_libretranslate_reports_invalid_languages_json() -> None:
+    session = FakeSession(get_responses=[make_response(200, "not-json")])
+    translator = LibreTranslateTranslator(retries=0)
+    translator.session = session
+
+    with pytest.raises(TranslatorError) as error:
+        translator.list_languages()
+
+    assert "LibreTranslate languages response was not valid JSON" in str(error.value)
+
+
+def test_libretranslate_reports_languages_http_error() -> None:
+    session = FakeSession(get_responses=[make_response(500, "broken")])
+    translator = LibreTranslateTranslator(retries=0)
+    translator.session = session
+
+    with pytest.raises(TranslatorError) as error:
+        translator.list_languages()
+
+    assert "LibreTranslate HTTP error 500: broken" in str(error.value)


### PR DESCRIPTION
## Objetivo

Adicionar a primeira base para listar idiomas do LibreTranslate e permitir escolher outro idioma no fluxo guiado de preview.

## O que mudou

- Adicionado `ayvu languages` para listar idiomas do servidor LibreTranslate local.
- Adicionada consulta ao endpoint `/languages` em `LibreTranslateTranslator`.
- O preview guiado agora mostra o destino padrao `pt` e permite escolher outro codigo.
- Adicionados testes para listagem, falhas sem traceback, retry e selecao guiada.
- README atualizado com o novo comando.

## Fora do escopo

- Configuracao persistente de idioma padrao.
- Gerenciamento de pacotes do LibreTranslate para marcar idiomas como disponiveis para baixar ou indisponiveis. Por enquanto, os idiomas retornados pelo servidor aparecem como `installed`.

## Validacao/testes

- `uv run pytest` - 84 passed.
- `uv run ayvu languages --help`.
- `git diff --check`.

## Issue relacionada

Refs #37