### PR TITLE
Usar idioma padrao configuravel no modo comum guiado

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,11 +135,17 @@ salva por padrão em:
 ~/Documentos/Livros/Preview/livro-preview.epub
 ```
 
+No primeiro uso do modo comum, o Ayvu pergunta o idioma padrão de leitura/tradução e o
+salva na configuração. Nas próximas execuções esse idioma é usado como destino padrão
+em traduções e previews, sem perguntar de novo.
+
 Ao executar apenas `uv run ayvu`, o Ayvu abre um primeiro menu guiado com opções para traduzir
 livro, gerar preview, abrir biblioteca, acessar configurações, mostrar ajuda ou sair. Biblioteca
-e configurações ainda aparecem como opções indisponíveis. Nos fluxos guiados de tradução e
-preview, o Ayvu mostra o idioma de destino padrão `pt` e permite escolher outro código a partir
-dos idiomas informados pelo LibreTranslate.
+ainda aparece como opção indisponível. A opção `Settings` permite ver e alterar o idioma
+padrão, salvando a mudança na configuração (o restante das configurações ainda não está
+pronto). Nos fluxos guiados de tradução e preview, o Ayvu mostra o idioma de destino padrão
+salvo e permite escolher outro código a partir dos idiomas informados pelo LibreTranslate.
+No modo desenvolvedor, o idioma de destino continua sendo definido por `--target`.
 
 Antes de iniciar a tradução, o Ayvu verifica internamente o par de idiomas, o glossário, o cache, o EPUB de entrada e, em traduções reais, o tradutor configurado. Se algo impedir a execução, o comando falha cedo com uma mensagem curta e um próximo passo.
 
@@ -232,8 +238,10 @@ nessa pasta e oferece retomar uma execução detectada.
 
 ## Configuração
 
-O Ayvu já define um formato inicial para preferências locais. A interface de
-configurações ainda não está pronta, mas o arquivo planejado fica em:
+O Ayvu já define um formato inicial para preferências locais. O modo comum já
+usa o campo `default_target_language`: ele é perguntado no primeiro uso e pode
+ser alterado depois pela opção `Settings`. Os demais campos ainda não têm
+interface dedicada. O arquivo fica em:
 
 ```text
 $XDG_CONFIG_HOME/ayvu/config.json

--- a/src/ayvu/cli.py
+++ b/src/ayvu/cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
 from typing import Optional
 
@@ -10,6 +11,7 @@ from rich.table import Table
 
 from .cache import TranslationCache
 from .cli_progress import TranslationProgress, TranslationProgressSnapshot
