### PR TITLE
Implementar menu guiado de configurações

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ livro-extraido/
 .codex
 glossary.json
 *AGENTS*.md
+CLAUDE.md
 GEMINI*.md
 .github/pull_request_template.md
 

--- a/README.md
+++ b/README.md
@@ -141,10 +141,10 @@ em traduções e previews, sem perguntar de novo.
 
 Ao executar apenas `uv run ayvu`, o Ayvu abre um primeiro menu guiado com opções para traduzir
 livro, gerar preview, abrir biblioteca, acessar configurações, mostrar ajuda ou sair. Biblioteca
-ainda aparece como opção indisponível. A opção `Settings` permite ver e alterar o idioma
-padrão, salvando a mudança na configuração (o restante das configurações ainda não está
-pronto). Nos fluxos guiados de tradução e preview, o Ayvu mostra o idioma de destino padrão
-salvo e permite escolher outro código a partir dos idiomas informados pelo LibreTranslate.
+ainda aparece como opção indisponível. A opção `Settings` permite ver e alterar idioma padrão,
+pasta base dos livros, nomes das pastas das funcionalidades e app leitor de EPUB. Nos fluxos
+guiados de tradução e preview, o Ayvu mostra o idioma de destino padrão salvo e permite escolher
+outro código a partir dos idiomas informados pelo LibreTranslate.
 No modo desenvolvedor, o idioma de destino continua sendo definido por `--target`.
 
 Antes de iniciar a tradução, o Ayvu verifica internamente o par de idiomas, o glossário, o cache, o EPUB de entrada e, em traduções reais, o tradutor configurado. Se algo impedir a execução, o comando falha cedo com uma mensagem curta e um próximo passo.
@@ -231,7 +231,7 @@ uv run ayvu translate livro.epub \
 Trechos já traduzidos serão reaproveitados automaticamente.
 
 Durante traduções reais, o Ayvu também grava um estado local da execução em
-`~/Documentos/Livros/Processando`. Esse arquivo registra os caminhos e opções
+`~/Documentos/Livros/Processando`, ou na pasta de processamento configurada. Esse arquivo registra os caminhos e opções
 necessários para uma retomada futura. Ele não substitui o cache e não é apagado
 automaticamente.
 
@@ -240,10 +240,9 @@ nessa pasta e oferece retomar uma execução detectada.
 
 ## Configuração
 
-O Ayvu já define um formato inicial para preferências locais. O modo comum já
-usa o campo `default_target_language`: ele é perguntado no primeiro uso e pode
-ser alterado depois pela opção `Settings`. Os demais campos ainda não têm
-interface dedicada. O arquivo fica em:
+O Ayvu define um formato inicial para preferências locais. No modo comum, o primeiro uso pergunta o
+idioma padrão e salva a configuração. Depois, a opção `Settings` permite alterar idioma padrão,
+pasta base dos livros, nomes das pastas das funcionalidades e app leitor de EPUB. O arquivo fica em:
 
 ```text
 $XDG_CONFIG_HOME/ayvu/config.json
@@ -273,11 +272,14 @@ Formato inicial:
 }
 ```
 
-A precedência planejada é:
+A precedência usada pelos fluxos atuais é:
 
 ```text
 argumentos da CLI > arquivo de configuração > padrões internos
 ```
+
+Sem caminhos explícitos, a pasta base e os nomes de pastas configurados definem onde o Ayvu salva
+previews, traduções, relatórios Markdown e estados de processamento.
 
 ## Testes
 

--- a/docs/relatorio-tecnico.md
+++ b/docs/relatorio-tecnico.md
@@ -239,7 +239,7 @@ uv run ayvu --mode common translate livro.epub
 
 `src/ayvu/cli_progress.py` adapta callbacks de tradução para `rich.Progress` e mantém contadores de textos.
 
-`src/ayvu/config.py` define o formato inicial de configuração JSON, o caminho padrão do arquivo, leitura/gravação e resolução das pastas locais do Ayvu.
+`src/ayvu/config.py` define o formato inicial de configuração JSON, o caminho padrão do arquivo, leitura/gravação e resolução das pastas locais do Ayvu. O menu guiado de `Settings` permite alterar idioma padrão, pasta base, nomes das pastas das funcionalidades e app leitor.
 
 `src/ayvu/validation.py` valida o EPUB gerado: confirma abertura e documentos XHTML/HTML e avisa sobre capítulos vazios, links internos quebrados e imagens referenciadas ausentes, com callback de progresso opcional. Qualquer aviso faz a execução falhar com código 1.
 
