### PR TITLE
Permitir escolher novo nome quando a saída já existe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ lancadas e secoes versionadas quando uma release for publicada.
 - Estado local de retomada em `~/Documentos/Livros/Processando`.
 - Relatorio Markdown opcional no modo comum.
 - Tutorial para modo comum, fluxo intermediario e modo desenvolvedor.
+- Escolha de outro nome no modo comum quando o EPUB de saida ja existe.
 - Tratamento limpo de interrupcao com `Ctrl+C`.
 - Testes com EPUB minimo gerado por codigo.
 - GitHub Actions para rodar `uv run pytest`.

--- a/README.md
+++ b/README.md
@@ -169,7 +169,9 @@ uv run ayvu translate livro.epub \
   --glossary glossary.json
 ```
 
-No **Modo Comum**, se a saída já existir, o Ayvu mostra o caminho calculado e pergunta se deve sobrescrever. Para pular a pergunta e sobrescrever direto (comportamento padrão do Modo Desenvolvedor):
+No **Modo Comum**, se a saída já existir, o Ayvu mostra o caminho calculado e permite
+sobrescrever, escolher outro nome ou cancelar sem alterar o arquivo existente. Para pular a
+pergunta e sobrescrever direto:
 
 ```bash
 uv run ayvu translate livro.epub \

--- a/docs/tutorial-modo-comum-e-dev.md
+++ b/docs/tutorial-modo-comum-e-dev.md
@@ -77,6 +77,9 @@ Sem caminho de saída explícito, o padrão é:
 ~/Documentos/Livros/Traduzidos/livro-pt.epub
 ```
 
+Se esse EPUB de saída já existir, o modo comum permite sobrescrever, escolher outro nome
+ou cancelar sem alterar o arquivo existente.
+
 Ao final, o Ayvu mostra um relatório no terminal com capítulos processados, textos traduzidos, textos reaproveitados do cache, erros e caminho de saída. No modo comum, ele também pode salvar esse relatório em Markdown em:
 
 ```text

--- a/src/ayvu/cli.py
+++ b/src/ayvu/cli.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Optional
+from typing import NoReturn, Optional
 
 import typer
 from rich.console import Console
@@ -44,6 +44,9 @@ GUIDED_LIBRARY_OPTION = "3"
 GUIDED_SETTINGS_OPTION = "4"
 GUIDED_HELP_OPTION = "5"
 GUIDED_EXIT_OPTION = "0"
+EXISTING_OUTPUT_OVERWRITE_OPTION = "1"
+EXISTING_OUTPUT_RENAME_OPTION = "2"
+EXISTING_OUTPUT_CANCEL_OPTION = "0"
 
 
 @app.callback(invoke_without_command=True)
@@ -253,12 +256,8 @@ def _run_translation(
         default_dir=default_translated_books_dir(),
     )
     output_plan = _confirm_default_output_location(output_plan, epub_path, mode=mode)
+    output_plan = _resolve_existing_output_conflict(output_plan, overwrite=overwrite, mode=mode)
     output_path = output_plan.path