+from .config import AyvuConfig, ConfigError, ConfigStore
 from .domain import (
     LanguagePair,
     OutputPlan,
@@ -521,9 +523,43 @@ def _run_guided_main_flow(ctx: typer.Context, mode: UserMode) -> bool:
     if mode == UserMode.DEVELOPER:
         return False
 
+    config = _load_or_init_config()
     _print_guided_main_menu()
     choice = typer.prompt("Choose an option", default=GUIDED_PREVIEW_OPTION).strip()
-    return _handle_guided_main_choice(choice, ctx)
+    return _handle_guided_main_choice(choice, ctx, config)
+
+
+def _load_or_init_config(store: ConfigStore | None = None) -> AyvuConfig:
+    store = store or ConfigStore.default()
+    if not store.path.exists():
+        return _init_default_language_config(store)
+
+    try:
+        return store.load()
+    except ConfigError as exc:
+        console.print(f"[yellow]Configuração inválida ignorada:[/yellow] {exc}")
+        console.print("Usando configuração padrão. Ajuste o arquivo de configuração se quiser alterar o idioma.")
+        return AyvuConfig.default()
+
+
+def _init_default_language_config(store: ConfigStore) -> AyvuConfig:
+    console.print("[yellow]Primeiro uso do modo comum.[/yellow]")
+    console.print("Escolha o idioma padrão de leitura/tradução. Você poderá alterá-lo depois em Settings.")
+    language = _prompt_target_language_code(DEFAULT_TARGET_LANGUAGE)
+    config = AyvuConfig(default_target_language=language)
+    if _save_config(store, config):
+        console.print(f"[green]Idioma padrão salvo:[/green] {language}")
+    return config
+
+
+def _save_config(store: ConfigStore, config: AyvuConfig) -> bool:
+    try:
+        store.save(config)
+        return True
+    except ConfigError as exc:
+        console.print(f"[yellow]Não foi possível salvar a configuração:[/yellow] {exc}")
+        console.print("O idioma será usado nesta execução, mas não foi persistido.")
+        return False
 
 
 def _print_guided_main_menu() -> None:
@@ -539,13 +575,13 @@ def _print_guided_main_menu() -> None:
     console.print(table)
 
 
-def _handle_guided_main_choice(choice: str, ctx: typer.Context) -> bool:
+def _handle_guided_main_choice(choice: str, ctx: typer.Context, config: AyvuConfig) -> bool:
     if choice == GUIDED_TRANSLATE_OPTION:
-        _run_guided_translation()
+        _run_guided_translation(config.default_target_language)
         return True
 
     if choice == GUIDED_PREVIEW_OPTION:
-        _run_guided_preview()
+        _run_guided_preview(config.default_target_language)
         return True
 
     if choice == GUIDED_LIBRARY_OPTION:
@@ -553,7 +589,7 @@ def _handle_guided_main_choice(choice: str, ctx: typer.Context) -> bool:
         return True
 
     if choice == GUIDED_SETTINGS_OPTION:
-        _print_guided_placeholder("Settings menu")
+        _run_guided_settings(config)
         return True
 
     if choice == GUIDED_HELP_OPTION:
@@ -569,9 +605,9 @@ def _handle_guided_main_choice(choice: str, ctx: typer.Context) -> bool:
     return True
 
 
-def _run_guided_translation() -> None:
+def _run_guided_translation(default_target: str) -> None:
     epub_path = Path(typer.prompt("EPUB path")).expanduser()
-    target = _choose_guided_target_language(DEFAULT_TARGET_LANGUAGE)
+    target = _choose_guided_target_language(default_target)
     _run_translation(
         epub_path=epub_path,
         output=None,
@@ -591,10 +627,26 @@ def _run_guided_translation() -> None:
     )
 
 
-def _run_guided_preview() -> None:
+def _run_guided_preview(default_target: str) -> None:
     epub_path = Path(typer.prompt("EPUB path")).expanduser()
-    target = _choose_guided_target_language(DEFAULT_TARGET_LANGUAGE)
+    target = _choose_guided_target_language(default_target)
     _run_preview(epub_path, target=target, mode=UserMode.COMMON)
+
+
+def _run_guided_settings(config: AyvuConfig) -> None:
+    console.print(f"[yellow]Current default language:[/yellow] {config.default_target_language}")
+    if not typer.confirm("Change default language?", default=False):
+        console.print("Default language unchanged.")
+        return
+
+    language = _prompt_target_language_code(config.default_target_language)
+    if language == config.default_target_language:
+        console.print("Default language unchanged.")
+        return
+
+    updated = replace(config, default_target_language=language)
+    if _save_config(ConfigStore.default(), updated):
+        console.print(f"[green]Default language saved:[/green] {language}")
 
 
 def _print_guided_placeholder(name: str) -> None:
@@ -607,6 +659,10 @@ def _choose_guided_target_language(default_target: str) -> str:
     if typer.confirm("Use default target language?", default=True):
         return default_target
 
+    return _prompt_target_language_code(default_target)
+
+
+def _prompt_target_language_code(default_target: str) -> str:
     available_languages = _load_languages_for_guided_selection()
     if available_languages:
         _print_languages(available_languages)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -585,7 +585,7 @@ def test_root_command_uses_saved_default_language_in_guided_preview(isolated_con
     monkeypatch.setattr("ayvu.cli.run_translation_preflight", fake_preflight)
     monkeypatch.setattr("ayvu.cli.TranslationCache", lambda _path: FakeCache())
     monkeypatch.setattr("ayvu.cli.translate_epub", fake_translate)
-    monkeypatch.setattr("ayvu.cli.validate_output_epub", lambda _path: ValidationResult(ok=True, document_count=1))
+    monkeypatch.setattr("ayvu.cli.validate_output_epub", lambda _path, on_progress=None: ValidationResult(ok=True, document_count=1))
 
     result = runner.invoke(app, [], input=f"2\n{epub_path}\ny\n")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,8 @@
+import json
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
 from typer.testing import CliRunner
 
 from ayvu.cli import (
@@ -19,6 +21,33 @@ from ayvu.validation import ValidationResult
 
 
 runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def isolated_config(tmp_path, monkeypatch):
+    """Isolate Ayvu config per test and pre-write a default config.
+
+    Most guided-flow tests assume the default language already exists, so the
+    first-use prompt does not fire. Tests that exercise the first-use flow
+    delete the returned path before invoking the CLI.
+    """
+    config_home = tmp_path / "xdg"
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(config_home))
+    config_path = config_home / "ayvu" / "config.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        json.dumps({"version": 1, "default_target_language": "pt"}) + "\n",
+        encoding="utf-8",
+    )
+    return config_path
+
+
+class FakeNoLanguagesTranslator:
+    def __init__(self, *_args: object, **_kwargs: object) -> None:
+        return None
+
+    def list_languages(self) -> tuple[TranslatorLanguage, ...]:
+        raise TranslatorError("no server")
 
 
 def test_output_plan_keeps_explicit_output():
@@ -486,15 +515,95 @@ def test_root_command_shows_guided_library_placeholder(tmp_path, monkeypatch):
     assert "Use the command help" in result.output
 
 
-def test_root_command_shows_guided_settings_placeholder(tmp_path, monkeypatch):
+def test_root_command_settings_keeps_language_when_not_changed(tmp_path, monkeypatch):
     monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: tmp_path / "missing")
 
