### PR TITLE
Definir modos comum e desenvolvedor

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,10 +169,7 @@ uv run ayvu translate livro.epub \
   --dry-run
 ```
 
-Ao final da tradução, o Ayvu mostra um relatório no terminal com o EPUB original,
-idiomas, saída calculada, capítulos processados, textos traduzidos, cache e erros.
-Também pergunta se deve salvar esse relatório em Markdown em
-`~/Documentos/Livros/Relatorios`.
+Ao final da tradução, o Ayvu mostra um relatório no terminal com o EPUB original, idiomas, saída calculada, capítulos processados, textos traduzidos, cache e erros. No **Modo Comum**, também pergunta se deve salvar esse relatório em Markdown em `~/Documentos/Livros/Relatorios`.
 
 Extrair texto visível para Markdown:
 
@@ -247,3 +244,4 @@ ayvu/
 - EPUBs com XHTML malformado podem depender do comportamento do parser.
 - Livros técnicos costumam exigir glossário para manter termos consistentes.
 - A qualidade final depende do servidor de tradução usado.
+inal depende do servidor de tradução usado.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,19 @@ Teste a conexão:
 uv run ayvu test-translator --url http://localhost:5000
 ```
 
+## Modos de Uso
+
+O Ayvu possui dois modos de execução que equilibram facilidade de uso com eficiência técnica:
+
+- **Modo Comum (common)**: Focado em uma experiência guiada. Oferece sugestões de retomada de traduções interrompidas, convites para gerar previews e solicita confirmações antes de ações importantes (como sobrescrever arquivos). É o modo padrão ao executar apenas `ayvu`.
+- **Modo Desenvolvedor (developer)**: Focado em execução direta e automação. Pula perguntas interativas e assume as configurações padrão ou passadas via argumentos. É o modo padrão ao utilizar subcomandos como `translate` ou `inspect`.
+
+Você pode forçar um modo específico usando a opção global `--mode`:
+
+```bash
+uv run ayvu --mode common translate livro.epub
+```
+
 ## Uso
 
 Inspecionar um EPUB:
@@ -140,8 +153,7 @@ uv run ayvu translate livro.epub \
   --glossary glossary.json
 ```
 
-Se a saída já existir, o Ayvu mostra o caminho calculado e pergunta se deve sobrescrever.
-Para pular a pergunta e sobrescrever direto:
+No **Modo Comum**, se a saída já existir, o Ayvu mostra o caminho calculado e pergunta se deve sobrescrever. Para pular a pergunta e sobrescrever direto (comportamento padrão do Modo Desenvolvedor):
 
 ```bash
 uv run ayvu translate livro.epub \

--- a/README.md
+++ b/README.md
@@ -127,16 +127,16 @@ mostrar a ajuda dos comandos técnicos.
 
 Antes de iniciar a tradução, o Ayvu verifica internamente o par de idiomas, o glossário, o cache, o EPUB de entrada e, em traduções reais, o tradutor configurado. Se algo impedir a execução, o comando falha cedo com uma mensagem curta e um próximo passo.
 
-Sem `--output`, o Ayvu mostra a pasta padrão de saída, o nome calculado para o EPUB traduzido
-e pergunta se você deseja manter esse local antes de iniciar a tradução. Por padrão, o arquivo
-traduzido é salvo em:
+Sem `--output`, o Ayvu salva por padrão em:
 
 ```text
 ~/Documentos/Livros/Traduzidos/livro-pt.epub
 ```
 
