### PR TITLE
Criar biblioteca inicial do Ayvu

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ O EPUB original nunca é alterado. A saída é gravada em um novo arquivo `.epub
 - Nome de saída automático baseado no idioma de destino.
 - Preview traduzido de uma amostra inicial do EPUB.
 - Modo comum guiado e modo desenvolvedor direto.
+- Biblioteca inicial para listar originais e traduções e abrir EPUBs no leitor configurado ou padrão do sistema.
 - Checagens internas antes de iniciar traduções reais.
 - Modo `dry-run` para simular o processamento sem gerar arquivo.
 - Extração de texto visível para Markdown.
@@ -140,9 +141,11 @@ salva na configuração. Nas próximas execuções esse idioma é usado como des
 em traduções e previews, sem perguntar de novo.
 
 Ao executar apenas `uv run ayvu`, o Ayvu abre um primeiro menu guiado com opções para traduzir
-livro, gerar preview, abrir biblioteca, acessar configurações, mostrar ajuda ou sair. Biblioteca
-ainda aparece como opção indisponível. A opção `Settings` permite ver e alterar idioma padrão,
-pasta base dos livros, nomes das pastas das funcionalidades e app leitor de EPUB. Nos fluxos
+livro, gerar preview, abrir biblioteca, acessar configurações, mostrar ajuda ou sair. A biblioteca
+lista EPUBs das pastas `Original` e `Traduzidos`, mostra as versões disponíveis de cada livro e
+permite abrir o original ou uma tradução no leitor configurado ou no leitor padrão detectado no
+sistema. A opção `Settings` permite ver e alterar idioma padrão, pasta base dos livros, nomes das
+pastas das funcionalidades e app leitor de EPUB. Nos fluxos
 guiados de tradução e preview, o Ayvu mostra o idioma de destino padrão salvo como primeira
 opção. Ao escolher `Outro idioma`, ele lista os idiomas informados pelo LibreTranslate com nome,
 código e estado, permitindo selecionar pela opção exibida ou digitar um código.
@@ -239,6 +242,28 @@ automaticamente.
 Ao executar `uv run ayvu`, o modo comum procura estados de tradução em andamento
 nessa pasta e oferece retomar uma execução detectada.
 
+## Biblioteca
+
+A biblioteca inicial usa a pasta base configurada, por padrão:
+
+```text
+~/Documentos/Livros
+```
+
+Com os nomes padrão, os EPUBs ficam organizados assim:
+
+```text
+~/Documentos/Livros/
+├── Original/
+└── Traduzidos/
+```
+
+Coloque EPUBs originais em `Original` e traduções finais em `Traduzidos`. Ao escolher
+`Open library` no menu comum, o Ayvu lista os livros em ordem alfabética, mostra se existe
+original e quais traduções foram encontradas, permite ver informações do livro e abre a versão
+selecionada no app leitor. Se nenhum leitor padrão for detectado, configure o comando do leitor em
+`Settings` no campo `Reader app`.
+
 ## Configuração
 
 O Ayvu define um formato inicial para preferências locais. No modo comum, o primeiro uso pergunta o
@@ -280,7 +305,9 @@ argumentos da CLI > arquivo de configuração > padrões internos
 ```
 
 Sem caminhos explícitos, a pasta base e os nomes de pastas configurados definem onde o Ayvu salva
-previews, traduções, relatórios Markdown e estados de processamento.
+previews, traduções, relatórios Markdown e estados de processamento, além das pastas usadas pela
+biblioteca. O campo `reader_app` define o comando usado para abrir EPUBs pela biblioteca quando o
+leitor padrão do sistema não for suficiente.
 
 ## Testes
 

--- a/docs/relatorio-tecnico.md
+++ b/docs/relatorio-tecnico.md
@@ -2,7 +2,7 @@
 
 Este documento registra o estado técnico atual do Ayvu, as decisões principais de arquitetura, os fluxos implementados e os próximos riscos conhecidos.
 
-Última atualização: 2026-05-15.
+Última atualização: 2026-05-22.
 
 ## 1. Objetivo do projeto
 
