### PR TITLE
Definir formato de configuração do Ayvu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ lancadas e secoes versionadas quando uma release for publicada.
 - Modo comum e modo desenvolvedor via `--mode`.
 - Preview traduzido com `uv run ayvu --preview livro.epub`.
 - Comando `languages` para listar idiomas retornados pelo LibreTranslate.
+- Formato inicial de configuracao em JSON para preferencias locais do Ayvu.
 - Preflight antes da traducao real, verificando EPUB, cache, glossario,
   idiomas e tradutor.
 - Estado local de retomada em `~/Documentos/Livros/Processando`.

--- a/README.md
+++ b/README.md
@@ -227,6 +227,45 @@ automaticamente.
 Ao executar `uv run ayvu`, o modo comum procura estados de tradução em andamento
 nessa pasta e oferece retomar uma execução detectada.
 
+## Configuração
+
+O Ayvu já define um formato inicial para preferências locais. A interface de
+configurações ainda não está pronta, mas o arquivo planejado fica em:
+
+```text
+$XDG_CONFIG_HOME/ayvu/config.json
+```
+
+Quando `XDG_CONFIG_HOME` não estiver definido, o fallback é:
+
+```text
+~/.config/ayvu/config.json
+```
+
+Formato inicial:
+
+```json
+{
+  "version": 1,
+  "default_target_language": "pt",
+  "books_dir": "~/Documentos/Livros",
+  "folders": {
+    "original": "Original",
+    "translated": "Traduzidos",
+    "preview": "Preview",
+    "reports": "Relatorios",
+    "processing": "Processando"
+  },
+  "reader_app": null
+}
+```
+
+A precedência planejada é:
+
+```text
+argumentos da CLI > arquivo de configuração > padrões internos
+```
+
 ## Testes
 
 ```bash

--- a/docs/relatorio-tecnico.md
+++ b/docs/relatorio-tecnico.md
@@ -41,12 +41,13 @@ O Ayvu já possui:
 - modo comum guiado e modo desenvolvedor direto;
 - retomada local de traduções interrompidas;
 - comando para listar idiomas do LibreTranslate;
+- formato inicial de configuração local;
 - validação básica do EPUB gerado;
 - testes automatizados e CI no GitHub Actions.
 
 Ainda não possui:
 
-- arquivo de configuração persistente do Ayvu;
+- interface completa para editar configurações persistentes do Ayvu;
 - biblioteca completa de livros;
 - gerenciamento automático do LibreTranslate;
 - tradução por bloco preservando tags internas;
@@ -73,6 +74,7 @@ ayvu/
 │       ├── chunking.py
 │       ├── cli.py
 │       ├── cli_progress.py
+│       ├── config.py
 │       ├── domain.py
 │       ├── epub_io.py
 │       ├── glossary.py
@@ -87,6 +89,7 @@ ayvu/
 │   ├── test_chunking.py
 │   ├── test_cli.py
 │   ├── test_cli_progress.py
+│   ├── test_config.py
 │   ├── test_epub_io.py
 │   ├── test_glossary.py
 │   ├── test_html_translate.py
@@ -236,9 +239,49 @@ uv run ayvu --mode common translate livro.epub
 
 `src/ayvu/cli_progress.py` adapta callbacks de tradução para `rich.Progress` e mantém contadores de textos.
 
+`src/ayvu/config.py` define o formato inicial de configuração JSON, o caminho padrão do arquivo, leitura/gravação e resolução das pastas locais do Ayvu.
+
 `src/ayvu/validation.py` faz validação básica do EPUB gerado.
 
-## 9. Pipeline de EPUB
+## 9. Configuração local
+
+O formato inicial da configuração local fica em:
+
+```text
+$XDG_CONFIG_HOME/ayvu/config.json
+```
+
+Quando `XDG_CONFIG_HOME` não estiver definido, o fallback é:
+
+```text
+~/.config/ayvu/config.json
+```
+
+Formato versionado atual:
+
+```json
+{
+  "version": 1,
+  "default_target_language": "pt",
+  "books_dir": "~/Documentos/Livros",
+  "folders": {
+    "original": "Original",
+    "translated": "Traduzidos",
+    "preview": "Preview",
+    "reports": "Relatorios",
+    "processing": "Processando"
+  },
+  "reader_app": null
+}
+```
+
+A precedência planejada para os próximos fluxos é:
+
+```text
+argumentos da CLI > arquivo de configuração > padrões internos
+```
+
+## 10. Pipeline de EPUB
 
 A decisão mais importante do pipeline é não reconstruir o EPUB inteiro com `ebooklib.write_epub()`.
 
@@ -264,7 +307,7 @@ Essa abordagem preserva:
 - nomes de arquivos internos;
 - entradas não modificadas do ZIP.
 
-## 10. Tradução de HTML
+## 11. Tradução de HTML
 
 A regra principal é:
 
@@ -298,7 +341,7 @@ Hoje isso pode ser traduzido em três nós separados:
 
 Essa escolha preserva a estrutura, mas pode perder contexto. A melhoria planejada é traduzir blocos com placeholders de tags, sem enviar HTML real ao tradutor.
 
-## 11. Cache, glossário e chunking
+## 12. Cache, glossário e chunking
 
 O cache SQLite usa chave baseada em:
 
@@ -319,7 +362,7 @@ parágrafos
 
 O limite padrão é `3000` caracteres.
 
-## 12. Preflight e erros esperados
+## 13. Preflight e erros esperados
 
 Antes de uma tradução real, o Ayvu verifica:
 
@@ -332,7 +375,7 @@ Antes de uma tradução real, o Ayvu verifica:
 
 Em `--dry-run`, a chamada real ao tradutor é pulada. Falhas esperadas são convertidas em mensagens curtas com causa provável e próximo passo, evitando traceback para erro comum de usuário.
 
-## 13. Retomada local
+## 14. Retomada local
 
 Além do cache SQLite, traduções reais registram um estado local em:
 
@@ -344,7 +387,7 @@ Esse estado guarda caminhos e opções da execução para facilitar retomada pel
 
 O cache continua sendo a parte que evita retraduzir textos já concluídos.
 
-## 14. Relatórios
+## 15. Relatórios
 
 Ao final da tradução, o Ayvu mostra um relatório no terminal com:
 
@@ -359,7 +402,7 @@ Ao final da tradução, o Ayvu mostra um relatório no terminal com:
 
 No modo comum, o Ayvu também oferece salvar esse relatório em Markdown em `~/Documentos/Livros/Relatorios`, sem sobrescrever relatórios anteriores.
 
-## 15. Bug crítico: EPUB com tela branca
+## 16. Bug crítico: EPUB com tela branca
 
 Durante o desenvolvimento inicial, um EPUB traduzido abria no leitor, mas mostrava tela branca.
 
@@ -376,7 +419,7 @@ O problema aparecia ao reescrever o livro com `ebooklib.write_epub()`, que recon
 
 A correção foi abandonar a reescrita completa pelo `ebooklib` e copiar o EPUB original como ZIP, substituindo somente os documentos traduzidos. Essa decisão continua sendo central para a estabilidade do Ayvu.
 
-## 16. LibreTranslate
+## 17. LibreTranslate
 
 O backend atual é `LibreTranslateTranslator`.
 
@@ -406,13 +449,14 @@ uv run ayvu test-translator --url http://localhost:5000
 
 Se o servidor estiver indisponível, o Ayvu deve falhar com uma mensagem orientada a ação, não com traceback bruto.
 
-## 17. Testes e CI
+## 18. Testes e CI
 
-A suíte atual tem 88 testes definidos em `tests/`, cobrindo:
+A suíte atual tem 100 testes definidos em `tests/`, cobrindo:
 
 - cache SQLite;
 - chunking;
 - glossário;
+- configuração local;
 - tradução de HTML;
 - preservação de tags;
 - extração de texto visível;
@@ -433,7 +477,7 @@ uv sync --extra dev --frozen
 uv run pytest
 ```
 
