### PR TITLE
Detectar idioma do EPUB quando --source nao for informado

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,12 +116,16 @@ Traduzir um EPUB:
 
 ```bash
 uv run ayvu translate livro.epub \
-  --source en \
   --target pt \
   --translator libretranslate \
   --url http://localhost:5000 \
   --cache .cache/traducoes.sqlite
 ```
+
+Se `--source` não for informado, o Ayvu lê o idioma do EPUB nos metadados, exibe o
+plano da tradução (`From`/`To`) antes de começar e usa o idioma detectado como
+origem. Quando o metadado estiver ausente ou inválido, o Ayvu avisa e usa `en`
+como padrão; informe `--source` para escolher outro idioma de origem.
 
 Gerar um preview traduzido:
 

--- a/src/ayvu/cli.py
+++ b/src/ayvu/cli.py
@@ -20,7 +20,7 @@ from .domain import (
     default_preview_books_dir,
     default_translated_books_dir,
 )
-from .epub_io import TranslationReport, extract_markdown, inspect_epub, translate_epub
+from .epub_io import TranslationReport, detect_epub_language, extract_markdown, inspect_epub, translate_epub
 from .library import LibraryBook, LibraryOpenError, open_library_epub, scan_library
 from .preflight import PreflightError, run_translation_preflight
 from .resume import (
@@ -186,7 +186,11 @@ def translate(
         "-o",
         help="Output EPUB path. Defaults to <input-stem>-<target>.epub.",
     ),
-    source: str = typer.Option(DEFAULT_SOURCE_LANGUAGE, "--source", help="Source language."),
+    source: Optional[str] = typer.Option(
+        None,
+        "--source",
+        help="Source language. If omitted, Ayvu reads the language metadata from the EPUB.",
+    ),
     target: str = typer.Option(DEFAULT_TARGET_LANGUAGE, "--target", help="Target language."),
     translator_name: str = typer.Option("libretranslate", "--translator", help="Translator backend."),
     url: str = typer.Option(DEFAULT_TRANSLATOR_URL, "--url", help="Translator base URL."),
@@ -238,10 +242,52 @@ def _print_epub_read_error(detail: str, mode: UserMode) -> None:
     )
 
 