@@ -42,13 +42,13 @@ O Ayvu já possui:
 - retomada local de traduções interrompidas;
 - comando para listar idiomas do LibreTranslate;
 - formato inicial de configuração local;
+- biblioteca inicial para listar originais e traduções e abrir EPUBs no leitor configurado ou padrão do sistema;
 - validação do EPUB gerado com barra de progresso e avisos de capítulo vazio, link interno quebrado e imagem ausente;
 - testes automatizados e CI no GitHub Actions.
 
 Ainda não possui:
 
-- interface completa para editar configurações persistentes do Ayvu;
-- biblioteca completa de livros;
+- biblioteca completa com importação automática, fila e histórico;
 - gerenciamento automático do LibreTranslate;
 - tradução por bloco preservando tags internas;
 - validação EPUB avançada com EPUBCheck;
@@ -79,6 +79,7 @@ ayvu/
 │       ├── epub_io.py
 │       ├── glossary.py
 │       ├── html_translate.py
+│       ├── library.py
 │       ├── preflight.py
 │       ├── resume.py
 │       ├── translator.py
@@ -93,6 +94,7 @@ ayvu/
 │   ├── test_epub_io.py
 │   ├── test_glossary.py
 │   ├── test_html_translate.py
+│   ├── test_library.py
 │   ├── test_preflight.py
 │   ├── test_resume.py
 │   ├── test_translator.py
@@ -198,7 +200,7 @@ Executar o menu guiado:
 uv run ayvu
 ```
 
-O modo guiado permite iniciar tradução, gerar preview, ver ajuda, acessar configurações e abrir o placeholder de biblioteca. Também pode detectar estados locais de tradução interrompida. Na tradução e no preview guiados, o idioma padrão salvo aparece como primeira opção; ao escolher `Outro idioma`, o Ayvu lista idiomas do LibreTranslate com nome, código e estado.
+O modo guiado permite iniciar tradução, gerar preview, ver ajuda, acessar configurações e abrir a biblioteca inicial. Também pode detectar estados locais de tradução interrompida. Na tradução e no preview guiados, o idioma padrão salvo aparece como primeira opção; ao escolher `Outro idioma`, o Ayvu lista idiomas do LibreTranslate com nome, código e estado. A biblioteca lista livros das pastas configuradas de originais e traduções, mostra versões disponíveis e abre o EPUB escolhido no leitor configurado ou no leitor padrão detectado no sistema.
 
 ## 7. Modos de uso
 
@@ -224,6 +226,8 @@ uv run ayvu --mode common translate livro.epub
 `src/ayvu/epub_io.py` cuida de leitura, inspeção, extração, tradução estrutural e escrita do EPUB final.
 
 `src/ayvu/html_translate.py` traduz HTML/XHTML em nível de nó de texto visível, preservando tags e ignorando conteúdo que não deve ser traduzido.
+
+`src/ayvu/library.py` varre as pastas de biblioteca configuradas, agrupa EPUB original e traduções por livro e resolve o comando usado para abrir EPUBs no app leitor.
 
 `src/ayvu/translator.py` define o contrato `Translator` e o backend `LibreTranslateTranslator`.
 
@@ -281,7 +285,7 @@ A precedência usada pelos fluxos atuais é:
 argumentos da CLI > arquivo de configuração > padrões internos
 ```
 
-Hoje a configuração já alimenta os diretórios padrão de preview, traduções, relatórios Markdown e estados de processamento. O app leitor fica salvo para os fluxos de biblioteca.
+Hoje a configuração já alimenta os diretórios padrão de preview, traduções, relatórios Markdown, estados de processamento e biblioteca. O app leitor configurado é usado pela biblioteca ao abrir EPUBs.
 
 ## 10. Pipeline de EPUB
 