-
-    if output_plan.blocks_existing_file(overwrite):
-        if not _confirm_existing_output_overwrite(output_path, mode=mode):
-            console.print("[red]Canceled:[/red] existing output was not changed.")
-            raise typer.Exit(code=1)
 
     try:
         preflight = run_translation_preflight(
@@ -965,13 +964,55 @@ def _single_line(value: str) -> str:
     return " ".join(value.split())
 
 
-def _confirm_existing_output_overwrite(output_path: Path, mode: UserMode) -> bool:
+def _resolve_existing_output_conflict(output_plan: OutputPlan, overwrite: bool, mode: UserMode) -> OutputPlan:
+    if not output_plan.blocks_existing_file(overwrite):
+        return output_plan
     if mode == UserMode.DEVELOPER:
-        return False
+        _cancel_existing_output(output_plan.path)
 
-    console.print(f"[yellow]Output path:[/yellow] {output_path}")
+    console.print(f"[yellow]Output path:[/yellow] {output_plan.path}")
     console.print("[yellow]Translated EPUB already exists.[/yellow]")
-    return typer.confirm("Overwrite existing translated EPUB?", default=False)
+    action = _prompt_existing_output_action()
+    if action == EXISTING_OUTPUT_OVERWRITE_OPTION:
+        return output_plan
+    if action == EXISTING_OUTPUT_RENAME_OPTION:
+        return output_plan.with_path(_prompt_available_output_path(output_plan.path))
+
+    _cancel_existing_output(output_plan.path)
+
+
+def _prompt_existing_output_action() -> str:
+    console.print(f"{EXISTING_OUTPUT_OVERWRITE_OPTION}. Overwrite existing EPUB")
+    console.print(f"{EXISTING_OUTPUT_RENAME_OPTION}. Choose another name")
+    console.print(f"{EXISTING_OUTPUT_CANCEL_OPTION}. Cancel")
+
+    while True:
+        action = typer.prompt("Choose an option", default=EXISTING_OUTPUT_RENAME_OPTION).strip()
+        if action in {
+            EXISTING_OUTPUT_OVERWRITE_OPTION,
+            EXISTING_OUTPUT_RENAME_OPTION,
+            EXISTING_OUTPUT_CANCEL_OPTION,
+        }:
+            return action
+        console.print("[red]Invalid option.[/red] Choose 1, 2, or 0.")
+
+
+def _prompt_available_output_path(default_path: Path) -> Path:
+    while True:
+        output_path = _prompt_output_path(default_path)
+        if not output_path.exists():
+            console.print(f"[green]Final output path:[/green] {output_path}")
+            return output_path
+        console.print(f"[red]Output path already exists:[/red] {output_path}")
+        if not typer.confirm("Choose another output path?", default=True):
+            _cancel_existing_output(output_path)
+
+
+def _cancel_existing_output(output_path: Path) -> NoReturn:
+    console.print("[red]Canceled:[/red] existing output was not changed.")
+    console.print(f"[yellow]Output path:[/yellow] {output_path}")
+    console.print("Use --overwrite to replace it or --output to choose another EPUB path.")
+    raise typer.Exit(code=1)
 
 
 def _confirm_existing_preview_overwrite(output_path: Path, mode: UserMode) -> bool:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -653,21 +653,106 @@ def test_translate_command_allows_custom_output_path_from_default_prompt(tmp_pat
     assert calls["output_path"] == output_path
 
 
-def test_translate_command_asks_before_overwriting_existing_output_and_cancels(tmp_path):
+def test_translate_command_asks_how_to_handle_existing_output_and_cancels(tmp_path):
     epub_path = tmp_path / "book.epub"
     output_path = tmp_path / "book-pt.epub"
     epub_path.write_bytes(b"not a real epub")
     output_path.write_text("already here", encoding="utf-8")
 
-    result = runner.invoke(app, ["--mode", "common", "translate", str(epub_path), "--output", str(output_path)], input="n\n")
+    result = runner.invoke(app, ["--mode", "common", "translate", str(epub_path), "--output", str(output_path)], input="0\n")
 
     assert result.exit_code == 1
     assert "Output path:" in result.output
     assert str(output_path) in result.output
     assert "Translated EPUB already exists." in result.output
-    assert "Overwrite existing translated EPUB?" in result.output
+    assert "Overwrite existing EPUB" in result.output
+    assert "Choose another name" in result.output
+    assert "Cancel" in result.output
     assert "Canceled:" in result.output
     assert "existing output was not changed." in result.output
+    assert output_path.read_text(encoding="utf-8") == "already here"
+    assert "Traceback" not in result.output
+
+
+def test_translate_command_allows_another_name_when_output_exists(tmp_path, monkeypatch):
+    epub_path = tmp_path / "book.epub"
+    output_path = tmp_path / "book-pt.epub"
+    renamed_output = tmp_path / "book-custom"
+    processing_dir = tmp_path / "Processando"
+    epub_path.write_bytes(b"fake epub")
+    output_path.write_text("already here", encoding="utf-8")
+    calls: dict[str, Path] = {}
+
+    def fake_translate(_input_path: Path, output_path: Path, **_kwargs: object) -> TranslationReport:
+        calls["output_path"] = output_path
+        return TranslationReport(output_path=output_path, input_path=epub_path, target_language="pt")
+
+    monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: processing_dir)
+    monkeypatch.setattr(
+        "ayvu.cli.run_translation_preflight",
+        lambda **_kwargs: SimpleNamespace(translator=object(), glossary=None),
+    )
+    monkeypatch.setattr("ayvu.cli.TranslationCache", lambda _path: FakeCache())
+    monkeypatch.setattr("ayvu.cli.translate_epub", fake_translate)
+    monkeypatch.setattr(
+        "ayvu.cli.validate_output_epub",
+        lambda _path, on_progress=None: ValidationResult(ok=True, document_count=1),
+    )
+    monkeypatch.setattr("ayvu.cli._offer_markdown_report", lambda *_args, **_kwargs: None)
+
+    result = runner.invoke(
+        app,
+        ["--mode", "common", "translate", str(epub_path), "--output", str(output_path)],
+        input=f"2\n{renamed_output}\n",
+    )
+
+    final_output = renamed_output.with_suffix(".epub")
+    assert result.exit_code == 0
+    assert "Translated EPUB already exists." in result.output
+    assert "Choose another name" in result.output
+    assert "Output EPUB path" in result.output
+    assert "Final output path:" in result.output
+    assert str(final_output) in result.output
+    assert calls["output_path"] == final_output
+    assert output_path.read_text(encoding="utf-8") == "already here"
+
+
+def test_translate_command_rejects_another_existing_output_name(tmp_path):
+    epub_path = tmp_path / "book.epub"
+    output_path = tmp_path / "book-pt.epub"
+    other_output = tmp_path / "already-used.epub"
+    epub_path.write_bytes(b"not a real epub")
+    output_path.write_text("already here", encoding="utf-8")
+    other_output.write_text("also here", encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        ["--mode", "common", "translate", str(epub_path), "--output", str(output_path)],
+        input=f"2\n{other_output}\nn\n",
+    )
+
+    assert result.exit_code == 1
+    assert "Output path already exists:" in result.output
+    assert str(other_output) in result.output
+    assert "Choose another output path?" in result.output
+    assert "existing output was not changed." in result.output
+    assert output_path.read_text(encoding="utf-8") == "already here"
+    assert other_output.read_text(encoding="utf-8") == "also here"
+    assert "Traceback" not in result.output
+
+
+def test_translate_command_developer_mode_requires_overwrite_for_existing_output(tmp_path):
+    epub_path = tmp_path / "book.epub"
+    output_path = tmp_path / "book-pt.epub"
+    epub_path.write_bytes(b"not a real epub")
+    output_path.write_text("already here", encoding="utf-8")
+
+    result = runner.invoke(app, ["translate", str(epub_path), "--output", str(output_path)])
+
+    assert result.exit_code == 1
+    assert "existing output was not changed." in result.output
+    assert "Use --overwrite to replace it or --output to choose another EPUB path." in result.output
+    assert "Choose an option" not in result.output
     assert output_path.read_text(encoding="utf-8") == "already here"
     assert "Traceback" not in result.output
 
@@ -681,11 +766,11 @@ def test_translate_command_continues_when_existing_output_is_confirmed(tmp_path)
     result = runner.invoke(
         app,
         ["--mode", "common", "translate", str(epub_path), "--output", str(output_path), "--translator", "unknown"],
-        input="y\n",
+        input="1\n",
     )
 
     assert result.exit_code == 1
-    assert "Overwrite existing translated EPUB?" in result.output
+    assert "Overwrite existing EPUB" in result.output
     assert "Não foi possível preparar o tradutor." in result.output
     assert "Use --translator libretranslate." in result.output
     assert "Detalhe técnico:" not in result.output


### PR DESCRIPTION
## Objetivo

Permitir que o modo comum resolva conflito de EPUB de saída existente sem obrigar o usuário a sobrescrever ou cancelar.

## O que mudou

- O fluxo de tradução no modo comum agora oferece três opções quando o EPUB de saída já existe: sobrescrever, escolher outro nome ou cancelar.
- O caminho alternativo informado pelo usuário recebe extensão .epub quando necessário e é recusado se também já existir.
- O modo desenvolvedor segue sem prompt interativo, orientando usar --overwrite ou --output.
- README, tutorial e changelog foram atualizados para refletir o novo comportamento.
- A cobertura de CLI foi ampliada para cancelar, renomear, rejeitar outro nome existente e preservar o comportamento do modo desenvolvedor.

## Fora do escopo

- Não altera o fluxo de preview.
- Não muda o formato de configuração.
- Não implementa biblioteca, configurações ou escolha de idioma padrão.

## Validação e testes

- uv run pytest tests/test_cli.py::test_translate_command_allows_another_name_when_output_exists -q: 1 passed
- uv run pytest tests/test_cli.py -q: 41 passed
- uv run pytest: 112 passed
- git diff --check: sem avisos
- GitHub Actions pytest: passou

Closes #45