### PR TITLE
Melhorar seleção guiada de idioma

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,8 +143,9 @@ Ao executar apenas `uv run ayvu`, o Ayvu abre um primeiro menu guiado com opçõ
 livro, gerar preview, abrir biblioteca, acessar configurações, mostrar ajuda ou sair. Biblioteca
 ainda aparece como opção indisponível. A opção `Settings` permite ver e alterar idioma padrão,
 pasta base dos livros, nomes das pastas das funcionalidades e app leitor de EPUB. Nos fluxos
-guiados de tradução e preview, o Ayvu mostra o idioma de destino padrão salvo e permite escolher
-outro código a partir dos idiomas informados pelo LibreTranslate.
+guiados de tradução e preview, o Ayvu mostra o idioma de destino padrão salvo como primeira
+opção. Ao escolher `Outro idioma`, ele lista os idiomas informados pelo LibreTranslate com nome,
+código e estado, permitindo selecionar pela opção exibida ou digitar um código.
 No modo desenvolvedor, o idioma de destino continua sendo definido por `--target`.
 
 Antes de iniciar a tradução, o Ayvu verifica internamente o par de idiomas, o glossário, o cache, o EPUB de entrada e, em traduções reais, o tradutor configurado. Se algo impedir a execução, o comando falha cedo com uma mensagem curta e um próximo passo.