--- a/docs/tutorial-modo-comum-e-dev.md
+++ b/docs/tutorial-modo-comum-e-dev.md
@@ -43,7 +43,7 @@ Abra o menu inicial:
 uv run ayvu
 ```
 
-O menu permite iniciar uma tradução, gerar preview, ver ajuda, abrir biblioteca e acessar configurações. Biblioteca ainda aparece como opção indisponível na versão atual; as configurações já permitem alterar idioma padrão, pasta base dos livros, nomes das pastas das funcionalidades e app leitor de EPUB.
+O menu permite iniciar uma tradução, gerar preview, ver ajuda, abrir biblioteca e acessar configurações. A biblioteca lista EPUBs das pastas configuradas para originais e traduções, mostra as versões disponíveis e permite abrir o arquivo escolhido no leitor configurado ou no leitor padrão detectado no sistema. As configurações permitem alterar idioma padrão, pasta base dos livros, nomes das pastas das funcionalidades e app leitor de EPUB.
 
 ### Gerar um preview
 
@@ -153,11 +153,11 @@ No menu inicial, escolha `Settings` para ver os valores atuais e alterar prefer�
 ~/Documentos/Livros
 ```
 
-Dentro dela, o Ayvu usa os nomes configurados para previews, traduções finais, relatórios e estados de processamento. Você também pode alterar o nome da pasta `Original`, que segue como convenção para a biblioteca futura, e configurar o app leitor de EPUB para os próximos fluxos de biblioteca.
+Dentro dela, o Ayvu usa os nomes configurados para previews, traduções finais, relatórios, estados de processamento e biblioteca. Você também pode alterar o nome da pasta `Original` e configurar o app leitor de EPUB usado pela biblioteca.
 
-### Organizar biblioteca manualmente
+### Usar biblioteca
 
-A biblioteca guiada ainda não está completa. Enquanto isso, use a estrutura padrão como convenção local:
+A biblioteca inicial usa a estrutura configurada no modo comum. Com os nomes padrão:
 
 ```text
 ~/Documentos/Livros/
@@ -168,7 +168,9 @@ A biblioteca guiada ainda não está completa. Enquanto isso, use a estrutura pa
 └── Processando/
 ```
 
-Mantenha EPUBs originais em `Original`, previews em `Preview`, traduções finais em `Traduzidos` e relatórios em `Relatorios`. `Original` é apenas uma convenção manual do usuário por enquanto; o Ayvu ainda não cria nem gerencia essa pasta.
+Mantenha EPUBs originais em `Original`, previews em `Preview`, traduções finais em `Traduzidos` e relatórios em `Relatorios`. Ao escolher `Open library`, o Ayvu lista os livros em ordem alfabética, mostra quais têm original e quais traduções foram encontradas, permite ver informações do livro e abre a versão selecionada no leitor de EPUB.
+
+Se o Ayvu não detectar um leitor padrão do sistema, abra `Settings` e preencha `Reader app` com o comando do seu leitor, por exemplo `foliate`.
 
 ## Tutorial dev: comandos diretos
 
@@ -273,7 +275,8 @@ Depois da tradução:
 
 ## Limites atuais
 
-- Biblioteca e configurações ainda não estão completas.
+- A biblioteca inicial lista e abre EPUBs, mas ainda não gerencia importação automática, fila ou histórico completo.
+- Configurações ainda cobrem apenas as preferências locais iniciais.
 - A tradução ainda acontece por nós de texto, então frases quebradas por tags podem perder contexto.
 - A qualidade depende do servidor de tradução local.
 - Livros técnicos costumam exigir glossário.

--- a/src/ayvu/cli.py
+++ b/src/ayvu/cli.py
@@ -21,6 +21,7 @@ from .domain import (
     default_translated_books_dir,
 )
 from .epub_io import TranslationReport, extract_markdown, inspect_epub, translate_epub