-## 18. Próximos passos técnicos
+## 19. Próximos passos técnicos
 
 Prioridades que ainda fazem sentido:
 
@@ -448,7 +492,7 @@ Prioridades que ainda fazem sentido:
 9. Documentar arquitetura em um documento dedicado.
 10. Preparar empacotamento e releases públicas.
 
-## 19. Possível suporte a PDF
+## 20. Possível suporte a PDF
 
 PDF continua sendo um alvo futuro e mais difícil que EPUB, porque não é uma estrutura semântica de livro. PDF é mais próximo de páginas impressas com posições absolutas.
 
@@ -463,7 +507,7 @@ PDF
 
 Não é recomendado começar tentando traduzir PDF preservando layout perfeito. A tradução muda tamanho de texto e pode quebrar caixas, colunas, tabelas e fontes.
 
-## 20. Ideia central
+## 21. Ideia central
 
 O Ayvu deixou de ser um script de tradução e virou uma base real de CLI:
 

--- a/src/ayvu/config.py
+++ b/src/ayvu/config.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Mapping
+
+
+CONFIG_VERSION = 1
+DEFAULT_TARGET_LANGUAGE = "pt"
+DEFAULT_BOOKS_DIR = "~/Documentos/Livros"
+DEFAULT_CONFIG_DIR = "ayvu"
+DEFAULT_CONFIG_FILE = "config.json"
+
+
+class ConfigError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class FolderNames:
+    original: str = "Original"
+    translated: str = "Traduzidos"
+    preview: str = "Preview"
+    reports: str = "Relatorios"
+    processing: str = "Processando"
+
+    @classmethod
+    def from_dict(cls, data: object) -> "FolderNames":
+        if data is None:
+            return cls()
+        if not isinstance(data, dict):
+            raise ConfigError("Config field folders must be an object.")
+
+        return cls(
+            original=_folder_name(data, "original", cls.original),
+            translated=_folder_name(data, "translated", cls.translated),
+            preview=_folder_name(data, "preview", cls.preview),
+            reports=_folder_name(data, "reports", cls.reports),
+            processing=_folder_name(data, "processing", cls.processing),
+        )
+
+    def to_dict(self) -> dict[str, str]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class AyvuConfig:
+    version: int = CONFIG_VERSION
+    default_target_language: str = DEFAULT_TARGET_LANGUAGE
+    books_dir: Path = Path(DEFAULT_BOOKS_DIR)
+    folders: FolderNames = field(default_factory=FolderNames)
+    reader_app: str | None = None
+
+    @classmethod
+    def default(cls) -> "AyvuConfig":
+        return cls()
+
+    @classmethod
+    def from_dict(cls, data: object) -> "AyvuConfig":
+        if not isinstance(data, dict):
+            raise ConfigError("Config JSON must be an object.")
+
+        version = _optional_int(data, "version", CONFIG_VERSION)
+        if version != CONFIG_VERSION:
+            raise ConfigError(f"Unsupported config version: {version}.")
+
+        return cls(
+            version=version,
+            default_target_language=_optional_text(
+                data,
+                "default_target_language",
+                DEFAULT_TARGET_LANGUAGE,
+            ),
+            books_dir=Path(_optional_text(data, "books_dir", DEFAULT_BOOKS_DIR)),
+            folders=FolderNames.from_dict(data.get("folders")),
+            reader_app=_optional_nullable_text(data, "reader_app"),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "version": self.version,
+            "default_target_language": self.default_target_language,
+            "books_dir": str(self.books_dir),
+            "folders": self.folders.to_dict(),
+            "reader_app": self.reader_app,
+        }
+
+    @property
+    def resolved_books_dir(self) -> Path:
+        return self.books_dir.expanduser()
+
+    @property
+    def original_dir(self) -> Path:
+        return self.resolved_books_dir / self.folders.original
+
+    @property
+    def translated_dir(self) -> Path:
+        return self.resolved_books_dir / self.folders.translated
+
+    @property
+    def preview_dir(self) -> Path:
+        return self.resolved_books_dir / self.folders.preview
+
+    @property
+    def reports_dir(self) -> Path:
+        return self.resolved_books_dir / self.folders.reports
+
+    @property
+    def processing_dir(self) -> Path:
+        return self.resolved_books_dir / self.folders.processing
+
+
+@dataclass(frozen=True)
+class ConfigStore:
+    path: Path
+
+    @classmethod
+    def default(cls) -> "ConfigStore":
+        return cls(default_config_path())
+
+    def load(self) -> AyvuConfig:
+        if not self.path.exists():
+            return AyvuConfig.default()
+
+        try:
+            data = json.loads(self.path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise ConfigError(f"Config file is not valid JSON: {self.path}") from exc
+        except OSError as exc:
+            raise ConfigError(f"Could not read config file: {self.path}") from exc
+
+        try:
+            return AyvuConfig.from_dict(data)
+        except ConfigError as exc:
+            raise ConfigError(f"Invalid config file {self.path}: {exc}") from exc
+
+    def save(self, config: AyvuConfig) -> Path:
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            self.path.write_text(
+                json.dumps(config.to_dict(), indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+        except OSError as exc:
+            raise ConfigError(f"Could not write config file: {self.path}") from exc
+        return self.path
+
+
+def default_config_path(env: Mapping[str, str] | None = None, home: Path | None = None) -> Path:
+    environment = os.environ if env is None else env
+    config_home = environment.get("XDG_CONFIG_HOME")
+    if config_home:
+        base_dir = Path(config_home).expanduser()
+    else:
+        base_dir = (home or Path.home()) / ".config"
+    return base_dir / DEFAULT_CONFIG_DIR / DEFAULT_CONFIG_FILE
+
+
+def _optional_text(data: dict[str, object], key: str, default: str) -> str:
+    value = data.get(key, default)
+    if not isinstance(value, str) or not value.strip():
+        raise ConfigError(f"Config field {key} must be a non-empty string.")
+    return value
+
+
+def _optional_nullable_text(data: dict[str, object], key: str) -> str | None:
+    value = data.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise ConfigError(f"Config field {key} must be a non-empty string or null.")
+    return value
+
+
+def _optional_int(data: dict[str, object], key: str, default: int) -> int:
+    value = data.get(key, default)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ConfigError(f"Config field {key} must be an integer.")
+    return value
+
+
+def _folder_name(data: dict[str, object], key: str, default: str) -> str:
+    value = _optional_text(data, key, default)
+    path = Path(value)
+    if path.is_absolute() or path.name != value or "/" in value or "\\" in value:
+        raise ConfigError(f"Config folder name {key} must be a folder name, not a path.")
+    return value

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,125 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from ayvu.config import (
+    AyvuConfig,
+    ConfigError,
+    ConfigStore,
+    FolderNames,
+    default_config_path,
+)
+
+
+def test_default_config_path_uses_xdg_config_home():
+    path = default_config_path({"XDG_CONFIG_HOME": "/tmp/custom-config"})
+
+    assert path == Path("/tmp/custom-config/ayvu/config.json")
+
+
+def test_default_config_path_falls_back_to_home_config(tmp_path):
+    path = default_config_path({}, home=tmp_path)
+
+    assert path == tmp_path / ".config" / "ayvu" / "config.json"
+
+
+def test_default_config_defines_initial_preferences():
+    config = AyvuConfig.default()
+
+    assert config.version == 1
+    assert config.default_target_language == "pt"
+    assert config.books_dir == Path("~/Documentos/Livros")
+    assert config.folders == FolderNames()
+    assert config.reader_app is None
+
+
+def test_config_serializes_full_initial_format():
+    config = AyvuConfig.default()
+
+    assert config.to_dict() == {
+        "version": 1,
+        "default_target_language": "pt",
+        "books_dir": "~/Documentos/Livros",
+        "folders": {
+            "original": "Original",
+            "translated": "Traduzidos",
+            "preview": "Preview",
+            "reports": "Relatorios",
+            "processing": "Processando",
+        },
+        "reader_app": None,
+    }
+
+
+def test_config_loads_partial_file_with_defaults(tmp_path):
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"version": 1, "default_target_language": "es"}\n', encoding="utf-8")
+
+    config = ConfigStore(config_path).load()
+
+    assert config.default_target_language == "es"
+    assert config.books_dir == Path("~/Documentos/Livros")
+    assert config.folders.translated == "Traduzidos"
+
+
+def test_config_resolves_feature_directories(tmp_path):
+    books_dir = tmp_path / "Biblioteca"
+    config = AyvuConfig(
+        books_dir=books_dir,
+        folders=FolderNames(
+            original="Originais",
+            translated="PT",
+            preview="Amostras",
+            reports="Relatorios",
+            processing="Em-Andamento",
+        ),
+    )
+
+    assert config.original_dir == books_dir / "Originais"
+    assert config.translated_dir == books_dir / "PT"
+    assert config.preview_dir == books_dir / "Amostras"
+    assert config.reports_dir == books_dir / "Relatorios"
+    assert config.processing_dir == books_dir / "Em-Andamento"
+
+
+def test_config_store_saves_json_with_parent_directories(tmp_path):
+    config_path = tmp_path / "nested" / "ayvu" / "config.json"
+    config = AyvuConfig(default_target_language="es", reader_app="foliate")
+
+    saved_path = ConfigStore(config_path).save(config)
+
+    assert saved_path == config_path
+    assert json.loads(config_path.read_text(encoding="utf-8"))["reader_app"] == "foliate"
+
+
+def test_missing_config_file_returns_defaults(tmp_path):
+    config = ConfigStore(tmp_path / "missing.json").load()
+
+    assert config == AyvuConfig.default()
+
+
+def test_invalid_json_raises_config_error(tmp_path):
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{bad", encoding="utf-8")
+
+    with pytest.raises(ConfigError, match="not valid JSON"):
+        ConfigStore(config_path).load()
+
+
+def test_unsupported_version_raises_config_error(tmp_path):
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"version": 99}\n', encoding="utf-8")
+
+    with pytest.raises(ConfigError, match="Unsupported config version"):
+        ConfigStore(config_path).load()
+
+
+def test_folder_names_must_not_be_paths():
+    with pytest.raises(ConfigError, match="must be a folder name"):
+        FolderNames.from_dict({"translated": "Livros/Traduzidos"})
+
+
+def test_blank_default_language_is_rejected():
+    with pytest.raises(ConfigError, match="default_target_language"):
+        AyvuConfig.from_dict({"version": 1, "default_target_language": " "})


### PR DESCRIPTION
## Objetivo

Definir o formato inicial de configuracao local do Ayvu para desbloquear idioma padrao, pasta padrao, nomes de pastas e configuracoes futuras.

## O que mudou

- Adiciona src/ayvu/config.py com AyvuConfig, FolderNames, ConfigStore, caminho padrao XDG e validacoes basicas.
- Define o JSON versionado com idioma padrao, pasta base de livros, nomes das pastas e app leitor padrao.
- Adiciona tests/test_config.py cobrindo caminho padrao, serializacao, leitura, escrita, defaults e validacoes.
- Documenta o formato e a precedencia planejada no README e no relatorio tecnico.
- Registra a mudanca no CHANGELOG.

## Fora do escopo

- Criar UI de configuracoes.
- Perguntar idioma padrao no primeiro uso.
- Aplicar a configuracao aos fluxos existentes da CLI.
- Alterar comportamento de traducao, preview ou retomada.

## Validacao/testes

- uv run pytest: 100 passed.
- git diff --check: sem problemas.

## Issue relacionada

Closes #41