--- a/docs/relatorio-tecnico.md
+++ b/docs/relatorio-tecnico.md
@@ -198,7 +198,7 @@ Executar o menu guiado:
 uv run ayvu
 ```
 
-O modo guiado permite iniciar tradução, gerar preview, ver ajuda e acessar placeholders de biblioteca e configurações. Também pode detectar estados locais de tradução interrompida.
+O modo guiado permite iniciar tradução, gerar preview, ver ajuda, acessar configurações e abrir o placeholder de biblioteca. Também pode detectar estados locais de tradução interrompida. Na tradução e no preview guiados, o idioma padrão salvo aparece como primeira opção; ao escolher `Outro idioma`, o Ayvu lista idiomas do LibreTranslate com nome, código e estado.
 
 ## 7. Modos de uso
 

--- a/docs/tutorial-modo-comum-e-dev.md
+++ b/docs/tutorial-modo-comum-e-dev.md
@@ -67,7 +67,7 @@ Abra o preview no seu leitor de EPUB e confira capa, sumário, primeiro capítul
 
 ### Traduzir o livro completo
 
-Pelo menu inicial, escolha traduzir livro e informe o caminho do EPUB. O Ayvu mostra o idioma de destino padrão, permite escolher outro código de idioma e confirma onde o arquivo traduzido será salvo.
+Pelo menu inicial, escolha traduzir livro e informe o caminho do EPUB. O Ayvu mostra o idioma de destino padrão como primeira opção e também oferece `Outro idioma`. Ao escolher outro idioma, ele lista os idiomas do LibreTranslate com nome, código e estado. Depois disso, confirma onde o arquivo traduzido será salvo.
 
 Antes de iniciar uma tradução real, o Ayvu verifica EPUB, idioma, glossário, cache e tradutor. Se algo estiver errado, ele falha cedo com uma mensagem curta e um próximo passo.
 

--- a/src/ayvu/cli.py
+++ b/src/ayvu/cli.py
@@ -46,6 +46,8 @@ GUIDED_LIBRARY_OPTION = "3"
 GUIDED_SETTINGS_OPTION = "4"
 GUIDED_HELP_OPTION = "5"
 GUIDED_EXIT_OPTION = "0"
+GUIDED_DEFAULT_LANGUAGE_OPTION = "1"
+GUIDED_OTHER_LANGUAGE_OPTION = "2"
 SETTINGS_LANGUAGE_OPTION = "1"
 SETTINGS_BOOKS_DIR_OPTION = "2"
 SETTINGS_FOLDERS_OPTION = "3"
@@ -817,21 +819,52 @@ def _print_guided_placeholder(name: str) -> None:
 
 def _choose_guided_target_language(default_target: str) -> str:
     console.print(f"[yellow]Default target language:[/yellow] {default_target}")
-    if typer.confirm("Use default target language?", default=True):
-        return default_target
+    console.print(f"{GUIDED_DEFAULT_LANGUAGE_OPTION}. Use default target language ({default_target})")
+    console.print(f"{GUIDED_OTHER_LANGUAGE_OPTION}. Outro idioma")
 
-    return _prompt_target_language_code(default_target)
+    while True:
+        choice = typer.prompt("Choose target language", default=GUIDED_DEFAULT_LANGUAGE_OPTION).strip()
+        if choice == GUIDED_DEFAULT_LANGUAGE_OPTION:
+            return default_target
+        if choice == GUIDED_OTHER_LANGUAGE_OPTION:
+            return _prompt_target_language_code(default_target)
+        console.print("[red]Invalid option.[/red] Choose 1 or 2.")
 
 
 def _prompt_target_language_code(default_target: str) -> str:
     available_languages = _load_languages_for_guided_selection()
     if available_languages:
-        _print_languages(available_languages)
+        _print_guided_language_choices(available_languages)
     else:
         console.print("Enter a language code manually.")
 
-    target = typer.prompt("Target language code", default=default_target).strip()
+    target = typer.prompt("Target language option or code", default=default_target).strip()
+    selected = _language_code_from_guided_choice(target, available_languages)
+    if selected:
+        return selected
     return target or default_target
+
+
+def _print_guided_language_choices(languages: tuple[TranslatorLanguage, ...]) -> None:
+    table = Table(title="LibreTranslate languages")
+    table.add_column("Option")
+    table.add_column("Language")
+    table.add_column("Code")
+    table.add_column("State")
+
+    for index, language in enumerate(languages, start=1):
+        table.add_row(str(index), language.name, language.code, language.state)
+    console.print(table)
+
+
+def _language_code_from_guided_choice(choice: str, languages: tuple[TranslatorLanguage, ...]) -> str | None:
+    if not choice.isdigit():
+        return None
+
+    index = int(choice)
+    if 1 <= index <= len(languages):
+        return languages[index - 1].code
+    return None
 
 
 def _load_languages_for_guided_selection() -> tuple[TranslatorLanguage, ...]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -425,6 +425,10 @@ def test_root_command_generates_guided_preview_when_confirmed(tmp_path, monkeypa
     monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: tmp_path / "missing")
     monkeypatch.setattr("ayvu.cli.default_preview_books_dir", lambda: preview_dir)
     monkeypatch.setattr(
+        "ayvu.cli.LibreTranslateTranslator",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("languages should not be listed")),
+    )
+    monkeypatch.setattr(
         "ayvu.cli.run_translation_preflight",
         lambda **_kwargs: SimpleNamespace(translator=object(), glossary=None),
     )
@@ -432,7 +436,7 @@ def test_root_command_generates_guided_preview_when_confirmed(tmp_path, monkeypa
     monkeypatch.setattr("ayvu.cli.translate_epub", fake_translate)
     monkeypatch.setattr("ayvu.cli.validate_output_epub", lambda _path, on_progress=None: ValidationResult(ok=True, document_count=1))
 
-    result = runner.invoke(app, [], input=f"2\n{epub_path}\ny\n")
+    result = runner.invoke(app, [], input=f"2\n{epub_path}\n1\n")
 
     options = calls["options"]
     assert result.exit_code == 0
@@ -440,7 +444,9 @@ def test_root_command_generates_guided_preview_when_confirmed(tmp_path, monkeypa
     assert "Generate preview" in result.output
     assert "EPUB path" in result.output
     assert "Default target language:" in result.output
-    assert "Use default target language?" in result.output
+    assert "Use default target language (pt)" in result.output
+    assert "Outro idioma" in result.output
+    assert "Choose target language" in result.output
     assert "Preview output folder:" in result.output
     assert "Preview EPUB name:" in result.output
     assert "Preview salvo em:" in result.output
@@ -482,15 +488,17 @@ def test_root_command_allows_guided_preview_target_from_languages(tmp_path, monk
     monkeypatch.setattr("ayvu.cli.translate_epub", fake_translate)
     monkeypatch.setattr("ayvu.cli.validate_output_epub", lambda _path, on_progress=None: ValidationResult(ok=True, document_count=1))
 
-    result = runner.invoke(app, [], input=f"2\n{epub_path}\nn\nes\n")
+    result = runner.invoke(app, [], input=f"2\n{epub_path}\n2\n2\n")
 
     options = calls["options"]
     assert result.exit_code == 0
     assert "Default target language:" in result.output
+    assert "Outro idioma" in result.output
     assert "LibreTranslate languages" in result.output
+    assert "Option" in result.output
     assert "Portuguese" in result.output
     assert "Spanish" in result.output
-    assert "Target language code" in result.output
+    assert "Target language option or code" in result.output
     assert calls["target"] == "es"
     assert options.target == "es"
 
@@ -519,13 +527,14 @@ def test_root_command_starts_guided_translation(tmp_path, monkeypatch):
     monkeypatch.setattr("ayvu.cli.validate_output_epub", lambda _path, on_progress=None: ValidationResult(ok=True, document_count=1))
     monkeypatch.setattr("ayvu.cli._offer_markdown_report", lambda *_args, **_kwargs: None)
 
-    result = runner.invoke(app, [], input=f"1\n{epub_path}\ny\ny\n")
+    result = runner.invoke(app, [], input=f"1\n{epub_path}\n1\ny\n")
 
     options = calls["options"]
     assert result.exit_code == 0
     assert "Translate a book" in result.output
     assert "EPUB path" in result.output
     assert "Default target language:" in result.output
+    assert "Outro idioma" in result.output
     assert "Default output folder:" in result.output
     assert calls["input_path"] == epub_path
     assert calls["output_path"] == output_dir / "book-pt.epub"
@@ -680,7 +689,7 @@ def test_root_command_uses_saved_default_language_in_guided_preview(isolated_con
     monkeypatch.setattr("ayvu.cli.translate_epub", fake_translate)
     monkeypatch.setattr("ayvu.cli.validate_output_epub", lambda _path, on_progress=None: ValidationResult(ok=True, document_count=1))
 
-    result = runner.invoke(app, [], input=f"2\n{epub_path}\ny\n")
+    result = runner.invoke(app, [], input=f"2\n{epub_path}\n1\n")
 
     assert result.exit_code == 0
     assert "Default target language:" in result.output


### PR DESCRIPTION
## Objetivo

Permitir escolher o idioma de tradução no modo comum sem exigir URL ou detalhes técnicos do LibreTranslate.

## O que mudou

- Mostra o idioma padrão configurado como primeira opção nos fluxos guiados de tradução e preview.
- Adiciona a opção Outro idioma antes de consultar o LibreTranslate.
- Lista idiomas do LibreTranslate com opção, nome, código e estado apenas quando o usuário escolhe outro idioma.
- Permite selecionar outro idioma pelo número exibido ou digitando um código manualmente.
- Mantém o comando técnico languages para o modo dev.
- Atualiza README, tutorial e relatório técnico.

## Fora do escopo

- Instalar ou baixar idiomas automaticamente.
- Validar disponibilidade de pares de tradução antes da tradução completa.
- Detectar idioma de origem do EPUB.

## Validação e testes

- uv run pytest: 125 passed
- git diff --check

## Issue relacionada

Closes #37