+from .library import LibraryBook, LibraryOpenError, open_library_epub, scan_library
 from .preflight import PreflightError, run_translation_preflight
 from .resume import (
     InvalidResumeState,
@@ -48,6 +49,7 @@ GUIDED_HELP_OPTION = "5"
 GUIDED_EXIT_OPTION = "0"
 GUIDED_DEFAULT_LANGUAGE_OPTION = "1"
 GUIDED_OTHER_LANGUAGE_OPTION = "2"
+LIBRARY_BACK_OPTION = "0"
 SETTINGS_LANGUAGE_OPTION = "1"
 SETTINGS_BOOKS_DIR_OPTION = "2"
 SETTINGS_FOLDERS_OPTION = "3"
@@ -648,7 +650,7 @@ def _handle_guided_main_choice(choice: str, ctx: typer.Context, config: AyvuConf
         return True
 
     if choice == GUIDED_LIBRARY_OPTION:
-        _print_guided_placeholder("Library")
+        _run_guided_library(config)
         return True
 
     if choice == GUIDED_SETTINGS_OPTION:
@@ -695,6 +697,124 @@ def _run_guided_preview(config: AyvuConfig) -> None:
     epub_path = Path(typer.prompt("EPUB path")).expanduser()
     target = _choose_guided_target_language(config.default_target_language)
     _run_preview(epub_path, target=target, mode=UserMode.COMMON, config=config)
+
+
+def _run_guided_library(config: AyvuConfig) -> None:
+    books = scan_library(config)
+    if not books:
+        console.print("[yellow]Library has no EPUB books yet.[/yellow]")
+        console.print(f"Original folder: {config.original_dir}")
+        console.print(f"Translated folder: {config.translated_dir}")
+        return
+
+    _print_library_books(books)
+    book = _prompt_library_book(books)
+    if book is None:
+        return
+    _run_guided_library_book(config, book)
+
+
+def _print_library_books(books: tuple[LibraryBook, ...]) -> None:
+    table = Table(title="Library")
+    table.add_column("Option")
+    table.add_column("Book")
+    table.add_column("Original")
+    table.add_column("Translations")
+
+    for index, book in enumerate(books, start=1):
+        table.add_row(
+            str(index),
+            book.name,
+            "yes" if book.has_original else "-",
+            _display_book_translations(book),
+        )
+    console.print(table)
+    console.print(f"{LIBRARY_BACK_OPTION}. Back")
+
+
+def _prompt_library_book(books: tuple[LibraryBook, ...]) -> LibraryBook | None:
+    while True:
+        choice = typer.prompt("Choose a book", default=LIBRARY_BACK_OPTION).strip()
+        if choice == LIBRARY_BACK_OPTION:
+            console.print("Library closed.")
+            return None
+        if choice.isdigit() and 1 <= int(choice) <= len(books):
+            return books[int(choice) - 1]
+        console.print(f"[red]Invalid book.[/red] Choose 1-{len(books)} or 0.")
+
+
+def _run_guided_library_book(config: AyvuConfig, book: LibraryBook) -> None:
+    while True:
+        actions = _library_book_actions(book)
+        _print_library_book_actions(book, actions)
+        choice = typer.prompt("Choose a library action", default=LIBRARY_BACK_OPTION).strip()
+        if choice == LIBRARY_BACK_OPTION:
+            console.print("Back to library.")
+            return
+        if not choice.isdigit() or not 1 <= int(choice) <= len(actions):
+            console.print(f"[red]Invalid action.[/red] Choose 1-{len(actions)} or 0.")
+            continue
+
+        label, path = actions[int(choice) - 1]
+        if path is None:
+            _print_library_book_info(book)
+            continue
+        _open_library_book_path(path, config, label)
+        return
+
+
+def _library_book_actions(book: LibraryBook) -> list[tuple[str, Path | None]]:
+    actions: list[tuple[str, Path | None]] = []
+    if book.original_path:
+        actions.append(("Open original", book.original_path))
+    for translation in book.translations:
+        actions.append((f"Open {translation.label}", translation.path))
+    actions.append(("Show information", None))
+    return actions
+
+
+def _print_library_book_actions(book: LibraryBook, actions: list[tuple[str, Path | None]]) -> None:
+    table = Table(title=book.name)
+    table.add_column("Option")
+    table.add_column("Action")
+    for index, action in enumerate(actions, start=1):
+        table.add_row(str(index), action[0])
+    console.print(table)
+    console.print(f"{LIBRARY_BACK_OPTION}. Back")
+
+
+def _print_library_book_info(book: LibraryBook) -> None:
+    table = Table(title="Book information")
+    table.add_column("Field")
+    table.add_column("Value")
+    table.add_row("Book", book.name)
+    table.add_row("Original EPUB", str(book.original_path) if book.original_path else "-")
+    table.add_row("Translations", _display_book_translations(book))
+    table.add_row("Translation files", _display_translation_paths(book))
+    console.print(table)
+
+
+def _open_library_book_path(path: Path, config: AyvuConfig, label: str) -> None:
+    try:
+        open_library_epub(path, reader_app=config.reader_app)
+    except LibraryOpenError as exc:
+        console.print(f"[red]Could not open EPUB:[/red] {exc}")
+        console.print("Configure Reader app in Settings or install a default EPUB reader.")
+        return
+
+    console.print(f"[green]{label}:[/green] {path}")
+
+
+def _display_book_translations(book: LibraryBook) -> str:
+    if not book.translations:
+        return "-"
+    return ", ".join(translation.label for translation in book.translations)
+
+
+def _display_translation_paths(book: LibraryBook) -> str:
+    if not book.translations:
+        return "-"
+    return "\n".join(str(translation.path) for translation in book.translations)
 
 
 def _run_guided_settings(config: AyvuConfig) -> None:
@@ -810,11 +930,6 @@ def _prompt_folder_name(prompt: str, current: str) -> str:
 def _prompt_optional_text(prompt: str, current: str | None) -> str | None:
     value = typer.prompt(prompt, default=current or "").strip()
     return value or None
-
-
-def _print_guided_placeholder(name: str) -> None:
-    console.print(f"[yellow]{name} is not available yet.[/yellow]")
-    console.print("Use the command help for the current technical commands.")
 
 
 def _choose_guided_target_language(default_target: str) -> str:

--- a/src/ayvu/library.py
+++ b/src/ayvu/library.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import os
+import shlex
+import shutil
+import subprocess
+from collections import defaultdict
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+from .config import AyvuConfig
+
+
+LANGUAGE_NAMES = {
+    "de": "Alemão",
+    "en": "Inglês",
+    "es": "Espanhol",
+    "fr": "Francês",
+    "it": "Italiano",
+    "ja": "Japonês",
+    "pt": "Português",
+    "pt-br": "Português (Brasil)",
+}
+
+
+class LibraryOpenError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class LibraryTranslation:
+    path: Path
+    language: str
+
+    @property
+    def label(self) -> str:
+        return f"Traduzido - {language_display_name(self.language)}"
+
+
+@dataclass(frozen=True)
+class LibraryBook:
+    name: str
+    original_path: Path | None
+    translations: tuple[LibraryTranslation, ...]
+
+    @property
+    def has_original(self) -> bool:
+        return self.original_path is not None
+
+
+def scan_library(config: AyvuConfig) -> tuple[LibraryBook, ...]:
+    originals = _epub_files(config.original_dir)
+    translations = _epub_files(config.translated_dir)
+    original_paths = {path.stem: path for path in originals}
+    grouped_translations = _group_translations(translations, original_paths)
+
+    book_names = set(original_paths) | set(grouped_translations)
+    books = [
+        LibraryBook(
+            name=name,
+            original_path=original_paths.get(name),
+            translations=tuple(sorted(grouped_translations[name], key=_translation_sort_key)),
+        )
+        for name in book_names
+    ]
+    return tuple(sorted(books, key=lambda book: book.name.casefold()))
+
+
+def language_display_name(language: str) -> str:
+    normalized = language.strip()
+    if not normalized:
+        return "idioma desconhecido"
+    return LANGUAGE_NAMES.get(normalized.lower(), normalized)
+
+
+def open_library_epub(
+    path: Path,
+    reader_app: str | None = None,
+    runner: Callable[[list[str]], object] | None = None,
+    which: Callable[[str], str | None] | None = None,
+) -> None:
+    if not path.is_file():
+        raise LibraryOpenError(f"EPUB file was not found: {path}")
+
+    command = _reader_command(reader_app, which or shutil.which)
+    if command is None:
+        raise LibraryOpenError("No EPUB reader app is configured or available on this system.")
+
+    run = runner or subprocess.Popen
+    try:
+        run([*command, str(path)])
+    except OSError as exc:
+        raise LibraryOpenError(f"Could not open EPUB with {command[0]}: {exc}") from exc
+
+
+def _epub_files(directory: Path) -> tuple[Path, ...]:
+    if not directory.exists():
+        return ()
+    return tuple(sorted((path for path in directory.glob("*.epub") if path.is_file()), key=_path_sort_key))
+
+
+def _group_translations(
+    translations: Iterable[Path],
+    original_paths: dict[str, Path],
+) -> dict[str, list[LibraryTranslation]]:
+    grouped: dict[str, list[LibraryTranslation]] = defaultdict(list)
+    for path in translations:
+        book_name, language = _split_translation_stem(path.stem, original_paths)
+        grouped[book_name].append(LibraryTranslation(path=path, language=language))
+    return grouped
+
+
+def _split_translation_stem(stem: str, original_paths: dict[str, Path]) -> tuple[str, str]:
+    for original_stem in sorted(original_paths, key=len, reverse=True):
+        prefix = f"{original_stem}-"
+        if stem.startswith(prefix) and len(stem) > len(prefix):
+            return original_stem, stem[len(prefix) :]
+
+    return _split_stem_without_original(stem)
+
+
+def _split_stem_without_original(stem: str) -> tuple[str, str]:
+    parts = stem.split("-")
+    if len(parts) >= 3 and _looks_language_code(parts[-2]) and _looks_region_code(parts[-1]):
+        return "-".join(parts[:-2]) or stem, f"{parts[-2]}-{parts[-1]}"
+    if len(parts) >= 2:
+        return "-".join(parts[:-1]) or stem, parts[-1]
+    return stem, ""
+
+
+def _looks_language_code(value: str) -> bool:
+    return value.isalpha() and len(value) in (2, 3)
+
+
+def _looks_region_code(value: str) -> bool:
+    return value.isalpha() and len(value) == 2
+
+
+def _reader_command(reader_app: str | None, which: Callable[[str], str | None]) -> list[str] | None:
+    if reader_app:
+        try:
+            command = shlex.split(reader_app)
+        except ValueError as exc:
+            raise LibraryOpenError("Reader app command is invalid.") from exc
+        if command:
+            return command
+
+    for command in _system_reader_commands():
+        if which(command[0]):
+            return list(command)
+    return None
+
+
+def _system_reader_commands() -> tuple[tuple[str, ...], ...]:
+    if os.name == "nt":
+        return ()
+    return (("xdg-open",), ("gio", "open"), ("open",))
+
+
+def _path_sort_key(path: Path) -> str:
+    return path.stem.casefold()
+
+
+def _translation_sort_key(translation: LibraryTranslation) -> tuple[str, str]:
+    return (language_display_name(translation.language).casefold(), translation.path.name.casefold())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,6 +14,7 @@ from ayvu.cli import (
 )
 from ayvu.domain import LanguagePair, OutputPlan, TranslationOptions, UserMode
 from ayvu.epub_io import TranslationReport
+from ayvu.library import LibraryOpenError
 from ayvu.preflight import PreflightError
 from ayvu.resume import COMPLETED_STATUS, ResumeStateStore, TranslationResumeState
 from ayvu.translator import TranslatorError, TranslatorLanguage
@@ -541,15 +542,107 @@ def test_root_command_starts_guided_translation(tmp_path, monkeypatch):
     assert options.target == "pt"
 
 
-def test_root_command_shows_guided_library_placeholder(tmp_path, monkeypatch):
-    monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: tmp_path / "missing")
+def test_root_command_shows_empty_guided_library(isolated_config, tmp_path):
+    books_dir = tmp_path / "Biblioteca"
+    isolated_config.write_text(
+        json.dumps({"version": 1, "default_target_language": "pt", "books_dir": str(books_dir)}) + "\n",
+        encoding="utf-8",
+    )
 
     result = runner.invoke(app, [], input="3\n")
 
     assert result.exit_code == 0
     assert "Open library" in result.output
-    assert "Library is not available yet." in result.output
-    assert "Use the command help" in result.output
+    assert "Library has no EPUB books yet." in result.output
+    assert str(books_dir / "Original") in result.output.replace("\n", "")
+    assert str(books_dir / "Traduzidos") in result.output.replace("\n", "")
+
+
+def test_root_command_opens_library_translation(isolated_config, tmp_path, monkeypatch):
+    books_dir = tmp_path / "Biblioteca"
+    original_dir = books_dir / "Original"
+    translated_dir = books_dir / "Traduzidos"
+    original_dir.mkdir(parents=True)
+    translated_dir.mkdir()
+    (original_dir / "Book.epub").write_bytes(b"")
+    translated_path = translated_dir / "Book-pt.epub"
+    translated_path.write_bytes(b"")
+    isolated_config.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "default_target_language": "pt",
+                "books_dir": str(books_dir),
+                "reader_app": "foliate",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    opened: dict[str, object] = {}
+
+    def fake_open(path: Path, reader_app: str | None = None) -> None:
+        opened["path"] = path
+        opened["reader_app"] = reader_app
+
+    monkeypatch.setattr("ayvu.cli.open_library_epub", fake_open)
+
+    result = runner.invoke(app, [], input="3\n1\n2\n")
+
+    assert result.exit_code == 0
+    assert "Library" in result.output
+    assert "Book" in result.output
+    assert "Traduzido - Português" in result.output
+    assert "Open Traduzido - Português" in result.output
+    assert opened == {"path": translated_path, "reader_app": "foliate"}
+
+
+def test_root_command_shows_library_book_information(isolated_config, tmp_path):
+    books_dir = tmp_path / "Biblioteca"
+    original_dir = books_dir / "Original"
+    translated_dir = books_dir / "Traduzidos"
+    original_dir.mkdir(parents=True)
+    translated_dir.mkdir()
+    original_path = original_dir / "Book.epub"
+    translated_path = translated_dir / "Book-pt.epub"
+    original_path.write_bytes(b"")
+    translated_path.write_bytes(b"")
+    isolated_config.write_text(
+        json.dumps({"version": 1, "default_target_language": "pt", "books_dir": str(books_dir)}) + "\n",
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, [], input="3\n1\n3\n0\n")
+
+    assert result.exit_code == 0
+    assert "Book information" in result.output
+    assert "Original EPUB" in result.output
+    assert "Translations" in result.output
+    assert "Traduzido - Português" in result.output
+    assert "Translation files" in result.output
+
+
+def test_root_command_reports_library_open_failure(isolated_config, tmp_path, monkeypatch):
+    books_dir = tmp_path / "Biblioteca"
+    original_dir = books_dir / "Original"
+    original_dir.mkdir(parents=True)
+    (original_dir / "Book.epub").write_bytes(b"")
+    isolated_config.write_text(
+        json.dumps({"version": 1, "default_target_language": "pt", "books_dir": str(books_dir)}) + "\n",
+        encoding="utf-8",
+    )
+
+    def fail_open(_path: Path, reader_app: str | None = None) -> None:
+        raise LibraryOpenError("No EPUB reader app is configured or available on this system.")
+
+    monkeypatch.setattr("ayvu.cli.open_library_epub", fail_open)
+
+    result = runner.invoke(app, [], input="3\n1\n1\n")
+
+    assert result.exit_code == 0
+    assert "Could not open EPUB:" in result.output
+    assert "No EPUB reader app" in result.output
+    assert "Configure Reader app in Settings" in result.output
 
 
 def test_root_command_settings_keeps_language_when_not_changed(tmp_path, monkeypatch):

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -1,0 +1,88 @@
+from pathlib import Path
+
+import pytest
+
+from ayvu.config import AyvuConfig
+from ayvu.library import LibraryOpenError, open_library_epub, scan_library
+
+
+def test_scan_library_groups_originals_and_translations_by_book(tmp_path):
+    config = AyvuConfig(books_dir=tmp_path)
+    original_dir = config.original_dir
+    translated_dir = config.translated_dir
+    original_dir.mkdir(parents=True)
+    translated_dir.mkdir(parents=True)
+    (original_dir / "Beta.epub").write_bytes(b"")
+    (original_dir / "Alpha.epub").write_bytes(b"")
+    (translated_dir / "Alpha-pt.epub").write_bytes(b"")
+    (translated_dir / "Beta-es.epub").write_bytes(b"")
+    (translated_dir / "Gamma-pt-BR.epub").write_bytes(b"")
+    (translated_dir / "ignore.txt").write_text("not an epub", encoding="utf-8")
+
+    books = scan_library(config)
+
+    assert [book.name for book in books] == ["Alpha", "Beta", "Gamma"]
+    assert books[0].has_original
+    assert [translation.label for translation in books[0].translations] == ["Traduzido - Português"]
+    assert [translation.label for translation in books[1].translations] == ["Traduzido - Espanhol"]
+    assert not books[2].has_original
+    assert [translation.label for translation in books[2].translations] == ["Traduzido - Português (Brasil)"]
+
+
+def test_scan_library_returns_empty_when_configured_dirs_do_not_exist(tmp_path):
+    config = AyvuConfig(books_dir=tmp_path)
+
+    assert scan_library(config) == ()
+
+
+def test_open_library_epub_uses_configured_reader_command(tmp_path):
+    epub_path = tmp_path / "book.epub"
+    epub_path.write_bytes(b"")
+    calls: list[list[str]] = []
+
+    open_library_epub(
+        epub_path,
+        reader_app="foliate --new-window",
+        runner=calls.append,
+        which=lambda _name: None,
+    )
+
+    assert calls == [["foliate", "--new-window", str(epub_path)]]
+
+
+def test_open_library_epub_uses_detected_system_reader(tmp_path):
+    epub_path = tmp_path / "book.epub"
+    epub_path.write_bytes(b"")
+    calls: list[list[str]] = []
+
+    open_library_epub(
+        epub_path,
+        runner=calls.append,
+        which=lambda name: f"/usr/bin/{name}" if name == "xdg-open" else None,
+    )
+
+    assert calls == [["xdg-open", str(epub_path)]]
+
+
+def test_open_library_epub_requires_reader_app_or_detected_reader(tmp_path):
+    epub_path = tmp_path / "book.epub"
+    epub_path.write_bytes(b"")
+
+    with pytest.raises(LibraryOpenError, match="No EPUB reader"):
+        open_library_epub(epub_path, runner=lambda _command: None, which=lambda _name: None)
+
+
+def test_open_library_epub_reports_missing_epub(tmp_path):
+    with pytest.raises(LibraryOpenError, match="not found"):
+        open_library_epub(tmp_path / "missing.epub", runner=lambda _command: None, which=lambda _name: "xdg-open")
+
+
+def test_open_library_epub_reports_reader_failure(tmp_path):
+    epub_path = tmp_path / "book.epub"
+    epub_path.write_bytes(b"")
+
+    def fail(_command: list[str]) -> None:
+        raise OSError("broken")
+
+    with pytest.raises(LibraryOpenError, match="Could not open EPUB"):
+        open_library_epub(epub_path, reader_app="foliate", runner=fail)


### PR DESCRIPTION
## Objetivo

Criar a biblioteca inicial do Ayvu no modo comum e permitir abrir EPUBs pelo leitor configurado ou pelo padrão detectado no sistema.

## O que mudou

- Adicionado módulo de biblioteca para listar EPUBs em Original e Traduzidos.
- Agrupamento de original e traduções por livro, com traduções exibidas por idioma.
- Integração da opção Open library no menu comum.
- Abertura de original ou tradução no leitor configurado em Settings ou no abridor padrão do sistema.
- Mensagens claras quando a biblioteca está vazia ou não há leitor disponível.
- Testes unitários e de CLI para listagem, seleção, abertura, informações do livro e erros esperados.
- README e docs atualizados para refletir a biblioteca inicial.

## Fora do escopo

- Importação automática de livros para a biblioteca.
- Fila de tradução, histórico completo e integração com Calibre.
- Gerenciamento automático do LibreTranslate.

## Validação

- uv run pytest: 135 passed
- git diff --check: sem erros

Closes #44
Closes #50