### PR TITLE
Permitir configurar pasta base no primeiro uso

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,10 @@ salva por padrão em:
 ~/Documentos/Livros/Preview/livro-preview.epub
 ```
 
-No primeiro uso do modo comum, o Ayvu pergunta o idioma padrão de leitura/tradução e o
-salva na configuração. Nas próximas execuções esse idioma é usado como destino padrão
-em traduções e previews, sem perguntar de novo.
+No primeiro uso do modo comum, o Ayvu pergunta o idioma padrão de leitura/tradução e
+a pasta base dos livros, depois salva essas escolhas na configuração. Nas próximas
+execuções esse idioma é usado como destino padrão em traduções e previews, e a pasta
+base organiza biblioteca, previews, relatórios e traduções, sem perguntar de novo.
 
 Ao executar apenas `uv run ayvu`, o Ayvu abre um primeiro menu guiado com opções para traduzir
 livro, gerar preview, abrir biblioteca, acessar configurações, mostrar ajuda ou sair. A biblioteca

--- a/docs/tutorial-modo-comum-e-dev.md
+++ b/docs/tutorial-modo-comum-e-dev.md
@@ -45,6 +45,8 @@ uv run ayvu
 
 O menu permite iniciar uma tradução, gerar preview, ver ajuda, abrir biblioteca e acessar configurações. A biblioteca lista EPUBs das pastas configuradas para originais e traduções, mostra as versões disponíveis e permite abrir o arquivo escolhido no leitor configurado ou no leitor padrão detectado no sistema. As configurações permitem alterar idioma padrão, pasta base dos livros, nomes das pastas das funcionalidades e app leitor de EPUB.
 
+No primeiro uso, o Ayvu pergunta o idioma padrão de leitura/tradução e a pasta base dos livros. Essa pasta é usada para organizar biblioteca, previews, relatórios, traduções e estados de processamento.
+
 ### Gerar um preview
 
 O preview é o primeiro teste recomendado para um livro novo. Ele traduz uma amostra inicial do EPUB e preserva a estrutura do restante do arquivo.

--- a/src/ayvu/cli.py
+++ b/src/ayvu/cli.py
@@ -611,9 +611,15 @@ def _init_default_language_config(store: ConfigStore) -> AyvuConfig:
     console.print("[yellow]Primeiro uso do modo comum.[/yellow]")
     console.print("Escolha o idioma padrão de leitura/tradução. Você poderá alterá-lo depois em Settings.")
     language = _prompt_target_language_code(DEFAULT_TARGET_LANGUAGE)
-    config = AyvuConfig(default_target_language=language)
+    console.print(
+        "Escolha a pasta base dos livros. "
+        "O Ayvu usará essa pasta para biblioteca, previews, relatórios e traduções."
+    )
+    books_dir = _prompt_path("Books folder", Path(DEFAULT_BOOKS_DIR))
+    config = AyvuConfig(default_target_language=language, books_dir=books_dir)
     if _save_config(store, config):
         console.print(f"[green]Idioma padrão salvo:[/green] {language}")
+        console.print(f"[green]Pasta base salva:[/green] {books_dir}")
     return config
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -735,16 +735,19 @@ def test_root_command_settings_changes_reader_app(isolated_config, tmp_path, mon
 
 def test_root_command_first_use_asks_and_saves_default_language(isolated_config, tmp_path, monkeypatch):
     isolated_config.unlink()
+    books_dir = tmp_path / "Minha Biblioteca"
     monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: tmp_path / "missing")
     monkeypatch.setattr("ayvu.cli.LibreTranslateTranslator", FakeNoLanguagesTranslator)
 
-    result = runner.invoke(app, [], input="es\n0\n")
+    result = runner.invoke(app, [], input=f"es\n{books_dir}\n0\n")
 
     assert result.exit_code == 0
     assert "Primeiro uso do modo comum." in result.output
     assert "Idioma padrão salvo:" in result.output
+    assert "Pasta base salva:" in result.output
     saved = json.loads(isolated_config.read_text(encoding="utf-8"))
     assert saved["default_target_language"] == "es"
+    assert saved["books_dir"] == str(books_dir)
 
 
 def test_root_command_does_not_reask_when_config_exists(tmp_path, monkeypatch):


### PR DESCRIPTION
## Objetivo

Completar o fluxo da issue #43 permitindo definir a pasta base dos livros já no primeiro uso do modo comum.

## O que mudou

- O primeiro uso do modo comum agora pergunta o idioma padrão e a pasta base dos livros.
- A configuração inicial salva `default_target_language` e `books_dir` no `config.json`.
- O teste de primeiro uso valida a persistência da pasta base.
- README e tutorial foram atualizados para explicar o novo comportamento.

## Fora do escopo

- Adicionar novos argumentos de caminho no modo desenvolvedor.
- Criar importação automática de livros para a biblioteca.
- Alterar nomes das pastas internas além do fluxo já existente em Settings.

## Validação/Testes

- `uv run pytest`: 135 passed
- `git diff --check`: sem erros

Closes #43