+def _resolve_source_language(
+    explicit_source: str | None,
+    epub_path: Path,
+    mode: UserMode,
+) -> tuple[str, bool]:
+    if explicit_source is not None and explicit_source.strip():
+        return explicit_source.strip(), False
+
+    try:
+        detected = detect_epub_language(epub_path)
+    except Exception:
+        return DEFAULT_SOURCE_LANGUAGE, True
+
+    if detected is None:
+        console.print(
+            "[yellow]Idioma do EPUB ausente ou inválido nos metadados.[/yellow] "
+            f"Usando '{DEFAULT_SOURCE_LANGUAGE}' como padrão. "
+            "Use --source para escolher outro idioma de origem."
+        )
+        return DEFAULT_SOURCE_LANGUAGE, True
+
+    return detected, True
+
+
+def _print_translation_plan(
+    language_pair: LanguagePair,
+    source_inferred: bool,
+    mode: UserMode,
+) -> None:
+    table = Table(title="Translation plan")
+    table.add_column("Field")
+    table.add_column("Value")
+    source_value = language_pair.source
+    if source_inferred and mode == UserMode.DEVELOPER:
+        source_value = f"{language_pair.source} (inferido do EPUB)"
+    table.add_row("From", source_value)
+    table.add_row("To", language_pair.target)
+    console.print(table)
+    if source_inferred and mode == UserMode.COMMON:
+        console.print(f"[dim]Idioma de origem detectado do EPUB: {language_pair.source}[/dim]")
+
+
 def _run_translation(
     epub_path: Path,
     output: Path | None,
-    source: str,
+    source: str | None,
     target: str,
     translator_name: str,
     url: str,
@@ -257,7 +303,9 @@ def _run_translation(
     config: AyvuConfig | None = None,
 ) -> None:
     config = config or _load_existing_config_or_default()
-    language_pair = LanguagePair(source=source, target=target)
+    resolved_source, source_inferred = _resolve_source_language(source, epub_path, mode=mode)
+    language_pair = LanguagePair(source=resolved_source, target=target)
+    _print_translation_plan(language_pair, source_inferred=source_inferred, mode=mode)
     translation_options = TranslationOptions(
         language_pair=language_pair,
         dry_run=dry_run,
@@ -711,7 +759,7 @@ def _run_guided_translation(config: AyvuConfig) -> None:
     _run_translation(
         epub_path=epub_path,
         output=None,
-        source=DEFAULT_SOURCE_LANGUAGE,
+        source=None,
         target=target,
         translator_name="libretranslate",
         url=DEFAULT_TRANSLATOR_URL,

--- a/src/ayvu/epub_io.py
+++ b/src/ayvu/epub_io.py
@@ -112,6 +112,23 @@ def inspect_epub(path: str | Path) -> EpubInfo:
     )
 
 
+def normalize_language_code(raw: str | None) -> str | None:
+    if raw is None:
+        return None
+    cleaned = raw.strip()
+    if not cleaned:
+        return None
+    primary = cleaned.split("-", 1)[0].split("_", 1)[0].lower()
+    if not primary.isalpha() or not 2 <= len(primary) <= 3:
+        return None
+    return primary
+
+
+def detect_epub_language(path: str | Path) -> str | None:
+    info = inspect_epub(path)
+    return normalize_language_code(info.language)
+
+
 def translate_epub(
     input_path: str | Path,
     output_path: str | Path,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+from ebooklib import epub
 from typer.testing import CliRunner
 
 from ayvu.cli import (
@@ -1497,3 +1498,96 @@ def test_extract_command_reports_invalid_epub_without_traceback(tmp_path):
     assert "Não foi possível ler o EPUB informado." in result.output
     assert "Confirme que o arquivo é um EPUB válido e legível" in result.output
     assert "Traceback" not in result.output
+
+
+def _mock_translation_pipeline(monkeypatch, calls: dict[str, object]) -> None:
+    def fake_preflight(**kwargs: object) -> object:
+        calls["preflight"] = kwargs
+        return SimpleNamespace(translator=object(), glossary=None)
+
+    def fake_translate(input_path: Path, output_path: Path, **kwargs: object) -> TranslationReport:
+        calls["options"] = kwargs["options"]
+        return TranslationReport(
+            output_path=output_path,
+            input_path=input_path,
+            detected_language=kwargs["options"].source,
+            target_language=kwargs["options"].target,
+        )
+
+    monkeypatch.setattr("ayvu.cli.run_translation_preflight", fake_preflight)
+    monkeypatch.setattr("ayvu.cli.TranslationCache", lambda _path: FakeCache())
+    monkeypatch.setattr("ayvu.cli.translate_epub", fake_translate)
+    monkeypatch.setattr(
+        "ayvu.cli.validate_output_epub",
+        lambda _path, on_progress=None: ValidationResult(ok=True, document_count=1),
+    )
+    monkeypatch.setattr("ayvu.cli._offer_markdown_report", lambda *_args, **_kwargs: None)
+
+
+def test_translate_auto_detects_source_language_from_epub(minimal_epub_path, tmp_path, monkeypatch):
+    monkeypatch.setattr("ayvu.cli.default_translated_books_dir", lambda: tmp_path / "Traduzidos")
+    calls: dict[str, object] = {}
+    _mock_translation_pipeline(monkeypatch, calls)
+
+    result = runner.invoke(app, ["--mode", "developer", "translate", str(minimal_epub_path)])
+
+    assert result.exit_code == 0
+    assert calls["options"].source == "en"
+    assert "Translation plan" in result.output
+    assert "inferido do EPUB" in result.output
+
+
+def test_translate_explicit_source_overrides_epub_metadata(minimal_epub_path, tmp_path, monkeypatch):
+    monkeypatch.setattr("ayvu.cli.default_translated_books_dir", lambda: tmp_path / "Traduzidos")
+    calls: dict[str, object] = {}
+    _mock_translation_pipeline(monkeypatch, calls)
+
+    result = runner.invoke(
+        app,
+        ["--mode", "developer", "translate", str(minimal_epub_path), "--source", "fr"],
+    )
+
+    assert result.exit_code == 0
+    assert calls["options"].source == "fr"
+    assert "inferido do EPUB" not in result.output
+
+
+def test_translate_warns_when_epub_language_metadata_is_missing(tmp_path, monkeypatch):
+    epub_path = tmp_path / "no-lang.epub"
+    book = epub.EpubBook()
+    book.set_identifier("ayvu-no-lang")
+    book.set_title("No Language")
+    book.add_author("Ayvu Tests")
+    chapter = epub.EpubHtml(title="Ch", file_name="text/ch.xhtml")
+    chapter.content = "<h1>Title</h1><p>Body.</p>"
+    book.add_item(chapter)
+    book.add_item(epub.EpubNcx())
+    book.add_item(epub.EpubNav())
+    book.spine = ["nav", chapter]
+    epub.write_epub(str(epub_path), book)
+
+    monkeypatch.setattr("ayvu.cli.default_translated_books_dir", lambda: tmp_path / "Traduzidos")
+    calls: dict[str, object] = {}
+    _mock_translation_pipeline(monkeypatch, calls)
+
+    result = runner.invoke(app, ["--mode", "developer", "translate", str(epub_path)])
+
+    assert result.exit_code == 0
+    assert "Idioma do EPUB ausente ou inválido" in result.output
+    assert calls["options"].source == "en"
+
+
+def test_translate_common_mode_shows_detected_source_hint(minimal_epub_path, tmp_path, monkeypatch):
+    monkeypatch.setattr("ayvu.cli.default_translated_books_dir", lambda: tmp_path / "Traduzidos")
+    calls: dict[str, object] = {}
+    _mock_translation_pipeline(monkeypatch, calls)
+
+    result = runner.invoke(
+        app,
+        ["--mode", "common", "translate", str(minimal_epub_path)],
+        input="y\n",
+    )
+
+    assert result.exit_code == 0
+    assert "Translation plan" in result.output
+    assert "Idioma de origem detectado do EPUB: en" in result.output

--- a/tests/test_epub_io.py
+++ b/tests/test_epub_io.py
@@ -12,8 +12,10 @@ from ayvu.epub_io import (
     TranslationReport,
     _document_entries,
     _document_zip_path,
+    detect_epub_language,
     extract_markdown,
     inspect_epub,
+    normalize_language_code,
     translate_epub,
 )
 
@@ -171,6 +173,26 @@ def test_translate_epub_translates_minimal_generated_epub_without_mutating_input
     assert "PT:chapter two" in chapter
     assert "chapter2.xhtml#answer" in chapter
     assert "../images/pixel.png" in chapter
+
+
+def test_normalize_language_code_extracts_primary_subtag_from_bcp47():
+    assert normalize_language_code("pt-BR") == "pt"
+    assert normalize_language_code("en_US") == "en"
+    assert normalize_language_code("EN") == "en"
+    assert normalize_language_code("  fr ") == "fr"
+
+
+def test_normalize_language_code_rejects_empty_or_invalid_values():
+    assert normalize_language_code(None) is None
+    assert normalize_language_code("") is None
+    assert normalize_language_code("   ") is None
+    assert normalize_language_code("english") is None
+    assert normalize_language_code("12") is None
+    assert normalize_language_code("e n") is None
+
+
+def test_detect_epub_language_returns_normalized_metadata(minimal_epub_path: Path):
+    assert detect_epub_language(minimal_epub_path) == "en"
 
 
 def test_translate_epub_limits_documents_for_preview(minimal_epub_path: Path, tmp_path: Path):


### PR DESCRIPTION
## Objetivo

Detectar o idioma de origem do EPUB pelo metadado `dc:language` quando o usuario nao informa `--source`, e exibir claramente o plano da traducao (origem/destino) antes de iniciar.

Closes #68

## O que mudou

- `src/ayvu/epub_io.py`: novas funcoes `normalize_language_code` (extrai subtag primario BCP47, lowercase, descarta valores duvidosos) e `detect_epub_language` (wrapper sobre `inspect_epub`).
- `src/ayvu/cli.py`:
  - `--source` passa a ser opcional em `translate`; quando omitido, o Ayvu detecta o idioma pelo EPUB.
  - Nova `_resolve_source_language` retorna `(codigo, foi_inferido)`. Se o metadado faltar/for invalido, avisa em amarelo e cai em `en`. Se a leitura do EPUB falhar, retorna default silenciosamente para deixar o preflight surfacing o erro real.
  - Nova `_print_translation_plan` exibe tabela `Translation plan` com `From`/`To`. Modo dev marca `(inferido do EPUB)`; modo comum adiciona hint discreto com o idioma detectado.
  - `_run_guided_translation` passa `source=None` para usar a auto-deteccao.
- `README.md`: exemplo de `translate` sem `--source` e explicacao do comportamento.

## Fora do escopo

- Preview (`--preview`) continua usando `en` como source default. Pode ser estendido em issue separada.
- `test-translator` mantem `--source en` como default por nao operar sobre EPUB.

## Validacao

- `uv run pytest`: 143 testes passando.
- Testes novos:
  - `tests/test_epub_io.py`: normalizacao (`pt-BR` -> `pt`, `EN` -> `en`, vazio/garbage -> None) e deteccao no EPUB minimo.
  - `tests/test_cli.py`: auto-deteccao no modo dev, override por `--source`, aviso quando metadado de idioma esta ausente, e hint do idioma detectado no modo comum.

## Teste manual sugerido

```bash
uv run ayvu --mode developer translate caminho/para/livro.epub --target pt
```

Espera-se ver a tabela `Translation plan` com `From: <codigo> (inferido do EPUB)` e `To: pt` antes da barra de progresso.