@@ -275,11 +275,13 @@ Formato versionado atual:
 }
 ```
 
-A precedência planejada para os próximos fluxos é:
+A precedência usada pelos fluxos atuais é:
 
 ```text
 argumentos da CLI > arquivo de configuração > padrões internos
 ```
+
+Hoje a configuração já alimenta os diretórios padrão de preview, traduções, relatórios Markdown e estados de processamento. O app leitor fica salvo para os fluxos de biblioteca.
 
 ## 10. Pipeline de EPUB
 

--- a/docs/tutorial-modo-comum-e-dev.md
+++ b/docs/tutorial-modo-comum-e-dev.md
@@ -43,7 +43,7 @@ Abra o menu inicial:
 uv run ayvu
 ```
 
-O menu permite iniciar uma tradução, gerar preview, ver ajuda, abrir biblioteca e acessar configurações. Biblioteca e configurações ainda aparecem como opções indisponíveis na versão atual; elas estão reservadas para os próximos passos do modo comum.
+O menu permite iniciar uma tradução, gerar preview, ver ajuda, abrir biblioteca e acessar configurações. Biblioteca ainda aparece como opção indisponível na versão atual; as configurações já permitem alterar idioma padrão, pasta base dos livros, nomes das pastas das funcionalidades e app leitor de EPUB.
 
 ### Gerar um preview
 
@@ -145,6 +145,16 @@ uv run ayvu translate livro.epub \
 
 Se o processo for interrompido, rode o comando novamente com o mesmo cache. O Ayvu reaproveita os trechos já traduzidos.
 
+### Ajustar configurações
+
+No menu inicial, escolha `Settings` para ver os valores atuais e alterar preferências locais. A pasta base padrão inicial é:
+
+```text
+~/Documentos/Livros
+```
+
+Dentro dela, o Ayvu usa os nomes configurados para previews, traduções finais, relatórios e estados de processamento. Você também pode alterar o nome da pasta `Original`, que segue como convenção para a biblioteca futura, e configurar o app leitor de EPUB para os próximos fluxos de biblioteca.
+
 ### Organizar biblioteca manualmente
 
 A biblioteca guiada ainda não está completa. Enquanto isso, use a estrutura padrão como convenção local:
@@ -158,7 +168,7 @@ A biblioteca guiada ainda não está completa. Enquanto isso, use a estrutura pa
 └── Processando/
 ```
 
-Mantenha EPUBs originais em `Original`, previews em `Preview`, traduções finais em `Traduzidos` e relatórios em `Relatorios`. `Original` é apenas uma convenção manual do usuário por enquanto; o Ayvu ainda não cria nem gerencia essa pasta. O Ayvu já usa algumas dessas pastas nos fluxos atuais.
+Mantenha EPUBs originais em `Original`, previews em `Preview`, traduções finais em `Traduzidos` e relatórios em `Relatorios`. `Original` é apenas uma convenção manual do usuário por enquanto; o Ayvu ainda não cria nem gerencia essa pasta.
 
 ## Tutorial dev: comandos diretos
 

--- a/src/ayvu/cli.py
+++ b/src/ayvu/cli.py
@@ -11,7 +11,7 @@ from rich.table import Table
 
 from .cache import TranslationCache
 from .cli_progress import TranslationProgress, TranslationProgressSnapshot
-from .config import AyvuConfig, ConfigError, ConfigStore
+from .config import DEFAULT_BOOKS_DIR, AyvuConfig, ConfigError, ConfigStore, FolderNames
 from .domain import (
     LanguagePair,
     OutputPlan,
@@ -46,6 +46,11 @@ GUIDED_LIBRARY_OPTION = "3"
 GUIDED_SETTINGS_OPTION = "4"
 GUIDED_HELP_OPTION = "5"
 GUIDED_EXIT_OPTION = "0"
+SETTINGS_LANGUAGE_OPTION = "1"
+SETTINGS_BOOKS_DIR_OPTION = "2"
+SETTINGS_FOLDERS_OPTION = "3"
+SETTINGS_READER_OPTION = "4"
+SETTINGS_EXIT_OPTION = "0"
 EXISTING_OUTPUT_OVERWRITE_OPTION = "1"
 EXISTING_OUTPUT_RENAME_OPTION = "2"
 EXISTING_OUTPUT_CANCEL_OPTION = "0"
@@ -83,7 +88,8 @@ def main(
         _run_preview(preview, mode=mode)
         return
 
-    scan = _print_processing_translation_states(ResumeStateStore(default_processing_dir()))
+    config = _load_existing_config_or_default()
+    scan = _print_processing_translation_states(ResumeStateStore(_processing_dir(config)))
     if _offer_detected_translation_resume(scan.running, mode=mode):
         return
 
@@ -191,6 +197,7 @@ def translate(
 ) -> None:
     """Translate EPUB visible text while preserving EPUB structure."""
     mode = ctx.obj.get("mode", UserMode.DEVELOPER)
+    config = _load_existing_config_or_default()
     _run_translation(
         epub_path=epub_path,
         output=output,
@@ -207,6 +214,7 @@ def translate(
         retries=retries,
         chunk_limit=chunk_limit,
         mode=mode,
+        config=config,
     )
 
 
@@ -242,7 +250,9 @@ def _run_translation(
     retries: int,
     chunk_limit: int,
     mode: UserMode,
+    config: AyvuConfig | None = None,
 ) -> None:
+    config = config or _load_existing_config_or_default()
     language_pair = LanguagePair(source=source, target=target)
     translation_options = TranslationOptions(
         language_pair=language_pair,
@@ -255,7 +265,7 @@ def _run_translation(
         output,
         language_pair,
         dry_run=dry_run,
-        default_dir=default_translated_books_dir(),
+        default_dir=_translated_books_dir(config),
     )
     output_plan = _confirm_default_output_location(output_plan, epub_path, mode=mode)
     output_plan = _resolve_existing_output_conflict(output_plan, overwrite=overwrite, mode=mode)
@@ -291,6 +301,7 @@ def _run_translation(
             overwrite=overwrite,
             timeout=timeout,
             retries=retries,
+            processing_dir=_processing_dir(config),
         )
 
     progress_view: TranslationProgress | None = None
@@ -356,7 +367,9 @@ def _run_preview(
     chunk_limit: int = 3000,
     max_documents: int = DEFAULT_PREVIEW_DOCUMENT_LIMIT,
     mode: UserMode = UserMode.DEVELOPER,
+    config: AyvuConfig | None = None,
 ) -> None:
+    config = config or _load_existing_config_or_default()
     epub_path = epub_path.expanduser()
     _ensure_preview_input_exists(epub_path)
 
@@ -368,7 +381,7 @@ def _run_preview(
     )
     output_plan = OutputPlan.for_preview(
         epub_path,
-        default_dir=default_preview_books_dir(),
+        default_dir=_preview_books_dir(config),
     )
     output_path = output_plan.path
     _print_preview_output_location(output_path, max_documents)
@@ -580,6 +593,16 @@ def _load_or_init_config(store: ConfigStore | None = None) -> AyvuConfig:
         return AyvuConfig.default()
 
 
+def _load_existing_config_or_default(store: ConfigStore | None = None) -> AyvuConfig:
+    store = store or ConfigStore.default()
+    try:
+        return store.load()
+    except ConfigError as exc:
+        console.print(f"[yellow]Configuração inválida ignorada:[/yellow] {exc}")
+        console.print("Usando configuração padrão. Ajuste o arquivo de configuração quando possível.")
+        return AyvuConfig.default()
+
+
 def _init_default_language_config(store: ConfigStore) -> AyvuConfig:
     console.print("[yellow]Primeiro uso do modo comum.[/yellow]")
     console.print("Escolha o idioma padrão de leitura/tradução. Você poderá alterá-lo depois em Settings.")
@@ -596,7 +619,7 @@ def _save_config(store: ConfigStore, config: AyvuConfig) -> bool:
         return True
     except ConfigError as exc:
         console.print(f"[yellow]Não foi possível salvar a configuração:[/yellow] {exc}")
-        console.print("O idioma será usado nesta execução, mas não foi persistido.")
+        console.print("A mudança será usada nesta execução, mas não foi persistida.")
         return False
 
 
@@ -615,11 +638,11 @@ def _print_guided_main_menu() -> None:
 
 def _handle_guided_main_choice(choice: str, ctx: typer.Context, config: AyvuConfig) -> bool:
     if choice == GUIDED_TRANSLATE_OPTION:
-        _run_guided_translation(config.default_target_language)
+        _run_guided_translation(config)
         return True
 
     if choice == GUIDED_PREVIEW_OPTION:
-        _run_guided_preview(config.default_target_language)
+        _run_guided_preview(config)
         return True
 
     if choice == GUIDED_LIBRARY_OPTION:
@@ -643,9 +666,9 @@ def _handle_guided_main_choice(choice: str, ctx: typer.Context, config: AyvuConf
     return True
 
 
-def _run_guided_translation(default_target: str) -> None:
+def _run_guided_translation(config: AyvuConfig) -> None:
     epub_path = Path(typer.prompt("EPUB path")).expanduser()
-    target = _choose_guided_target_language(default_target)
+    target = _choose_guided_target_language(config.default_target_language)
     _run_translation(
         epub_path=epub_path,
         output=None,
@@ -662,29 +685,129 @@ def _run_guided_translation(default_target: str) -> None:
         retries=2,
         chunk_limit=3000,
         mode=UserMode.COMMON,
+        config=config,
     )
 
 
-def _run_guided_preview(default_target: str) -> None:
+def _run_guided_preview(config: AyvuConfig) -> None:
     epub_path = Path(typer.prompt("EPUB path")).expanduser()
-    target = _choose_guided_target_language(default_target)
-    _run_preview(epub_path, target=target, mode=UserMode.COMMON)
+    target = _choose_guided_target_language(config.default_target_language)
+    _run_preview(epub_path, target=target, mode=UserMode.COMMON, config=config)
 
 
 def _run_guided_settings(config: AyvuConfig) -> None:
-    console.print(f"[yellow]Current default language:[/yellow] {config.default_target_language}")
-    if not typer.confirm("Change default language?", default=False):
-        console.print("Default language unchanged.")
-        return
+    store = ConfigStore.default()
+    current = config
+    while True:
+        _print_settings(current)
+        _print_settings_menu()
+        choice = typer.prompt("Choose a setting", default=SETTINGS_EXIT_OPTION).strip()
+        if choice == SETTINGS_LANGUAGE_OPTION:
+            current = _update_guided_settings(store, current, _settings_with_default_language(current))
+            continue
+        if choice == SETTINGS_BOOKS_DIR_OPTION:
+            current = _update_guided_settings(store, current, _settings_with_books_dir(current))
+            continue
+        if choice == SETTINGS_FOLDERS_OPTION:
+            current = _update_guided_settings(store, current, _settings_with_folder_names(current))
+            continue
+        if choice == SETTINGS_READER_OPTION:
+            current = _update_guided_settings(store, current, _settings_with_reader_app(current))
+            continue
+        if choice == SETTINGS_EXIT_OPTION:
+            console.print("Settings closed.")
+            return
 
+        console.print("[red]Invalid setting.[/red] Choose 1, 2, 3, 4, or 0.")
+
+
+def _print_settings(config: AyvuConfig) -> None:
+    table = Table(title="Settings")
+    table.add_column("Preference")
+    table.add_column("Current value")
+    table.add_row("Default target language", config.default_target_language)
+    table.add_row("Books folder", str(config.books_dir))
+    table.add_row("Original folder", config.folders.original)
+    table.add_row("Translated folder", config.folders.translated)
+    table.add_row("Preview folder", config.folders.preview)
+    table.add_row("Reports folder", config.folders.reports)
+    table.add_row("Processing folder", config.folders.processing)
+    table.add_row("Reader app", config.reader_app or "-")
+    console.print(table)
+
+
+def _print_settings_menu() -> None:
+    console.print(f"{SETTINGS_LANGUAGE_OPTION}. Change default language")
+    console.print(f"{SETTINGS_BOOKS_DIR_OPTION}. Change books folder")
+    console.print(f"{SETTINGS_FOLDERS_OPTION}. Change feature folder names")
+    console.print(f"{SETTINGS_READER_OPTION}. Change reader app")
+    console.print(f"{SETTINGS_EXIT_OPTION}. Back")
+
+
+def _update_guided_settings(store: ConfigStore, current: AyvuConfig, updated: AyvuConfig) -> AyvuConfig:
+    if updated == current:
+        console.print("Settings unchanged.")
+        return current
+    if _save_config(store, updated):
+        console.print("[green]Settings saved.[/green]")
+    return updated
+
+
+def _settings_with_default_language(config: AyvuConfig) -> AyvuConfig:
     language = _prompt_target_language_code(config.default_target_language)
     if language == config.default_target_language:
-        console.print("Default language unchanged.")
-        return
+        return config
+    return replace(config, default_target_language=language)
 
-    updated = replace(config, default_target_language=language)
-    if _save_config(ConfigStore.default(), updated):
-        console.print(f"[green]Default language saved:[/green] {language}")
+
+def _settings_with_books_dir(config: AyvuConfig) -> AyvuConfig:
+    books_dir = _prompt_path("Books folder", config.books_dir)
+    if books_dir == config.books_dir:
+        return config
+    return replace(config, books_dir=books_dir)
+
+
+def _settings_with_folder_names(config: AyvuConfig) -> AyvuConfig:
+    try:
+        folders = FolderNames.from_dict(
+            {
+                "original": _prompt_folder_name("Original folder name", config.folders.original),
+                "translated": _prompt_folder_name("Translated folder name", config.folders.translated),
+                "preview": _prompt_folder_name("Preview folder name", config.folders.preview),
+                "reports": _prompt_folder_name("Reports folder name", config.folders.reports),
+                "processing": _prompt_folder_name("Processing folder name", config.folders.processing),
+            }
+        )
+    except ConfigError as exc:
+        console.print(f"[red]Invalid folder name:[/red] {exc}")
+        return config
+    if folders == config.folders:
+        return config
+    return replace(config, folders=folders)
+
+
+def _settings_with_reader_app(config: AyvuConfig) -> AyvuConfig:
+    reader_app = _prompt_optional_text("Reader app command", config.reader_app)
+    if reader_app == config.reader_app:
+        return config
+    return replace(config, reader_app=reader_app)
+
+
+def _prompt_path(prompt: str, current: Path) -> Path:
+    raw_path = typer.prompt(prompt, default=str(current)).strip()
+    if not raw_path or raw_path == str(current):
+        return current
+    return Path(raw_path).expanduser()
+
+
+def _prompt_folder_name(prompt: str, current: str) -> str:
+    value = typer.prompt(prompt, default=current).strip()
+    return value or current
+
+
+def _prompt_optional_text(prompt: str, current: str | None) -> str | None:
+    value = typer.prompt(prompt, default=current or "").strip()
+    return value or None
 
 
 def _print_guided_placeholder(name: str) -> None:
@@ -834,8 +957,9 @@ def _save_running_resume_state(
     overwrite: bool,
     timeout: float,
     retries: int,
+    processing_dir: Path,
 ) -> tuple[ResumeStateStore, TranslationResumeState]:
-    store = ResumeStateStore(default_processing_dir())
+    store = ResumeStateStore(processing_dir)
     state = TranslationResumeState.create(
         input_path=epub_path,
         output_path=output_path,
@@ -927,7 +1051,7 @@ def _render_markdown_report(
 
 
 def _default_reports_dir() -> Path:
-    return Path.home() / "Documentos" / "Livros" / "Relatorios"
+    return _reports_dir(_load_existing_config_or_default())
 
 
 def _next_available_report_path(directory: Path, stem: str) -> Path:
@@ -1078,6 +1202,34 @@ def _confirm_existing_preview_overwrite(output_path: Path, mode: UserMode) -> bo
     console.print(f"[yellow]Preview output path:[/yellow] {output_path}")
     console.print("[yellow]Preview EPUB already exists.[/yellow]")
     return typer.confirm("Overwrite existing preview EPUB?", default=False)
+
+
+def _translated_books_dir(config: AyvuConfig) -> Path:
+    if _uses_internal_storage_defaults(config):
+        return default_translated_books_dir()
+    return config.translated_dir
+
+
+def _preview_books_dir(config: AyvuConfig) -> Path:
+    if _uses_internal_storage_defaults(config):
+        return default_preview_books_dir()
+    return config.preview_dir
+
+
+def _reports_dir(config: AyvuConfig) -> Path:
+    if _uses_internal_storage_defaults(config):
+        return Path.home() / "Documentos" / "Livros" / "Relatorios"
+    return config.reports_dir
+
+
+def _processing_dir(config: AyvuConfig) -> Path:
+    if _uses_internal_storage_defaults(config):
+        return default_processing_dir()
+    return config.processing_dir
+
+
+def _uses_internal_storage_defaults(config: AyvuConfig) -> bool:
+    return config.books_dir == Path(DEFAULT_BOOKS_DIR) and config.folders == FolderNames()
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -199,6 +199,34 @@ def test_root_command_shows_processing_translation_state(tmp_path, monkeypatch):
     assert "Canceled." in result.output
 
 
+def test_root_command_uses_configured_processing_dir(isolated_config, tmp_path):
+    books_dir = tmp_path / "Biblioteca"
+    processing_dir = books_dir / "Em-Andamento"
+    state = _resume_state(tmp_path)
+    ResumeStateStore(processing_dir).save(state)
+    isolated_config.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "default_target_language": "pt",
+                "books_dir": str(books_dir),
+                "folders": {"processing": "Em-Andamento"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, [], input="n\n0\n")
+
+    assert result.exit_code == 0
+    assert "Translations in progress were found." in result.output
+    assert "Processing translations" in result.output
+    assert "book.epub" in result.output
+    assert "Detected translation was not resumed." in result.output
+    assert "Canceled." in result.output
+
+
 def test_root_command_in_developer_mode_skips_guided_prompts(tmp_path, monkeypatch):
     epub_path = tmp_path / "book.epub"
     epub_path.write_bytes(b"fake")
@@ -518,24 +546,89 @@ def test_root_command_shows_guided_library_placeholder(tmp_path, monkeypatch):
 def test_root_command_settings_keeps_language_when_not_changed(tmp_path, monkeypatch):
     monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: tmp_path / "missing")
 
-    result = runner.invoke(app, [], input="4\nn\n")
+    result = runner.invoke(app, [], input="4\n1\npt\n0\n")
 
     assert result.exit_code == 0
-    assert "Current default language:" in result.output
-    assert "Change default language?" in result.output
-    assert "Default language unchanged." in result.output
+    assert "Settings" in result.output
+    assert "Default target language" in result.output
+    assert "Change default language" in result.output
+    assert "Settings unchanged." in result.output
+    assert "Settings closed." in result.output
 
 
 def test_root_command_settings_changes_and_persists_language(isolated_config, tmp_path, monkeypatch):
     monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: tmp_path / "missing")
     monkeypatch.setattr("ayvu.cli.LibreTranslateTranslator", FakeNoLanguagesTranslator)
 
-    result = runner.invoke(app, [], input="4\ny\nes\n")
+    result = runner.invoke(app, [], input="4\n1\nes\n0\n")
 
     assert result.exit_code == 0
-    assert "Default language saved:" in result.output
+    assert "Settings saved." in result.output
     saved = json.loads(isolated_config.read_text(encoding="utf-8"))
     assert saved["default_target_language"] == "es"
+
+
+def test_root_command_settings_changes_books_dir(isolated_config, tmp_path, monkeypatch):
+    books_dir = tmp_path / "Minha Biblioteca"
+    monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: tmp_path / "missing")
+
+    result = runner.invoke(app, [], input=f"4\n2\n{books_dir}\n0\n")
+
+    assert result.exit_code == 0
+    assert "Books folder" in result.output
+    assert "Settings saved." in result.output
+    saved = json.loads(isolated_config.read_text(encoding="utf-8"))
+    assert saved["books_dir"] == str(books_dir)
+
+
+def test_root_command_settings_changes_feature_folder_names(isolated_config, tmp_path, monkeypatch):
+    monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: tmp_path / "missing")
+
+    result = runner.invoke(
+        app,
+        [],
+        input="4\n3\nOriginais\nPT\nAmostras\nRelatorios-MD\nEm-Andamento\n0\n",
+    )
+
+    assert result.exit_code == 0
+    assert "Change feature folder names" in result.output
+    assert "Settings saved." in result.output
+    saved = json.loads(isolated_config.read_text(encoding="utf-8"))
+    assert saved["folders"] == {
+        "original": "Originais",
+        "translated": "PT",
+        "preview": "Amostras",
+        "reports": "Relatorios-MD",
+        "processing": "Em-Andamento",
+    }
+
+
+def test_root_command_settings_rejects_folder_paths(isolated_config, tmp_path, monkeypatch):
+    monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: tmp_path / "missing")
+
+    result = runner.invoke(
+        app,
+        [],
+        input="4\n3\nOriginais\nLivros/PT\nAmostras\nRelatorios\nProcessando\n0\n",
+    )
+
+    assert result.exit_code == 0
+    assert "Invalid folder name:" in result.output
+    saved = json.loads(isolated_config.read_text(encoding="utf-8"))
+    assert saved["default_target_language"] == "pt"
+    assert "folders" not in saved
+
+
+def test_root_command_settings_changes_reader_app(isolated_config, tmp_path, monkeypatch):
+    monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: tmp_path / "missing")
+
+    result = runner.invoke(app, [], input="4\n4\nfoliate\n0\n")
+
+    assert result.exit_code == 0
+    assert "Reader app" in result.output
+    assert "Settings saved." in result.output
+    saved = json.loads(isolated_config.read_text(encoding="utf-8"))
+    assert saved["reader_app"] == "foliate"
 
 
 def test_root_command_first_use_asks_and_saves_default_language(isolated_config, tmp_path, monkeypatch):
@@ -659,6 +752,51 @@ def test_preview_option_generates_preview_with_default_settings(tmp_path, monkey
     assert options.max_documents == DEFAULT_PREVIEW_DOCUMENT_LIMIT
 
 
+def test_preview_option_uses_configured_preview_dir(isolated_config, tmp_path, monkeypatch):
+    epub_path = tmp_path / "book.epub"
+    books_dir = tmp_path / "Biblioteca"
+    epub_path.write_bytes(b"fake epub")
+    calls: dict[str, object] = {}
+    isolated_config.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "default_target_language": "pt",
+                "books_dir": str(books_dir),
+                "folders": {"preview": "Amostras"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    def fake_translate(input_path: Path, output_path: Path, **kwargs: object) -> TranslationReport:
+        calls["input_path"] = input_path
+        calls["output_path"] = output_path
+        calls["options"] = kwargs["options"]
+        return TranslationReport(output_path=output_path, input_path=input_path, target_language="pt")
+
+    monkeypatch.setattr(
+        "ayvu.cli.run_translation_preflight",
+        lambda **_kwargs: SimpleNamespace(translator=object(), glossary=None),
+    )
+    monkeypatch.setattr("ayvu.cli.TranslationCache", lambda _path: FakeCache())
+    monkeypatch.setattr("ayvu.cli.translate_epub", fake_translate)
+    monkeypatch.setattr(
+        "ayvu.cli.validate_output_epub",
+        lambda _path, on_progress=None: ValidationResult(ok=True, document_count=1),
+    )
+
+    result = runner.invoke(app, ["--preview", str(epub_path)])
+
+    output_path = books_dir / "Amostras" / "book-preview.epub"
+    assert result.exit_code == 0
+    assert str(output_path.parent) in result.output.replace("\n", "")
+    assert calls["input_path"] == epub_path
+    assert calls["output_path"] == output_path
+    assert calls["options"].max_documents == DEFAULT_PREVIEW_DOCUMENT_LIMIT
+
+
 def test_translate_command_stops_when_preflight_fails(tmp_path, monkeypatch):
     epub_path = tmp_path / "book.epub"
     epub_path.write_bytes(b"fake epub")
@@ -725,6 +863,57 @@ def test_translate_command_confirms_default_output_location(tmp_path, monkeypatc
     assert "book-pt.epub" in result.output
     assert "Original EPUB stays in Original:" in result.output
     assert "Keep this output location?" in result.output
+    assert calls["input_path"] == epub_path
+    assert calls["output_path"] == output_path
+    assert resume_state.output_path == output_path.resolve()
+
+
+def test_translate_command_uses_configured_output_and_processing_dirs(isolated_config, tmp_path, monkeypatch):
+    epub_path = tmp_path / "book.epub"
+    books_dir = tmp_path / "Biblioteca"
+    epub_path.write_bytes(b"fake epub")
+    calls: dict[str, Path] = {}
+    isolated_config.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "default_target_language": "pt",
+                "books_dir": str(books_dir),
+                "folders": {
+                    "translated": "PT",
+                    "processing": "Em-Andamento",
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    def fake_translate(input_path: Path, output_path: Path, **_kwargs: object) -> TranslationReport:
+        calls["input_path"] = input_path
+        calls["output_path"] = output_path
+        return TranslationReport(output_path=output_path, input_path=input_path, target_language="pt")
+
+    monkeypatch.setattr(
+        "ayvu.cli.run_translation_preflight",
+        lambda **_kwargs: SimpleNamespace(translator=object(), glossary=None),
+    )
+    monkeypatch.setattr("ayvu.cli.TranslationCache", lambda _path: FakeCache())
+    monkeypatch.setattr("ayvu.cli.translate_epub", fake_translate)
+    monkeypatch.setattr(
+        "ayvu.cli.validate_output_epub",
+        lambda _path, on_progress=None: ValidationResult(ok=True, document_count=1),
+    )
+    monkeypatch.setattr("ayvu.cli._offer_markdown_report", lambda *_args, **_kwargs: None)
+
+    result = runner.invoke(app, ["--mode", "common", "translate", str(epub_path)], input="y\n")
+
+    output_path = books_dir / "PT" / "book-pt.epub"
+    processing_dir = books_dir / "Em-Andamento"
+    state_path = processing_dir / "book-pt.ayvu-state.json"
+    resume_state = ResumeStateStore(processing_dir).load(state_path)
+    assert result.exit_code == 0
+    assert str(output_path.parent) in result.output.replace("\n", "")
     assert calls["input_path"] == epub_path
     assert calls["output_path"] == output_path
     assert resume_state.output_path == output_path.resolve()
@@ -930,6 +1119,32 @@ def test_save_markdown_report_uses_default_reports_dir_without_overwriting(tmp_p
     assert second_path == reports_dir / "book-pt-report-2.md"
     assert first_path.read_text(encoding="utf-8").startswith("# Translation report")
     assert second_path.read_text(encoding="utf-8").startswith("# Translation report")
+
+
+def test_save_markdown_report_uses_configured_reports_dir(isolated_config, tmp_path):
+    books_dir = tmp_path / "Biblioteca"
+    isolated_config.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "default_target_language": "pt",
+                "books_dir": str(books_dir),
+                "folders": {"reports": "Relatorios-MD"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    report = TranslationReport(
+        output_path=Path("book-pt.epub"),
+        input_path=Path("book.epub"),
+        target_language="pt",
+    )
+
+    report_path = _save_markdown_report(report, dry_run=False)
+
+    assert report_path == books_dir / "Relatorios-MD" / "book-pt-report.md"
+    assert report_path.read_text(encoding="utf-8").startswith("# Translation report")
 
 
 def test_offer_markdown_report_does_not_save_when_declined(monkeypatch):


### PR DESCRIPTION
## Objetivo

Criar uma area de configuracoes no modo comum para centralizar preferencias locais do Ayvu.

## O que mudou

- Adiciona menu guiado de Settings com alteracao de idioma padrao, pasta base dos livros, nomes das pastas das funcionalidades e app leitor.
- Usa a configuracao para resolver diretorios padrao de preview, traducao, relatorios Markdown e estados de processamento.
- Mantem argumentos explicitos da CLI com precedencia sobre a configuracao.
- Ignora o arquivo local CLAUDE.md no .gitignore.
- Atualiza README, tutorial e relatorio tecnico com o estado atual do fluxo.

## Fora do escopo

- Biblioteca guiada e abertura de EPUBs no app leitor.
- Prompt de primeira execucao para escolher pasta base ou nomes das pastas.
- Alteracao de backend, cache, glossario ou traducao HTML.

## Validacao e testes

- uv run pytest: 125 passed
- git diff --check

## Issues relacionadas

Closes #49
Refs #43
Refs #48