### PR TITLE
Padronizar mensagens de erro para modo comum e dev

### DIFF
--- a/src/ayvu/cli.py
+++ b/src/ayvu/cli.py
@@ -106,6 +106,7 @@ def inspect(epub_path: Path = typer.Argument(..., exists=True, dir_okay=False, r
 
 @app.command("test-translator")
 def test_translator(
+    ctx: typer.Context,
     url: str = typer.Option(DEFAULT_TRANSLATOR_URL, "--url", help="LibreTranslate base URL or /translate endpoint."),
     source: str = typer.Option(DEFAULT_SOURCE_LANGUAGE, "--source"),
     target: str = typer.Option(DEFAULT_TARGET_LANGUAGE, "--target"),
@@ -113,28 +114,40 @@ def test_translator(
     retries: int = typer.Option(1, "--retries"),
 ) -> None:
     """Test connectivity with the local translator."""
+    mode = ctx.obj.get("mode", UserMode.DEVELOPER)
     translator = LibreTranslateTranslator(url=url, timeout=timeout, retries=retries)
     try:
         translated = translator.translate("Hello world", source, target)
     except TranslatorError as exc:
-        console.print(f"[red]Translator test failed:[/red] {exc}")
+        _print_expected_error(
+            "O teste do tradutor falhou.",
+            "Inicie o LibreTranslate, verifique --url e tente novamente.",
+            mode,
+            detail=str(exc),
+        )
         raise typer.Exit(code=1) from exc
     console.print(f"[green]Translator OK:[/green] Hello world -> {translated}")
 
 
 @app.command("languages")
 def languages(
+    ctx: typer.Context,
     url: str = typer.Option(DEFAULT_TRANSLATOR_URL, "--url", help="LibreTranslate base URL or /translate endpoint."),
     timeout: float = typer.Option(10.0, "--timeout"),
     retries: int = typer.Option(1, "--retries"),
 ) -> None:
     """List languages reported by the local LibreTranslate server."""
+    mode = ctx.obj.get("mode", UserMode.DEVELOPER)
     translator = LibreTranslateTranslator(url=url, timeout=timeout, retries=retries)
     try:
         available_languages = translator.list_languages()
     except TranslatorError as exc:
-        console.print(f"[red]Language list failed:[/red] {exc}")
-        console.print("Start LibreTranslate, check --url, and try again.")
+        _print_expected_error(
+            "Não foi possível listar os idiomas.",
+            "Inicie o LibreTranslate, verifique --url e tente novamente.",
+            mode,
+            detail=str(exc),
+        )
         raise typer.Exit(code=1) from exc
 
     _print_languages(available_languages)
@@ -182,6 +195,13 @@ def translate(
         chunk_limit=chunk_limit,
         mode=mode,
     )
+
+
+def _print_expected_error(summary: str, next_step: str, mode: UserMode, detail: str = "") -> None:
+    console.print(f"[red]{summary}[/red]")
+    if mode == UserMode.DEVELOPER and detail:
+        console.print(f"[dim]Detalhe técnico: {detail}[/dim]")
+    console.print(next_step)
 
 
 def _run_translation(
@@ -236,8 +256,7 @@ def _run_translation(
             dry_run=dry_run,
         )
     except PreflightError as exc:
-        console.print(f"[red]Environment check failed:[/red] {exc}")
-        console.print(exc.next_step)
+        _print_expected_error(exc.summary, exc.next_step, mode, detail=exc.detail)
         raise typer.Exit(code=1) from exc
 
     resume_store: ResumeStateStore | None = None
@@ -352,8 +371,7 @@ def _run_preview(
             dry_run=False,
         )
     except PreflightError as exc:
-        console.print(f"[red]Environment check failed:[/red] {exc}")
-        console.print(exc.next_step)
+        _print_expected_error(exc.summary, exc.next_step, mode, detail=exc.detail)
         raise typer.Exit(code=1) from exc
 
     with Progress(
@@ -655,7 +673,7 @@ def _resume_translation(state: TranslationResumeState, mode: UserMode) -> None:
         )
     except typer.Exit:
         console.print(
-            "Could not resume detected translation. Check the message above and restart the translation if needed."
+            "Não foi possível retomar a tradução detectada. Verifique a mensagem acima e reinicie a tradução se necessário."
         )
         raise
 

--- a/src/ayvu/cli.py
+++ b/src/ayvu/cli.py
@@ -89,9 +89,17 @@ def main(
 
 
 @app.command()
-def inspect(epub_path: Path = typer.Argument(..., exists=True, dir_okay=False, readable=True)) -> None:
+def inspect(
+    ctx: typer.Context,
+    epub_path: Path = typer.Argument(..., exists=True, dir_okay=False, readable=True),
+) -> None:
     """Show basic information about an EPUB."""
-    info = inspect_epub(epub_path)
+    mode = ctx.obj.get("mode", UserMode.DEVELOPER)
+    try:
+        info = inspect_epub(epub_path)
+    except Exception as exc:
+        _print_epub_read_error(str(exc), mode)
+        raise typer.Exit(code=1) from exc
     table = Table(title="EPUB information")
     table.add_column("Field")
     table.add_column("Value")
@@ -202,6 +210,15 @@ def _print_expected_error(summary: str, next_step: str, mode: UserMode, detail: 
     if mode == UserMode.DEVELOPER and detail:
         console.print(f"[dim]Detalhe técnico: {detail}[/dim]")
     console.print(next_step)
+
+
+def _print_epub_read_error(detail: str, mode: UserMode) -> None:
+    _print_expected_error(
+        "Não foi possível ler o EPUB informado.",
+        "Confirme que o arquivo é um EPUB válido e legível e tente novamente.",
+        mode,
+        detail=detail,
+    )
 
 
 def _run_translation(
@@ -410,16 +427,22 @@ def _run_preview(
 
 @app.command()
 def extract(
+    ctx: typer.Context,
     epub_path: Path = typer.Argument(..., exists=True, dir_okay=False, readable=True),
     output: Path = typer.Option(..., "--output", "-o", help="Directory where Markdown files will be written."),
     overwrite: bool = typer.Option(False, "--overwrite", help="Allow writing into an existing non-empty directory."),
 ) -> None:
     """Extract visible text from EPUB documents to Markdown files without translating."""
+    mode = ctx.obj.get("mode", UserMode.DEVELOPER)
     if output.exists() and any(output.iterdir()) and not overwrite:
         console.print(f"[red]Output directory is not empty:[/red] {output}")
         console.print("Use --overwrite to write into it.")
         raise typer.Exit(code=1)
-    written = extract_markdown(epub_path, output)
+    try:
+        written = extract_markdown(epub_path, output)
+    except Exception as exc:
+        _print_epub_read_error(str(exc), mode)
+        raise typer.Exit(code=1) from exc
     console.print(f"[green]Extracted {len(written)} Markdown files to[/green] {output}")
 
 

--- a/src/ayvu/preflight.py
+++ b/src/ayvu/preflight.py
@@ -12,9 +12,11 @@ from .translator import Translator, TranslatorError, create_translator
 
 
 class PreflightError(RuntimeError):
-    def __init__(self, message: str, next_step: str) -> None:
-        super().__init__(message)
+    def __init__(self, summary: str, next_step: str, detail: str = "") -> None:
+        super().__init__(summary)
+        self.summary = summary
         self.next_step = next_step
+        self.detail = detail
 
 
 @dataclass(frozen=True)
@@ -49,8 +51,9 @@ def _check_language_pair(language_pair: LanguagePair) -> None:
         language_pair.validate_for_translation()
     except LanguagePairError as exc:
         raise PreflightError(
-            f"Language pair check failed: {exc}.",
-            "Use non-empty language codes with --source and --target, for example --source en --target pt.",
+            "O par de idiomas informado não é válido.",
+            "Use códigos de idioma não vazios em --source e --target, por exemplo --source en --target pt.",
+            detail=str(exc),
         ) from exc
 
 
@@ -59,8 +62,9 @@ def _load_checked_glossary(glossary_path: Path | None) -> Glossary:
         return load_glossary(glossary_path)
     except GlossaryError as exc:
         raise PreflightError(
-            f"Glossary check failed: {exc}",
-            "Create the file, pass the correct path, or remove --glossary to run without one.",
+            "Não foi possível carregar o glossário.",
+            "Crie o arquivo, informe o caminho correto, ou remova --glossary para rodar sem glossário.",
+            detail=str(exc),
         ) from exc
 
 
@@ -69,8 +73,9 @@ def _create_checked_translator(name: str, url: str, timeout: float, retries: int
         return create_translator(name, url=url, timeout=timeout, retries=retries)
     except TranslatorError as exc:
         raise PreflightError(
-            f"Translator check failed: {exc}",
+            "Não foi possível preparar o tradutor.",
             "Use --translator libretranslate.",
+            detail=str(exc),
         ) from exc
 
 
@@ -80,8 +85,9 @@ def _check_cache(cache_path: Path) -> None:
             cache.verify_writable()
     except (OSError, sqlite3.Error) as exc:
         raise PreflightError(
-            f"Cache check failed: could not create or write cache at {cache_path}: {exc}",
-            "Choose a writable cache path with --cache or fix permissions for the cache directory.",
+            "Não foi possível criar ou escrever o cache.",
+            "Escolha um caminho de cache com permissão de escrita usando --cache, ou ajuste as permissões da pasta do cache.",
+            detail=f"Cache em {cache_path}: {exc}",
         ) from exc
 
 
@@ -90,8 +96,9 @@ def _check_epub(epub_path: Path) -> None:
         inspect_epub(epub_path)
     except Exception as exc:
         raise PreflightError(
-            f"EPUB check failed: could not read {epub_path}: {exc}",
-            "Confirm the file is a valid readable EPUB and try again.",
+            "Não foi possível ler o EPUB informado.",
+            "Confirme que o arquivo é um EPUB válido e legível e tente novamente.",
+            detail=f"{epub_path}: {exc}",
         ) from exc
 
 
@@ -100,6 +107,7 @@ def _check_translator(translator: Translator, language_pair: LanguagePair, url: 
         translator.translate("Hello world", language_pair.source, language_pair.target)
     except Exception as exc:
         raise PreflightError(
-            f"Translator check failed: {exc}",
-            f"Start LibreTranslate at {url}, check --url, and confirm the language pair is available.",
+            "O tradutor não respondeu.",
+            f"Inicie o LibreTranslate em {url}, verifique --url e confirme que o par de idiomas está disponível.",
+            detail=str(exc),
         ) from exc

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -880,3 +880,28 @@ def _resume_state(tmp_path: Path) -> TranslationResumeState:
         timeout=30.0,
         retries=2,
     )
+
+
+def test_inspect_command_reports_invalid_epub_without_traceback(tmp_path):
+    epub_path = tmp_path / "bad.epub"
+    epub_path.write_bytes(b"not a real epub")
+
+    result = runner.invoke(app, ["inspect", str(epub_path)])
+
+    assert result.exit_code == 1
+    assert "Não foi possível ler o EPUB informado." in result.output
+    assert "Confirme que o arquivo é um EPUB válido e legível" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_extract_command_reports_invalid_epub_without_traceback(tmp_path):
+    epub_path = tmp_path / "bad.epub"
+    epub_path.write_bytes(b"not a real epub")
+    output_dir = tmp_path / "out"
+
+    result = runner.invoke(app, ["extract", str(epub_path), "--output", str(output_dir)])
+
+    assert result.exit_code == 1
+    assert "Não foi possível ler o EPUB informado." in result.output
+    assert "Confirme que o arquivo é um EPUB válido e legível" in result.output
+    assert "Traceback" not in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -94,8 +94,8 @@ def test_translate_command_has_clear_error_for_unknown_translator(tmp_path):
     result = runner.invoke(app, ["translate", str(epub_path), "--translator", "unknown", "--dry-run"])
 
     assert result.exit_code == 1
-    assert "Environment check failed:" in result.output
-    assert "Translator check failed:" in result.output
+    assert "Não foi possível preparar o tradutor." in result.output
+    assert "Detalhe técnico:" in result.output
     assert "Unsupported translator:" in result.output
     assert "unknown" in result.output
     assert "Use --translator libretranslate." in result.output
@@ -143,9 +143,9 @@ def test_languages_command_reports_failure_without_traceback(monkeypatch):
     result = runner.invoke(app, ["languages"])
 
     assert result.exit_code == 1
-    assert "Language list failed:" in result.output
+    assert "Não foi possível listar os idiomas." in result.output
     assert "server unavailable" in result.output
-    assert "Start LibreTranslate" in result.output
+    assert "Inicie o LibreTranslate" in result.output
     assert "Traceback" not in result.output
 
 
@@ -178,7 +178,7 @@ def test_root_command_in_developer_mode_skips_guided_prompts(tmp_path, monkeypat
     result = runner.invoke(app, ["--mode", "developer", "--preview", str(epub_path)])
 
     assert "Generate a translation preview?" not in result.output
-    assert "Environment check failed:" in result.output
+    assert "Não foi possível ler o EPUB informado." in result.output
 
 
 def test_translate_command_in_developer_mode_skips_confirmations(tmp_path, monkeypatch):
@@ -196,7 +196,57 @@ def test_translate_command_in_developer_mode_skips_confirmations(tmp_path, monke
     assert result.exit_code == 1
     assert "Default output folder:" not in result.output
     assert "Keep this output location?" not in result.output
-    assert "Environment check failed:" in result.output
+    assert "failed" in result.output
+    assert "next" in result.output
+
+
+def test_common_mode_hides_technical_detail_for_expected_error(tmp_path, monkeypatch):
+    epub_path = tmp_path / "book.epub"
+    epub_path.write_bytes(b"fake epub")
+    monkeypatch.setattr("ayvu.cli.default_translated_books_dir", lambda: tmp_path / "Traduzidos")
+    monkeypatch.setattr(
+        "ayvu.cli.run_translation_preflight",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            PreflightError(
+                "Não foi possível ler o EPUB informado.",
+                "Confirme que o arquivo é um EPUB válido e legível e tente novamente.",
+                detail="book.epub: invalid zip header",
+            )
+        ),
+    )
+
+    result = runner.invoke(app, ["--mode", "common", "translate", str(epub_path)], input="y\n")
+
+    assert result.exit_code == 1
+    assert "Não foi possível ler o EPUB informado." in result.output
+    assert "Confirme que o arquivo é um EPUB válido e legível e tente novamente." in result.output
+    assert "Detalhe técnico:" not in result.output
+    assert "invalid zip header" not in result.output
+    assert "Traceback" not in result.output
+
+
+def test_developer_mode_shows_technical_detail_for_expected_error(tmp_path, monkeypatch):
+    epub_path = tmp_path / "book.epub"
+    epub_path.write_bytes(b"fake epub")
+    monkeypatch.setattr("ayvu.cli.default_translated_books_dir", lambda: tmp_path / "Traduzidos")
+    monkeypatch.setattr(
+        "ayvu.cli.run_translation_preflight",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            PreflightError(
+                "Não foi possível ler o EPUB informado.",
+                "Confirme que o arquivo é um EPUB válido e legível e tente novamente.",
+                detail="book.epub: invalid zip header",
+            )
+        ),
+    )
+
+    result = runner.invoke(app, ["--mode", "developer", "translate", str(epub_path)])
+
+    assert result.exit_code == 1
+    assert "Não foi possível ler o EPUB informado." in result.output
+    assert "Detalhe técnico:" in result.output
+    assert "invalid zip header" in result.output
+    assert "Traceback" not in result.output
 
 
 def test_root_command_resumes_detected_translation_when_confirmed(tmp_path, monkeypatch):
@@ -266,9 +316,9 @@ def test_root_command_reports_resume_failure_without_traceback(tmp_path, monkeyp
 
     assert result.exit_code == 1
     assert "Continue detected translation?" in result.output
-    assert "Environment check failed:" in result.output
     assert "EPUB check failed: missing file" in result.output
-    assert "Could not resume detected translation." in result.output
+    assert "Choose a valid EPUB." in result.output
+    assert "Não foi possível retomar a tradução detectada." in result.output
     assert "Traceback" not in result.output
 
 
@@ -519,7 +569,6 @@ def test_translate_command_stops_when_preflight_fails(tmp_path, monkeypatch):
     assert result.exit_code == 1
     assert "Default output folder:" in result.output
     assert "Keep this output location?" in result.output
-    assert "Environment check failed:" in result.output
     assert "Cache check failed: no write permission" in result.output
     assert "Choose a writable cache path." in result.output
     assert "Traceback" not in result.output
@@ -637,10 +686,10 @@ def test_translate_command_continues_when_existing_output_is_confirmed(tmp_path)
 
     assert result.exit_code == 1
     assert "Overwrite existing translated EPUB?" in result.output
-    assert "Environment check failed:" in result.output
-    assert "Translator check failed:" in result.output
-    assert "Unsupported translator:" in result.output
-    assert "unknown" in result.output
+    assert "Não foi possível preparar o tradutor." in result.output
+    assert "Use --translator libretranslate." in result.output
+    assert "Detalhe técnico:" not in result.output
+    assert "Unsupported translator:" not in result.output
     assert output_path.read_text(encoding="utf-8") == "already here"
     assert "Traceback" not in result.output
 

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -86,8 +86,8 @@ def test_preflight_rejects_blank_language_pair(tmp_path):
             dry_run=True,
         )
 
-    assert "Language pair check failed" in str(error.value)
-    assert "--source and --target" in error.value.next_step
+    assert error.value.summary == "O par de idiomas informado não é válido."
+    assert "--source e --target" in error.value.next_step
 
 
 def test_preflight_reports_translator_probe_failure(monkeypatch, tmp_path):
@@ -107,8 +107,9 @@ def test_preflight_reports_translator_probe_failure(monkeypatch, tmp_path):
             dry_run=False,
         )
 
-    assert "Translator check failed" in str(error.value)
-    assert "language pair is available" in error.value.next_step
+    assert error.value.summary == "O tradutor não respondeu."
+    assert "language pair is not available" in error.value.detail
+    assert "par de idiomas está disponível" in error.value.next_step
 
 
 def test_preflight_reports_epub_failure(monkeypatch, tmp_path):
@@ -128,5 +129,6 @@ def test_preflight_reports_epub_failure(monkeypatch, tmp_path):
             dry_run=False,
         )
 
-    assert "EPUB check failed" in str(error.value)
-    assert "valid readable EPUB" in error.value.next_step
+    assert error.value.summary == "Não foi possível ler o EPUB informado."
+    assert "bad epub" in error.value.detail
+    assert "EPUB válido e legível" in error.value.next_step


### PR DESCRIPTION
## Objetivo

Padronizar as mensagens de erro esperado do Ayvu com causa provavel e proximo passo em portugues, variando a apresentacao por modo de uso (comum x desenvolvedor).

## O que mudou

- `PreflightError` agora carrega tres partes: `summary` (frase curta em PT, independente de modo), `next_step` (acao sugerida em PT, sempre exibida) e `detail` (contexto tecnico).
- Os seis `_check_*` de `preflight.py` passam a montar mensagens em portugues para: par de idiomas invalido, glossario invalido, backend do tradutor, cache sem permissao de escrita, EPUB ilegivel e tradutor indisponivel.
- Nova funcao `_print_expected_error(summary, next_step, mode, detail)` em `cli.py`, com responsabilidade unica de renderizar o erro:
  - modo comum: mensagem simples + acao sugerida (esconde exececao tecnica);
  - modo dev: acrescenta linha com detalhe tecnico.
- Handlers de `PreflightError` em `translate`, `preview` e retomada passam por essa funcao. `test-translator` e `languages` (que usam `TranslatorError`) recebem `ctx` para conhecer o modo e tambem mensagem PT + detalhe so no modo dev.
- Mensagem de falha de retomada traduzida para PT.
- Nenhum traceback para erro esperado (mantido via `typer.Exit`).

## Fora do escopo

- Nao foi traduzido o restante da CLI (fluxo guiado, relatorios, prompts e mensagens de sucesso). Isso e outra preocupacao, fora da issue #38.

## Validacao

- `uv run pytest`: 90 passed.
- Asserts em ingles dos testes reescritos para PT.
- Dois testes novos garantem: modo comum oculta detalhe tecnico, modo dev exibe, ambos sem traceback.

## Issue relacionada

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)
