### PR TITLE
Criar primeiro menu guiado do Ayvu

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,11 @@ salva por padrão em:
 ~/Documentos/Livros/Preview/livro-preview.epub
 ```
 
-Ao executar apenas `uv run ayvu`, o Ayvu também oferece a opção de gerar preview antes de
-mostrar a ajuda dos comandos técnicos. Nesse fluxo guiado, o Ayvu mostra o idioma de destino
-padrão `pt` e permite escolher outro código a partir dos idiomas informados pelo LibreTranslate.
+Ao executar apenas `uv run ayvu`, o Ayvu abre um primeiro menu guiado com opções para traduzir
+livro, gerar preview, abrir biblioteca, acessar configurações, mostrar ajuda ou sair. Biblioteca
+e configurações ainda aparecem como opções indisponíveis. Nos fluxos guiados de tradução e
+preview, o Ayvu mostra o idioma de destino padrão `pt` e permite escolher outro código a partir
+dos idiomas informados pelo LibreTranslate.
 
 Antes de iniciar a tradução, o Ayvu verifica internamente o par de idiomas, o glossário, o cache, o EPUB de entrada e, em traduções reais, o tradutor configurado. Se algo impedir a execução, o comando falha cedo com uma mensagem curta e um próximo passo.
 

--- a/src/ayvu/cli.py
+++ b/src/ayvu/cli.py
@@ -38,6 +38,12 @@ DEFAULT_SOURCE_LANGUAGE = "en"
 DEFAULT_TARGET_LANGUAGE = "pt"
 DEFAULT_TRANSLATOR_URL = "http://localhost:5000"
 DEFAULT_PREVIEW_DOCUMENT_LIMIT = 12
+GUIDED_TRANSLATE_OPTION = "1"
+GUIDED_PREVIEW_OPTION = "2"
+GUIDED_LIBRARY_OPTION = "3"
+GUIDED_SETTINGS_OPTION = "4"
+GUIDED_HELP_OPTION = "5"
+GUIDED_EXIT_OPTION = "0"
 
 
 @app.callback(invoke_without_command=True)
@@ -76,7 +82,7 @@ def main(
     if _offer_detected_translation_resume(scan.running, mode=mode):
         return
 
-    if _offer_guided_preview(mode=mode):
+    if _run_guided_main_flow(ctx, mode=mode):
         return
 
     console.print(ctx.get_help())
@@ -470,17 +476,89 @@ def _print_processing_translation_states(store: ResumeStateStore) -> ResumeState
     return scan
 
 
-def _offer_guided_preview(mode: UserMode) -> bool:
+def _run_guided_main_flow(ctx: typer.Context, mode: UserMode) -> bool:
     if mode == UserMode.DEVELOPER:
         return False
 
-    if not typer.confirm("Generate a translation preview?", default=False):
-        return False
+    _print_guided_main_menu()
+    choice = typer.prompt("Choose an option", default=GUIDED_PREVIEW_OPTION).strip()
+    return _handle_guided_main_choice(choice, ctx)
 
+
+def _print_guided_main_menu() -> None:
+    table = Table(title="Ayvu")
+    table.add_column("Option")
+    table.add_column("Action")
+    table.add_row(GUIDED_TRANSLATE_OPTION, "Translate a book")
+    table.add_row(GUIDED_PREVIEW_OPTION, "Generate preview")
+    table.add_row(GUIDED_LIBRARY_OPTION, "Open library")
+    table.add_row(GUIDED_SETTINGS_OPTION, "Settings")
+    table.add_row(GUIDED_HELP_OPTION, "Show command help")
+    table.add_row(GUIDED_EXIT_OPTION, "Exit")
+    console.print(table)
+
+
+def _handle_guided_main_choice(choice: str, ctx: typer.Context) -> bool:
+    if choice == GUIDED_TRANSLATE_OPTION:
+        _run_guided_translation()
+        return True
+
+    if choice == GUIDED_PREVIEW_OPTION:
+        _run_guided_preview()
+        return True
+
+    if choice == GUIDED_LIBRARY_OPTION:
+        _print_guided_placeholder("Library")
+        return True
+
+    if choice == GUIDED_SETTINGS_OPTION:
+        _print_guided_placeholder("Settings menu")
+        return True
+
+    if choice == GUIDED_HELP_OPTION:
+        console.print(ctx.get_help())
+        return True
+
+    if choice == GUIDED_EXIT_OPTION:
+        console.print("Canceled.")
+        return True
+
+    console.print("[red]Unknown option.[/red]")
+    console.print(ctx.get_help())
+    return True
+
+
+def _run_guided_translation() -> None:
     epub_path = Path(typer.prompt("EPUB path")).expanduser()
     target = _choose_guided_target_language(DEFAULT_TARGET_LANGUAGE)
-    _run_preview(epub_path, target=target, mode=mode)
-    return True
+    _run_translation(
+        epub_path=epub_path,
+        output=None,
+        source=DEFAULT_SOURCE_LANGUAGE,
+        target=target,
+        translator_name="libretranslate",
+        url=DEFAULT_TRANSLATOR_URL,
+        cache_path=Path(".cache/traducoes.sqlite"),
+        glossary_path=None,
+        dry_run=False,
+        fail_fast=False,
+        overwrite=False,
+        timeout=30.0,
+        retries=2,
+        chunk_limit=3000,
+        mode=UserMode.COMMON,
+    )
+
+
+def _run_guided_preview() -> None:
+    epub_path = Path(typer.prompt("EPUB path")).expanduser()
+    target = _choose_guided_target_language(DEFAULT_TARGET_LANGUAGE)
+    _run_preview(epub_path, target=target, mode=UserMode.COMMON)
+
+
+def _print_guided_placeholder(name: str) -> None:
+    console.print(f"[yellow]{name} is not available yet.[/yellow]")
+    console.print("Use the command help for the current technical commands.")
 
 
 def _choose_guided_target_language(default_target: str) -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -155,7 +155,7 @@ def test_root_command_shows_processing_translation_state(tmp_path, monkeypatch):
     ResumeStateStore(processing_dir).save(state)
     monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: processing_dir)
 
-    result = runner.invoke(app, [], input="n\nn\n")
+    result = runner.invoke(app, [], input="n\n0\n")
 
     assert result.exit_code == 0
     assert "Translations in progress were found." in result.output
@@ -165,8 +165,9 @@ def test_root_command_shows_processing_translation_state(tmp_path, monkeypatch):
     assert "cache.sqlite" in result.output
     assert "Continue detected translation?" in result.output
     assert "Detected translation was not resumed." in result.output
-    assert "Generate a translation preview?" in result.output
-    assert "Usage:" in result.output
+    assert "Choose an option" in result.output
+    assert "Generate preview" in result.output
+    assert "Canceled." in result.output
 
 
 def test_root_command_in_developer_mode_skips_guided_prompts(tmp_path, monkeypatch):
@@ -284,18 +285,20 @@ def test_root_command_reports_invalid_processing_state(tmp_path, monkeypatch):
     assert "bad.ayvu-state.json" in result.output
     assert "not valid JSON" in result.output
     assert "Restart the translation" in result.output
-    assert "Generate a translation preview?" in result.output
+    assert "Choose an option" in result.output
+    assert "Generate preview" in result.output
     assert "Usage:" in result.output
 
 
 def test_root_command_without_processing_state_has_no_processing_noise(tmp_path, monkeypatch):
     monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: tmp_path / "missing")
 
-    result = runner.invoke(app, [], input="n\n")
+    result = runner.invoke(app, [], input="0\n")
 
     assert result.exit_code == 0
-    assert "Generate a translation preview?" in result.output
-    assert "Usage:" in result.output
+    assert "Choose an option" in result.output
+    assert "Generate preview" in result.output
+    assert "Canceled." in result.output
     assert "Translations in progress were found." not in result.output
     assert "Invalid processing state files were found." not in result.output
 
@@ -322,11 +325,12 @@ def test_root_command_generates_guided_preview_when_confirmed(tmp_path, monkeypa
     monkeypatch.setattr("ayvu.cli.translate_epub", fake_translate)
     monkeypatch.setattr("ayvu.cli.validate_output_epub", lambda _path: ValidationResult(ok=True, document_count=1))
 
-    result = runner.invoke(app, [], input=f"y\n{epub_path}\ny\n")
+    result = runner.invoke(app, [], input=f"2\n{epub_path}\ny\n")
 
     options = calls["options"]
     assert result.exit_code == 0
-    assert "Generate a translation preview?" in result.output
+    assert "Choose an option" in result.output
+    assert "Generate preview" in result.output
     assert "EPUB path" in result.output
     assert "Default target language:" in result.output
     assert "Use default target language?" in result.output
@@ -371,7 +375,7 @@ def test_root_command_allows_guided_preview_target_from_languages(tmp_path, monk
     monkeypatch.setattr("ayvu.cli.translate_epub", fake_translate)
     monkeypatch.setattr("ayvu.cli.validate_output_epub", lambda _path: ValidationResult(ok=True, document_count=1))
 
-    result = runner.invoke(app, [], input=f"y\n{epub_path}\nn\nes\n")
+    result = runner.invoke(app, [], input=f"2\n{epub_path}\nn\nes\n")
 
     options = calls["options"]
     assert result.exit_code == 0
@@ -382,6 +386,76 @@ def test_root_command_allows_guided_preview_target_from_languages(tmp_path, monk
     assert "Target language code" in result.output
     assert calls["target"] == "es"
     assert options.target == "es"
+
+
+def test_root_command_starts_guided_translation(tmp_path, monkeypatch):
+    epub_path = tmp_path / "book.epub"
+    output_dir = tmp_path / "Traduzidos"
+    processing_dir = tmp_path / "Processando"
+    epub_path.write_bytes(b"fake epub")
+    calls: dict[str, object] = {}
+
+    def fake_translate(input_path: Path, output_path: Path, **kwargs: object) -> TranslationReport:
+        calls["input_path"] = input_path
+        calls["output_path"] = output_path
+        calls["options"] = kwargs["options"]
+        return TranslationReport(output_path=output_path, input_path=input_path, target_language="pt")
+
+    monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: processing_dir)
+    monkeypatch.setattr("ayvu.cli.default_translated_books_dir", lambda: output_dir)
+    monkeypatch.setattr(
+        "ayvu.cli.run_translation_preflight",
+        lambda **_kwargs: SimpleNamespace(translator=object(), glossary=None),
+    )
+    monkeypatch.setattr("ayvu.cli.TranslationCache", lambda _path: FakeCache())
+    monkeypatch.setattr("ayvu.cli.translate_epub", fake_translate)
+    monkeypatch.setattr("ayvu.cli.validate_output_epub", lambda _path: ValidationResult(ok=True, document_count=1))
+    monkeypatch.setattr("ayvu.cli._offer_markdown_report", lambda *_args, **_kwargs: None)
+
+    result = runner.invoke(app, [], input=f"1\n{epub_path}\ny\ny\n")
+
+    options = calls["options"]
+    assert result.exit_code == 0
+    assert "Translate a book" in result.output
+    assert "EPUB path" in result.output
+    assert "Default target language:" in result.output
+    assert "Default output folder:" in result.output
+    assert calls["input_path"] == epub_path
+    assert calls["output_path"] == output_dir / "book-pt.epub"
+    assert options.target == "pt"
+
+
+def test_root_command_shows_guided_library_placeholder(tmp_path, monkeypatch):
+    monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: tmp_path / "missing")
+
+    result = runner.invoke(app, [], input="3\n")
+
+    assert result.exit_code == 0
+    assert "Open library" in result.output
+    assert "Library is not available yet." in result.output
+    assert "Use the command help" in result.output
+
+
+def test_root_command_shows_guided_settings_placeholder(tmp_path, monkeypatch):
+    monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: tmp_path / "missing")
+
+    result = runner.invoke(app, [], input="4\n")
+
+    assert result.exit_code == 0
+    assert "Settings" in result.output
+    assert "Settings menu is not available yet." in result.output
+    assert "Use the command help" in result.output
+
+
+def test_root_command_can_show_help_from_guided_menu(tmp_path, monkeypatch):
+    monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: tmp_path / "missing")
+
+    result = runner.invoke(app, [], input="5\n")
+
+    assert result.exit_code == 0
+    assert "Show command help" in result.output
+    assert "Usage:" in result.output
+    assert "translate" in result.output
 
 
 def test_preview_option_generates_preview_with_default_settings(tmp_path, monkeypatch):


### PR DESCRIPTION
## Objetivo

Criar a primeira versao do fluxo guiado iniciado ao executar apenas `ayvu`.

## O que mudou

- Adicionado menu inicial com opcoes para traduzir livro, gerar preview, abrir biblioteca, configuracoes, ajuda e sair.
- O fluxo de traducao guiada reaproveita a traducao existente com padroes do modo comum.
- O fluxo de preview guiado continua permitindo escolher o idioma de destino.
- Biblioteca e configuracoes aparecem como opcoes ainda indisponiveis, com aviso claro.
- Testes atualizados para cobrir as opcoes principais do menu.
- README atualizado com o comportamento do menu guiado.

## Fora do escopo

- Implementar biblioteca real.
- Implementar configuracoes persistentes.
- Criar fluxo automatico completo da rota de usuario futura.

## Validacao/testes

- `uv run pytest` - 88 passed.
- `uv run ayvu --help`.
- `git diff --check`.

## Issue relacionada

Refs #40