-Se preferir outro caminho, responda não à pergunta e informe o caminho desejado. Para escolher
-manualmente o caminho da saída sem passar por essa pergunta, use `--output`:
+No **Modo Comum**, o Ayvu mostra a pasta padrão de saída, o nome calculado para o EPUB
+traduzido e pergunta se você deseja manter esse local antes de iniciar a tradução. Se preferir
+outro caminho, responda não à pergunta e informe o caminho desejado. No **Modo Desenvolvedor**,
+use `--output` para escolher manualmente o caminho da saída:
 
 ```bash
 uv run ayvu translate livro.epub \

--- a/src/ayvu/cli.py
+++ b/src/ayvu/cli.py
@@ -14,6 +14,7 @@ from .domain import (
     LanguagePair,
     OutputPlan,
     TranslationOptions,
+    UserMode,
     default_preview_books_dir,
     default_translated_books_dir,
 )
@@ -39,6 +40,11 @@ DEFAULT_PREVIEW_DOCUMENT_LIMIT = 12
 @app.callback(invoke_without_command=True)
 def main(
     ctx: typer.Context,
+    mode: Optional[UserMode] = typer.Option(
+        None,
+        "--mode",
+        help="Execution mode (common or developer). If not specified, it's inferred from usage.",
+    ),
     preview: Optional[Path] = typer.Option(
         None,
         "--preview",
@@ -46,18 +52,28 @@ def main(
     ),
 ) -> None:
     """Translate local EPUB files with a local HTTP translator."""
+    if mode is None:
+        mode = UserMode.DEVELOPER
+        # COMMON mode is only when running 'ayvu' without subcommands or options (except for help)
+        # Typer sets invoked_subcommand when a subcommand is used.
+        # ctx.params contains options of the callback itself.
+        if ctx.invoked_subcommand is None and not any(v for k, v in ctx.params.items() if k != "mode"):
+            mode = UserMode.COMMON
+    ctx.ensure_object(dict)
+    ctx.obj["mode"] = mode
+
     if ctx.invoked_subcommand is not None:
         return
 
     if preview is not None:
-        _run_preview(preview)
+        _run_preview(preview, mode=mode)
         return
 
     scan = _print_processing_translation_states(ResumeStateStore(default_processing_dir()))
-    if _offer_detected_translation_resume(scan.running):
+    if _offer_detected_translation_resume(scan.running, mode=mode):
         return
 
-    if _offer_guided_preview():
+    if _offer_guided_preview(mode=mode):
         return
 
     console.print(ctx.get_help())
@@ -99,6 +115,7 @@ def test_translator(
 
 @app.command()
 def translate(
+    ctx: typer.Context,
     epub_path: Path = typer.Argument(..., exists=True, dir_okay=False, readable=True),
     output: Optional[Path] = typer.Option(
         None,
@@ -120,6 +137,7 @@ def translate(
     chunk_limit: int = typer.Option(3000, "--chunk-limit", help="Maximum characters sent per request."),
 ) -> None:
     """Translate EPUB visible text while preserving EPUB structure."""
+    mode = ctx.obj.get("mode", UserMode.DEVELOPER)
     _run_translation(
         epub_path=epub_path,
         output=output,
@@ -135,6 +153,7 @@ def translate(
         timeout=timeout,
         retries=retries,
         chunk_limit=chunk_limit,
+        mode=mode,
     )
 
 
@@ -153,6 +172,7 @@ def _run_translation(
     timeout: float,
     retries: int,
     chunk_limit: int,
+    mode: UserMode,
 ) -> None:
     language_pair = LanguagePair(source=source, target=target)
     translation_options = TranslationOptions(
@@ -168,11 +188,11 @@ def _run_translation(
         dry_run=dry_run,
         default_dir=default_translated_books_dir(),
     )
-    output_plan = _confirm_default_output_location(output_plan, epub_path)
+    output_plan = _confirm_default_output_location(output_plan, epub_path, mode=mode)
     output_path = output_plan.path
 
     if output_plan.blocks_existing_file(overwrite):
-        if not _confirm_existing_output_overwrite(output_path):
+        if not _confirm_existing_output_overwrite(output_path, mode=mode):
             console.print("[red]Canceled:[/red] existing output was not changed.")
             raise typer.Exit(code=1)
 
@@ -243,7 +263,7 @@ def _run_translation(
         raise typer.Exit(code=1) from exc
 
     _print_report(report, dry_run)
-    _offer_markdown_report(report, dry_run)
+    _offer_markdown_report(report, dry_run, mode=mode)
 
     if not dry_run:
         validation = validate_output_epub(output_path)
@@ -269,6 +289,7 @@ def _run_preview(
     retries: int = 2,
     chunk_limit: int = 3000,
     max_documents: int = DEFAULT_PREVIEW_DOCUMENT_LIMIT,
+    mode: UserMode = UserMode.DEVELOPER,
 ) -> None:
     epub_path = epub_path.expanduser()
     _ensure_preview_input_exists(epub_path)
@@ -287,7 +308,7 @@ def _run_preview(
     _print_preview_output_location(output_path, max_documents)
 
     if output_plan.blocks_existing_file(overwrite=False):
-        if not _confirm_existing_preview_overwrite(output_path):
+        if not _confirm_existing_preview_overwrite(output_path, mode=mode):
             console.print("[red]Canceled:[/red] existing preview was not changed.")
             raise typer.Exit(code=1)
 
@@ -428,18 +449,27 @@ def _print_processing_translation_states(store: ResumeStateStore) -> ResumeState
     return scan
 
 
-def _offer_guided_preview() -> bool:
+def _offer_guided_preview(mode: UserMode) -> bool:
+    if mode == UserMode.DEVELOPER:
+        return False
+
     if not typer.confirm("Generate a translation preview?", default=False):
         return False
 
     epub_path = Path(typer.prompt("EPUB path")).expanduser()
-    _run_preview(epub_path)
+    _run_preview(epub_path, mode=mode)
     return True
 
 
-def _offer_detected_translation_resume(states: tuple[TranslationResumeState, ...]) -> bool:
+def _offer_detected_translation_resume(states: tuple[TranslationResumeState, ...], mode: UserMode) -> bool:
     if not states:
         return False
+    # In DEVELOPER mode, we don't resume automatically to avoid unexpected behavior.
+    # The user should probably use a resume-specific command if we had one,
+    # or just let the cache handle it.
+    if mode == UserMode.DEVELOPER:
+        return False
+
     if len(states) > 1:
         console.print("Multiple translations are in progress; automatic selection is not available yet.")
         return False
@@ -450,11 +480,11 @@ def _offer_detected_translation_resume(states: tuple[TranslationResumeState, ...
         return False
 
     console.print(f"[green]Resuming translation:[/green] {state.input_path.name} -> {state.output_path.name}")
-    _resume_translation(state)
+    _resume_translation(state, mode=mode)
     return True
 
 
-def _resume_translation(state: TranslationResumeState) -> None:
+def _resume_translation(state: TranslationResumeState, mode: UserMode) -> None:
     try:
         _run_translation(
             epub_path=state.input_path,
@@ -471,6 +501,7 @@ def _resume_translation(state: TranslationResumeState) -> None:
             timeout=state.timeout,
             retries=state.retries,
             chunk_limit=state.chunk_limit,
+            mode=mode,
         )
     except typer.Exit:
         console.print(
@@ -551,7 +582,10 @@ def _save_resume_state(store: ResumeStateStore, state: TranslationResumeState) -
         raise typer.Exit(code=1) from exc
 
 
-def _offer_markdown_report(report: TranslationReport, dry_run: bool) -> None:
+def _offer_markdown_report(report: TranslationReport, dry_run: bool, mode: UserMode = UserMode.DEVELOPER) -> None:
+    if mode == UserMode.DEVELOPER:
+        return
+
     if not typer.confirm("Save translation report as Markdown?", default=False):
         return
 
@@ -646,8 +680,8 @@ def _print_preview_output_location(output_path: Path, max_documents: int) -> Non
     console.print(f"Preview will translate up to {max_documents} EPUB documents.")
 
 
-def _confirm_default_output_location(output_plan: OutputPlan, input_path: Path) -> OutputPlan:
-    if output_plan.explicit_output or output_plan.dry_run:
+def _confirm_default_output_location(output_plan: OutputPlan, input_path: Path, mode: UserMode) -> OutputPlan:
+    if output_plan.explicit_output or output_plan.dry_run or mode == UserMode.DEVELOPER:
         return output_plan
 
     output_path = output_plan.path
@@ -682,13 +716,19 @@ def _single_line(value: str) -> str:
     return " ".join(value.split())
 
 
-def _confirm_existing_output_overwrite(output_path: Path) -> bool:
+def _confirm_existing_output_overwrite(output_path: Path, mode: UserMode) -> bool:
+    if mode == UserMode.DEVELOPER:
+        return False
+
     console.print(f"[yellow]Output path:[/yellow] {output_path}")
     console.print("[yellow]Translated EPUB already exists.[/yellow]")
     return typer.confirm("Overwrite existing translated EPUB?", default=False)
 
 
-def _confirm_existing_preview_overwrite(output_path: Path) -> bool:
+def _confirm_existing_preview_overwrite(output_path: Path, mode: UserMode) -> bool:
+    if mode == UserMode.DEVELOPER:
+        return False
+
     console.print(f"[yellow]Preview output path:[/yellow] {output_path}")
     console.print("[yellow]Preview EPUB already exists.[/yellow]")
     return typer.confirm("Overwrite existing preview EPUB?", default=False)

--- a/src/ayvu/domain.py
+++ b/src/ayvu/domain.py
@@ -1,7 +1,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
+
+
+class UserMode(Enum):
+    COMMON = "common"
+    DEVELOPER = "developer"
 
 
 class LanguagePairError(ValueError):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,7 +10,7 @@ from ayvu.cli import (
     _save_markdown_report,
     app,
 )
-from ayvu.domain import LanguagePair, OutputPlan, TranslationOptions
+from ayvu.domain import LanguagePair, OutputPlan, TranslationOptions, UserMode
 from ayvu.epub_io import TranslationReport
 from ayvu.preflight import PreflightError
 from ayvu.resume import COMPLETED_STATUS, ResumeStateStore, TranslationResumeState
@@ -119,6 +119,35 @@ def test_root_command_shows_processing_translation_state(tmp_path, monkeypatch):
     assert "Detected translation was not resumed." in result.output
     assert "Generate a translation preview?" in result.output
     assert "Usage:" in result.output
+
+
+def test_root_command_in_developer_mode_skips_guided_prompts(tmp_path, monkeypatch):
+    epub_path = tmp_path / "book.epub"
+    epub_path.write_bytes(b"fake")
+    monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: tmp_path / "missing")
+
+    result = runner.invoke(app, ["--mode", "developer", "--preview", str(epub_path)])
+
+    assert "Generate a translation preview?" not in result.output
+    assert "Environment check failed:" in result.output
+
+
+def test_translate_command_in_developer_mode_skips_confirmations(tmp_path, monkeypatch):
+    epub_path = tmp_path / "book.epub"
+    epub_path.write_bytes(b"fake")
+    monkeypatch.setattr("ayvu.cli.default_translated_books_dir", lambda: tmp_path / "Traduzidos")
+
+    monkeypatch.setattr(
+        "ayvu.cli.run_translation_preflight",
+        lambda **_kwargs: (_ for _ in ()).throw(PreflightError("failed", "next")),
+    )
+
+    result = runner.invoke(app, ["translate", str(epub_path)])
+
+    assert result.exit_code == 1
+    assert "Default output folder:" not in result.output
+    assert "Keep this output location?" not in result.output
+    assert "Environment check failed:" in result.output
 
 
 def test_root_command_resumes_detected_translation_when_confirmed(tmp_path, monkeypatch):
@@ -316,7 +345,7 @@ def test_translate_command_stops_when_preflight_fails(tmp_path, monkeypatch):
     monkeypatch.setattr("ayvu.cli.run_translation_preflight", fail_preflight)
     monkeypatch.setattr("ayvu.cli.translate_epub", fail_translate)
 
-    result = runner.invoke(app, ["translate", str(epub_path)], input="y\n")
+    result = runner.invoke(app, ["--mode", "common", "translate", str(epub_path)], input="y\n")
 
     assert result.exit_code == 1
     assert "Default output folder:" in result.output
@@ -357,7 +386,7 @@ def test_translate_command_confirms_default_output_location(tmp_path, monkeypatc
     monkeypatch.setattr("ayvu.cli.validate_output_epub", lambda _path: ValidationResult(ok=True, document_count=1))
     monkeypatch.setattr("ayvu.cli._offer_markdown_report", lambda *_args, **_kwargs: None)
 
-    result = runner.invoke(app, ["translate", str(epub_path)], input="y\n")
+    result = runner.invoke(app, ["--mode", "common", "translate", str(epub_path)], input="y\n")
 
     output_path = output_dir / "book-pt.epub"
     state_path = processing_dir / "book-pt.ayvu-state.json"
@@ -397,7 +426,7 @@ def test_translate_command_allows_custom_output_path_from_default_prompt(tmp_pat
     monkeypatch.setattr("ayvu.cli.validate_output_epub", lambda _path: ValidationResult(ok=True, document_count=1))
     monkeypatch.setattr("ayvu.cli._offer_markdown_report", lambda *_args, **_kwargs: None)
 
-    result = runner.invoke(app, ["translate", str(epub_path)], input=f"n\n{custom_output}\n")
+    result = runner.invoke(app, ["--mode", "common", "translate", str(epub_path)], input=f"n\n{custom_output}\n")
 
     output_path = custom_output.with_suffix(".epub")
     assert result.exit_code == 0
@@ -412,7 +441,7 @@ def test_translate_command_asks_before_overwriting_existing_output_and_cancels(t
     epub_path.write_bytes(b"not a real epub")
     output_path.write_text("already here", encoding="utf-8")
 
-    result = runner.invoke(app, ["translate", str(epub_path), "--output", str(output_path)], input="n\n")
+    result = runner.invoke(app, ["--mode", "common", "translate", str(epub_path), "--output", str(output_path)], input="n\n")
 
     assert result.exit_code == 1
     assert "Output path:" in result.output
@@ -433,7 +462,7 @@ def test_translate_command_continues_when_existing_output_is_confirmed(tmp_path)
 
     result = runner.invoke(
         app,
-        ["translate", str(epub_path), "--output", str(output_path), "--translator", "unknown"],
+        ["--mode", "common", "translate", str(epub_path), "--output", str(output_path), "--translator", "unknown"],
         input="y\n",
     )
 
@@ -502,7 +531,7 @@ def test_offer_markdown_report_does_not_save_when_declined(monkeypatch):
     monkeypatch.setattr("ayvu.cli.typer.confirm", lambda *_args, **_kwargs: False)
     monkeypatch.setattr("ayvu.cli._save_markdown_report", fake_save_report)
 
-    _offer_markdown_report(TranslationReport(), dry_run=False)
+    _offer_markdown_report(TranslationReport(), dry_run=False, mode=UserMode.COMMON)
 
     assert not saved
 
@@ -533,7 +562,7 @@ def test_translate_command_offers_and_saves_markdown_report(tmp_path, monkeypatc
     monkeypatch.setattr("ayvu.cli._default_reports_dir", lambda: reports_dir)
     monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: processing_dir)
 
-    result = runner.invoke(app, ["translate", str(epub_path), "--output", str(output_path)], input="y\n")
+    result = runner.invoke(app, ["--mode", "common", "translate", str(epub_path), "--output", str(output_path)], input="y\n")
 
     report_path = reports_dir / "book-pt-report.md"
     state_path = processing_dir / "book-pt.ayvu-state.json"


### PR DESCRIPTION
## Objetivo

Definir oficialmente dois modos de uso do Ayvu: modo comum guiado e modo desenvolvedor por argumentos.

## O que mudou

- Adicionado `UserMode` com `common` e `developer`.
- Adicionada opção global `--mode` para forçar o modo de execução.
- `ayvu` sem subcomando usa modo comum por padrão.
- Subcomandos como `translate` usam modo desenvolvedor por padrão.
- No modo desenvolvedor, prompts guiados e confirmações interativas são pulados.
- Testes atualizados para cobrir os dois modos.
- README atualizado com exemplos e comportamento esperado dos modos.

## Fora do escopo

- Menu guiado completo do comando `ayvu`.
- Configuração persistente de preferências do usuário.
- Mudanças no backend de tradução ou validação de EPUB.

## Validação/testes

- `uv run pytest` - 77 passed.
- `git diff --check`.

## Issue relacionada

Refs #46