-    result = runner.invoke(app, [], input="4\n")
+    result = runner.invoke(app, [], input="4\nn\n")
 
     assert result.exit_code == 0
-    assert "Settings" in result.output
-    assert "Settings menu is not available yet." in result.output
-    assert "Use the command help" in result.output
+    assert "Current default language:" in result.output
+    assert "Change default language?" in result.output
+    assert "Default language unchanged." in result.output
+
+
+def test_root_command_settings_changes_and_persists_language(isolated_config, tmp_path, monkeypatch):
+    monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: tmp_path / "missing")
+    monkeypatch.setattr("ayvu.cli.LibreTranslateTranslator", FakeNoLanguagesTranslator)
+
+    result = runner.invoke(app, [], input="4\ny\nes\n")
+
+    assert result.exit_code == 0
+    assert "Default language saved:" in result.output
+    saved = json.loads(isolated_config.read_text(encoding="utf-8"))
+    assert saved["default_target_language"] == "es"
+
+
+def test_root_command_first_use_asks_and_saves_default_language(isolated_config, tmp_path, monkeypatch):
+    isolated_config.unlink()
+    monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: tmp_path / "missing")
+    monkeypatch.setattr("ayvu.cli.LibreTranslateTranslator", FakeNoLanguagesTranslator)
+
+    result = runner.invoke(app, [], input="es\n0\n")
+
+    assert result.exit_code == 0
+    assert "Primeiro uso do modo comum." in result.output
+    assert "Idioma padrão salvo:" in result.output
+    saved = json.loads(isolated_config.read_text(encoding="utf-8"))
+    assert saved["default_target_language"] == "es"
+
+
+def test_root_command_does_not_reask_when_config_exists(tmp_path, monkeypatch):
+    monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: tmp_path / "missing")
+
+    result = runner.invoke(app, [], input="0\n")
+
+    assert result.exit_code == 0
+    assert "Primeiro uso do modo comum." not in result.output
+    assert "Choose an option" in result.output
+
+
+def test_root_command_uses_saved_default_language_in_guided_preview(isolated_config, tmp_path, monkeypatch):
+    isolated_config.write_text(
+        json.dumps({"version": 1, "default_target_language": "es"}) + "\n",
+        encoding="utf-8",
+    )
+    epub_path = tmp_path / "book.epub"
+    preview_dir = tmp_path / "Preview"
+    epub_path.write_bytes(b"fake epub")
+    calls: dict[str, object] = {}
+
+    def fake_preflight(**kwargs: object) -> object:
+        calls["target"] = kwargs["language_pair"].target
+        return SimpleNamespace(translator=object(), glossary=None)
+
+    def fake_translate(_input_path: Path, _output_path: Path, **kwargs: object) -> TranslationReport:
+        calls["options"] = kwargs["options"]
+        return TranslationReport(output_path=_output_path, input_path=_input_path, target_language="es")
+
+    monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: tmp_path / "missing")
+    monkeypatch.setattr("ayvu.cli.default_preview_books_dir", lambda: preview_dir)
+    monkeypatch.setattr("ayvu.cli.run_translation_preflight", fake_preflight)
+    monkeypatch.setattr("ayvu.cli.TranslationCache", lambda _path: FakeCache())
+    monkeypatch.setattr("ayvu.cli.translate_epub", fake_translate)
+    monkeypatch.setattr("ayvu.cli.validate_output_epub", lambda _path: ValidationResult(ok=True, document_count=1))
+
+    result = runner.invoke(app, [], input=f"2\n{epub_path}\ny\n")
+
+    assert result.exit_code == 0
+    assert "Default target language:" in result.output
+    assert calls["target"] == "es"
+    assert calls["options"].target == "es"
+
+
+def test_root_command_ignores_invalid_config(isolated_config, tmp_path, monkeypatch):
+    isolated_config.write_text("{not valid json", encoding="utf-8")
+    monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: tmp_path / "missing")
+
+    result = runner.invoke(app, [], input="0\n")
+
+    assert result.exit_code == 0
+    assert "Configuração inválida ignorada:" in result.output
+    assert "Choose an option" in result.output
 
 
 def test_root_command_can_show_help_from_guided_menu(tmp_path, monkeypatch):


