### PR TITLE
Permitir configurar nomes de pastas no primeiro uso

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,10 +136,12 @@ salva por padrão em:
 ~/Documentos/Livros/Preview/livro-preview.epub
 ```
 
-No primeiro uso do modo comum, o Ayvu pergunta o idioma padrão de leitura/tradução e
-a pasta base dos livros, depois salva essas escolhas na configuração. Nas próximas
-execuções esse idioma é usado como destino padrão em traduções e previews, e a pasta
-base organiza biblioteca, previews, relatórios e traduções, sem perguntar de novo.
+No primeiro uso do modo comum, o Ayvu pergunta o idioma padrão de leitura/tradução,
+a pasta base dos livros e mostra os nomes das pastas das funcionalidades. Você pode
+manter os nomes padrão ou alterá-los uma única vez antes de salvar a configuração.
+Nas próximas execuções esse idioma é usado como destino padrão em traduções e
+previews, e a pasta base organiza biblioteca, previews, relatórios e traduções, sem
+perguntar de novo.
 
 Ao executar apenas `uv run ayvu`, o Ayvu abre um primeiro menu guiado com opções para traduzir
 livro, gerar preview, abrir biblioteca, acessar configurações, mostrar ajuda ou sair. A biblioteca

--- a/docs/tutorial-modo-comum-e-dev.md
+++ b/docs/tutorial-modo-comum-e-dev.md
@@ -45,7 +45,7 @@ uv run ayvu
 
 O menu permite iniciar uma tradução, gerar preview, ver ajuda, abrir biblioteca e acessar configurações. A biblioteca lista EPUBs das pastas configuradas para originais e traduções, mostra as versões disponíveis e permite abrir o arquivo escolhido no leitor configurado ou no leitor padrão detectado no sistema. As configurações permitem alterar idioma padrão, pasta base dos livros, nomes das pastas das funcionalidades e app leitor de EPUB.
 
-No primeiro uso, o Ayvu pergunta o idioma padrão de leitura/tradução e a pasta base dos livros. Essa pasta é usada para organizar biblioteca, previews, relatórios, traduções e estados de processamento.
+No primeiro uso, o Ayvu pergunta o idioma padrão de leitura/tradução e a pasta base dos livros. Em seguida, mostra os nomes das pastas das funcionalidades e permite manter os padrões ou alterá-los uma única vez antes de salvar a configuração. Essa pasta é usada para organizar biblioteca, previews, relatórios, traduções e estados de processamento.
 
 ### Gerar um preview
 

--- a/src/ayvu/cli.py
+++ b/src/ayvu/cli.py
@@ -616,11 +616,40 @@ def _init_default_language_config(store: ConfigStore) -> AyvuConfig:
         "O Ayvu usará essa pasta para biblioteca, previews, relatórios e traduções."
     )
     books_dir = _prompt_path("Books folder", Path(DEFAULT_BOOKS_DIR))
-    config = AyvuConfig(default_target_language=language, books_dir=books_dir)
+    folders = _choose_initial_folder_names(books_dir)
+    config = AyvuConfig(
+        default_target_language=language,
+        books_dir=books_dir,
+        folders=folders,
+    )
     if _save_config(store, config):
         console.print(f"[green]Idioma padrão salvo:[/green] {language}")
         console.print(f"[green]Pasta base salva:[/green] {books_dir}")
     return config
+
+
+def _choose_initial_folder_names(books_dir: Path) -> FolderNames:
+    config = AyvuConfig(books_dir=books_dir)
+    console.print("O Ayvu usará estes nomes de pastas por padrão:")
+    _print_feature_folder_paths(config)
+    if typer.confirm("Manter estes nomes de pastas?", default=True):
+        return config.folders
+
+    updated = _settings_with_folder_names(config)
+    _print_feature_folder_paths(updated)
+    return updated.folders
+
+
+def _print_feature_folder_paths(config: AyvuConfig) -> None:
+    table = Table(title="Feature folders")
+    table.add_column("Feature")
+    table.add_column("Folder")
+    table.add_row("Original books", str(config.original_dir))
+    table.add_row("Translated books", str(config.translated_dir))
+    table.add_row("Previews", str(config.preview_dir))
+    table.add_row("Reports", str(config.reports_dir))
+    table.add_row("Processing states", str(config.processing_dir))
+    console.print(table)
 
 
 def _save_config(store: ConfigStore, config: AyvuConfig) -> bool:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -739,15 +739,47 @@ def test_root_command_first_use_asks_and_saves_default_language(isolated_config,
     monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: tmp_path / "missing")
     monkeypatch.setattr("ayvu.cli.LibreTranslateTranslator", FakeNoLanguagesTranslator)
 
-    result = runner.invoke(app, [], input=f"es\n{books_dir}\n0\n")
+    result = runner.invoke(app, [], input=f"es\n{books_dir}\ny\n0\n")
 
     assert result.exit_code == 0
     assert "Primeiro uso do modo comum." in result.output
     assert "Idioma padrão salvo:" in result.output
     assert "Pasta base salva:" in result.output
+    assert "Manter estes nomes de pastas?" in result.output
     saved = json.loads(isolated_config.read_text(encoding="utf-8"))
     assert saved["default_target_language"] == "es"
     assert saved["books_dir"] == str(books_dir)
+    assert saved["folders"] == {
+        "original": "Original",
+        "translated": "Traduzidos",
+        "preview": "Preview",
+        "reports": "Relatorios",
+        "processing": "Processando",
+    }
+
+
+def test_root_command_first_use_can_change_feature_folder_names(isolated_config, tmp_path, monkeypatch):
+    isolated_config.unlink()
+    books_dir = tmp_path / "Minha Biblioteca"
+    monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: tmp_path / "missing")
+    monkeypatch.setattr("ayvu.cli.LibreTranslateTranslator", FakeNoLanguagesTranslator)
+
+    result = runner.invoke(
+        app,
+        [],
+        input=f"es\n{books_dir}\nn\nOriginais\nPT\nAmostras\nRelatorios-MD\nEm-Andamento\n0\n",
+    )
+
+    assert result.exit_code == 0
+    assert "Feature folders" in result.output
+    saved = json.loads(isolated_config.read_text(encoding="utf-8"))
+    assert saved["folders"] == {
+        "original": "Originais",
+        "translated": "PT",
+        "preview": "Amostras",
+        "reports": "Relatorios-MD",
+        "processing": "Em-Andamento",
+    }
 
 
 def test_root_command_does_not_reask_when_config_exists(tmp_path, monkeypatch):
@@ -757,6 +789,7 @@ def test_root_command_does_not_reask_when_config_exists(tmp_path, monkeypatch):
 
     assert result.exit_code == 0
     assert "Primeiro uso do modo comum." not in result.output
+    assert "Manter estes nomes de pastas?" not in result.output
     assert "Choose an option" in result.output
 
 


### PR DESCRIPTION
## Objetivo

Concluir a issue #48 permitindo revisar e alterar os nomes das pastas das funcionalidades durante o primeiro uso do modo comum.

## O que mudou

- O primeiro uso agora mostra os caminhos das pastas derivadas da pasta base dos livros.
- O usuário pode manter os nomes padrão ou configurar `Original`, `Traduzidos`, `Preview`, `Relatorios` e `Processando` antes de salvar.
- A configuração inicial persiste os nomes das pastas no `config.json`.
- O fluxo não pergunta novamente quando a configuração já existe.
- README e tutorial foram atualizados.

## Fora do escopo

- Criar novas funcionalidades de biblioteca ou importação automática.
- Alterar o fluxo de Settings já existente para mudanças posteriores.
- Adicionar novos argumentos de CLI para nomes de pastas.

## Validação/Testes

- `uv run pytest`: 136 passed
- `git diff --check`: sem erros

Closes #48