### PR DESCRIPTION
## Objetivo

Permitir que o usuario escolha um idioma padrao de leitura/traducao no modo comum, salvo na configuracao, conforme a issue #42.

## O que mudou

- Primeiro uso do modo comum pergunta o idioma padrao e salva em `config.json` (via `ConfigStore`).
- Execucoes seguintes usam o idioma salvo como destino padrao em traducao e preview, sem perguntar de novo.
- A opcao `Settings` mostra o idioma atual e permite altera-lo, persistindo a mudanca.
- Opcao `Outro idioma` continua disponivel nos fluxos guiados.
- Config invalida nao interrompe o fluxo: avisa e segue com os padroes.
- Modo desenvolvedor continua definindo o destino por `--target`.
- README atualizado (modo comum e secao Configuracao).

## Fora do escopo

- Menu de configuracoes completo (issue #49).
- Pasta padrao, nomes de pastas e biblioteca (issues #43, #48, #44).
- Idioma de origem (mantem `en`).

## Validacao

- `uv run pytest`: 109 passed.
- `git diff --check` limpo.
- Novos testes cobrem: primeiro uso pergunta/salva, nao repergunta com config existente, uso do idioma salvo no preview, alteracao persistida em Settings e config invalida tolerada.

## Issue relacionada

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)
