### PR TITLE
Validar rota de traducao e permitir idioma intermediario

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ No modo desenvolvedor, o idioma de destino continua sendo definido por `--target
 
 Antes de iniciar a tradução, o Ayvu verifica internamente o par de idiomas, o glossário, o cache, o EPUB de entrada e, em traduções reais, o tradutor configurado. Se algo impedir a execução, o comando falha cedo com uma mensagem curta e um próximo passo.
 
+O Ayvu também resolve a rota de tradução consultando os idiomas do LibreTranslate: se não houver caminho direto entre origem e destino, tenta uma rota intermediária via inglês (por exemplo `fr -> en -> pt`). Quando a rota intermediária é usada, o modo comum avisa que a tradução passará por 2 etapas e que a qualidade pode ficar comprometida; o modo desenvolvedor mostra a rota explicitamente. Se nenhuma rota estiver disponível, o comando falha antes de processar o EPUB.
+
 Sem `--output`, o Ayvu salva por padrão em:
 
 ```text

--- a/src/ayvu/cli.py
+++ b/src/ayvu/cli.py
@@ -31,7 +31,7 @@ from .resume import (
     TranslationResumeState,
     default_processing_dir,
 )
-from .translator import LibreTranslateTranslator, TranslatorError, TranslatorLanguage
+from .translator import LibreTranslateTranslator, TranslationRoute, TranslatorError, TranslatorLanguage
 from .validation import validate_output_epub
 
 
@@ -284,6 +284,20 @@ def _print_translation_plan(
         console.print(f"[dim]Idioma de origem detectado do EPUB: {language_pair.source}[/dim]")
 
 
+def _print_translation_route(route: TranslationRoute | None, mode: UserMode) -> None:
+    if route is None:
+        return
+    if mode == UserMode.DEVELOPER:
+        console.print(f"[cyan]Route:[/cyan] {route.describe()}")
+    if route.is_direct:
+        return
+    if mode == UserMode.COMMON:
+        console.print(f"[yellow]A tradução passará por 2 etapas ({route.describe()}).[/yellow]")
+        console.print("[yellow]A qualidade pode ficar comprometida por causa do idioma intermediário.[/yellow]")
+    else:
+        console.print("[yellow]Rota intermediária em uso. A qualidade pode ficar comprometida.[/yellow]")
+
+
 def _run_translation(
     epub_path: Path,
     output: Path | None,
@@ -338,6 +352,8 @@ def _run_translation(
     except PreflightError as exc:
         _print_expected_error(exc.summary, exc.next_step, mode, detail=exc.detail)
         raise typer.Exit(code=1) from exc
+
+    _print_translation_route(preflight.route, mode=mode)
 
     resume_store: ResumeStateStore | None = None
     resume_state: TranslationResumeState | None = None
@@ -458,6 +474,8 @@ def _run_preview(
     except PreflightError as exc:
         _print_expected_error(exc.summary, exc.next_step, mode, detail=exc.detail)
         raise typer.Exit(code=1) from exc
+
+    _print_translation_route(preflight.route, mode=mode)
 
     with Progress(
         SpinnerColumn(),

--- a/src/ayvu/preflight.py
+++ b/src/ayvu/preflight.py
@@ -8,7 +8,16 @@ from .cache import TranslationCache
 from .domain import LanguagePair, LanguagePairError
 from .epub_io import inspect_epub
 from .glossary import Glossary, GlossaryError, load_glossary
-from .translator import Translator, TranslatorError, create_translator
+from .translator import (
+    RouteResolutionError,
+    RoutedTranslator,
+    TranslationRoute,
+    Translator,
+    TranslatorError,
+    TranslatorLanguage,
+    create_translator,
+    resolve_translation_route,
+)
 
 
 class PreflightError(RuntimeError):
@@ -23,6 +32,7 @@ class PreflightError(RuntimeError):
 class TranslationPreflightResult:
     translator: Translator
     glossary: Glossary
+    route: TranslationRoute | None = None
 
 
 def run_translation_preflight(
@@ -41,9 +51,12 @@ def run_translation_preflight(
     translator = _create_checked_translator(translator_name, url, timeout, retries)
     _check_cache(cache_path)
     _check_epub(epub_path)
+    route: TranslationRoute | None = None
     if not dry_run:
-        _check_translator(translator, language_pair, url)
-    return TranslationPreflightResult(translator=translator, glossary=glossary)
+        route = _resolve_route_or_fallback(translator, language_pair, url)
+        if route is not None and not route.is_direct:
+            translator = RoutedTranslator(translator, route)
+    return TranslationPreflightResult(translator=translator, glossary=glossary, route=route)
 
 
 def _check_language_pair(language_pair: LanguagePair) -> None:
@@ -102,7 +115,50 @@ def _check_epub(epub_path: Path) -> None:
         ) from exc
 
 
-def _check_translator(translator: Translator, language_pair: LanguagePair, url: str) -> None:
+def _resolve_route_or_fallback(
+    translator: Translator,
+    language_pair: LanguagePair,
+    url: str,
+) -> TranslationRoute | None:
+    languages = _list_translator_languages(translator, url)
+    if languages is None:
+        return _probe_translator_pair(translator, language_pair, url)
+
+    try:
+        return resolve_translation_route(languages, language_pair.source, language_pair.target)
+    except RouteResolutionError as exc:
+        raise PreflightError(
+            "O par de idiomas não está disponível no tradutor.",
+            (
+                "Confirme em 'ayvu languages' os idiomas instalados, escolha outro --target, "
+                "ou instale o idioma necessário no LibreTranslate."
+            ),
+            detail=str(exc),
+        ) from exc
+
+
+def _list_translator_languages(
+    translator: Translator,
+    url: str,
+) -> tuple[TranslatorLanguage, ...] | None:
+    lister = getattr(translator, "list_languages", None)
+    if lister is None:
+        return None
+    try:
+        return lister()
+    except TranslatorError as exc:
+        raise PreflightError(
+            "O tradutor não respondeu.",
+            f"Inicie o LibreTranslate em {url}, verifique --url e confirme que o servidor está acessível.",
+            detail=str(exc),
+        ) from exc
+
+
+def _probe_translator_pair(
+    translator: Translator,
+    language_pair: LanguagePair,
+    url: str,
+) -> TranslationRoute:
     try:
         translator.translate("Hello world", language_pair.source, language_pair.target)
     except Exception as exc:
@@ -111,3 +167,4 @@ def _check_translator(translator: Translator, language_pair: LanguagePair, url: 
             f"Inicie o LibreTranslate em {url}, verifique --url e confirme que o par de idiomas está disponível.",
             detail=str(exc),
         ) from exc
+    return TranslationRoute(source=language_pair.source, target=language_pair.target)

--- a/src/ayvu/translator.py
+++ b/src/ayvu/translator.py
@@ -19,6 +19,10 @@ class UnsupportedTranslatorError(TranslatorError):
     pass
 
 
+class RouteResolutionError(TranslatorError):
+    pass
+
+
 @dataclass(frozen=True)
 class TranslatorLanguage:
     code: str
@@ -27,10 +31,78 @@ class TranslatorLanguage:
     state: str = "installed"
 
 
+@dataclass(frozen=True)
+class TranslationRoute:
+    source: str
+    target: str
+    intermediate: str | None = None
+
+    @property
+    def is_direct(self) -> bool:
+        return self.intermediate is None
+
+    def describe(self) -> str:
+        if self.intermediate is None:
+            return f"{self.source} -> {self.target}"
+        return f"{self.source} -> {self.intermediate} -> {self.target}"
+
+
 class Translator(ABC):
     @abstractmethod
     def translate(self, text: str, source: str, target: str) -> str:
         raise NotImplementedError
+
+
+def resolve_translation_route(
+    languages: tuple[TranslatorLanguage, ...],
+    source: str,
+    target: str,
+    intermediate_candidates: tuple[str, ...] = ("en",),
+) -> TranslationRoute:
+    if source == target:
+        return TranslationRoute(source=source, target=target)
+
+    by_code = {language.code: language for language in languages}
+
+    source_lang = by_code.get(source)
+    if source_lang is not None and target in source_lang.targets:
+        return TranslationRoute(source=source, target=target)
+
+    for bridge in intermediate_candidates:
+        if bridge in (source, target):
+            continue
+        bridge_lang = by_code.get(bridge)
+        if bridge_lang is None or target not in bridge_lang.targets:
+            continue
+        if source_lang is None or bridge not in source_lang.targets:
+            continue
+        return TranslationRoute(source=source, target=target, intermediate=bridge)
+
+    raise RouteResolutionError(
+        f"No translation route available from '{source}' to '{target}'."
+    )
+
+
+class RoutedTranslator(Translator):
+    def __init__(self, base: Translator, route: TranslationRoute) -> None:
+        self._base = base
+        self._route = route
+
+    @property
+    def route(self) -> TranslationRoute:
+        return self._route
+
+    def translate(self, text: str, source: str, target: str) -> str:
+        if (
+            self._route.is_direct
+            or source != self._route.source
+            or target != self._route.target
+        ):
+            return self._base.translate(text, source, target)
+        intermediate = self._route.intermediate
+        assert intermediate is not None
+        first = self._base.translate(text, source, intermediate)
+        return self._base.translate(first, intermediate, target)
 
 
 class HttpSession(Protocol):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -324,7 +324,7 @@ def test_root_command_resumes_detected_translation_when_confirmed(tmp_path, monk
 
     def fake_preflight(**kwargs: object) -> object:
         calls["preflight"] = kwargs
-        return SimpleNamespace(translator=object(), glossary=None)
+        return SimpleNamespace(translator=object(), glossary=None, route=None)
 
     def fake_translate(*_args: object, **kwargs: object) -> TranslationReport:
         calls["translation_options"] = kwargs["options"]
@@ -432,7 +432,7 @@ def test_root_command_generates_guided_preview_when_confirmed(tmp_path, monkeypa
     )
     monkeypatch.setattr(
         "ayvu.cli.run_translation_preflight",
-        lambda **_kwargs: SimpleNamespace(translator=object(), glossary=None),
+        lambda **_kwargs: SimpleNamespace(translator=object(), glossary=None, route=None),
     )
     monkeypatch.setattr("ayvu.cli.TranslationCache", lambda _path: FakeCache())
     monkeypatch.setattr("ayvu.cli.translate_epub", fake_translate)
@@ -476,7 +476,7 @@ def test_root_command_allows_guided_preview_target_from_languages(tmp_path, monk
 
     def fake_preflight(**kwargs: object) -> object:
         calls["target"] = kwargs["language_pair"].target
-        return SimpleNamespace(translator=object(), glossary=None)
+        return SimpleNamespace(translator=object(), glossary=None, route=None)
 
     def fake_translate(_input_path: Path, _output_path: Path, **kwargs: object) -> TranslationReport:
         calls["options"] = kwargs["options"]
@@ -522,7 +522,7 @@ def test_root_command_starts_guided_translation(tmp_path, monkeypatch):
     monkeypatch.setattr("ayvu.cli.default_translated_books_dir", lambda: output_dir)
     monkeypatch.setattr(
         "ayvu.cli.run_translation_preflight",
-        lambda **_kwargs: SimpleNamespace(translator=object(), glossary=None),
+        lambda **_kwargs: SimpleNamespace(translator=object(), glossary=None, route=None),
     )
     monkeypatch.setattr("ayvu.cli.TranslationCache", lambda _path: FakeCache())
     monkeypatch.setattr("ayvu.cli.translate_epub", fake_translate)
@@ -806,7 +806,7 @@ def test_root_command_uses_saved_default_language_in_guided_preview(isolated_con
 
     def fake_preflight(**kwargs: object) -> object:
         calls["target"] = kwargs["language_pair"].target
-        return SimpleNamespace(translator=object(), glossary=None)
+        return SimpleNamespace(translator=object(), glossary=None, route=None)
 
     def fake_translate(_input_path: Path, _output_path: Path, **kwargs: object) -> TranslationReport:
         calls["options"] = kwargs["options"]
@@ -857,7 +857,7 @@ def test_preview_option_generates_preview_with_default_settings(tmp_path, monkey
 
     def fake_preflight(**kwargs: object) -> object:
         calls["preflight"] = kwargs
-        return SimpleNamespace(translator=object(), glossary=None)
+        return SimpleNamespace(translator=object(), glossary=None, route=None)
 
     def fake_translate(input_path: Path, output_path: Path, **kwargs: object) -> TranslationReport:
         calls["input_path"] = input_path
@@ -917,7 +917,7 @@ def test_preview_option_uses_configured_preview_dir(isolated_config, tmp_path, m
 
     monkeypatch.setattr(
         "ayvu.cli.run_translation_preflight",
-        lambda **_kwargs: SimpleNamespace(translator=object(), glossary=None),
+        lambda **_kwargs: SimpleNamespace(translator=object(), glossary=None, route=None),
     )
     monkeypatch.setattr("ayvu.cli.TranslationCache", lambda _path: FakeCache())
     monkeypatch.setattr("ayvu.cli.translate_epub", fake_translate)
@@ -983,7 +983,7 @@ def test_translate_command_confirms_default_output_location(tmp_path, monkeypatc
     monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: processing_dir)
     monkeypatch.setattr(
         "ayvu.cli.run_translation_preflight",
-        lambda **_kwargs: SimpleNamespace(translator=object(), glossary=None),
+        lambda **_kwargs: SimpleNamespace(translator=object(), glossary=None, route=None),
     )
     monkeypatch.setattr("ayvu.cli.TranslationCache", lambda _path: FakeCache())
     monkeypatch.setattr("ayvu.cli.translate_epub", fake_translate)
@@ -1035,7 +1035,7 @@ def test_translate_command_uses_configured_output_and_processing_dirs(isolated_c
 
     monkeypatch.setattr(
         "ayvu.cli.run_translation_preflight",
-        lambda **_kwargs: SimpleNamespace(translator=object(), glossary=None),
+        lambda **_kwargs: SimpleNamespace(translator=object(), glossary=None, route=None),
     )
     monkeypatch.setattr("ayvu.cli.TranslationCache", lambda _path: FakeCache())
     monkeypatch.setattr("ayvu.cli.translate_epub", fake_translate)
@@ -1074,7 +1074,7 @@ def test_translate_command_allows_custom_output_path_from_default_prompt(tmp_pat
     monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: processing_dir)
     monkeypatch.setattr(
         "ayvu.cli.run_translation_preflight",
-        lambda **_kwargs: SimpleNamespace(translator=object(), glossary=None),
+        lambda **_kwargs: SimpleNamespace(translator=object(), glossary=None, route=None),
     )
     monkeypatch.setattr("ayvu.cli.TranslationCache", lambda _path: FakeCache())
     monkeypatch.setattr("ayvu.cli.translate_epub", fake_translate)
@@ -1127,7 +1127,7 @@ def test_translate_command_allows_another_name_when_output_exists(tmp_path, monk
     monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: processing_dir)
     monkeypatch.setattr(
         "ayvu.cli.run_translation_preflight",
-        lambda **_kwargs: SimpleNamespace(translator=object(), glossary=None),
+        lambda **_kwargs: SimpleNamespace(translator=object(), glossary=None, route=None),
     )
     monkeypatch.setattr("ayvu.cli.TranslationCache", lambda _path: FakeCache())
     monkeypatch.setattr("ayvu.cli.translate_epub", fake_translate)
@@ -1320,7 +1320,7 @@ def test_translate_command_offers_and_saves_markdown_report(tmp_path, monkeypatc
     )
     monkeypatch.setattr(
         "ayvu.cli.run_translation_preflight",
-        lambda **_kwargs: SimpleNamespace(translator=object(), glossary=None),
+        lambda **_kwargs: SimpleNamespace(translator=object(), glossary=None, route=None),
     )
     monkeypatch.setattr("ayvu.cli.TranslationCache", lambda _path: FakeCache())
     monkeypatch.setattr("ayvu.cli.translate_epub", lambda *_args, **_kwargs: report)
@@ -1371,7 +1371,7 @@ def test_translate_command_puts_validation_warnings_in_report_and_markdown(tmp_p
     warning = "Capítulo sem texto visível: text/empty.xhtml"
     monkeypatch.setattr(
         "ayvu.cli.run_translation_preflight",
-        lambda **_kwargs: SimpleNamespace(translator=object(), glossary=None),
+        lambda **_kwargs: SimpleNamespace(translator=object(), glossary=None, route=None),
     )
     monkeypatch.setattr("ayvu.cli.TranslationCache", lambda _path: FakeCache())
     monkeypatch.setattr("ayvu.cli.translate_epub", lambda *_args, **_kwargs: report)
@@ -1414,7 +1414,7 @@ def test_translate_command_handles_keyboard_interrupt_cleanly(tmp_path, monkeypa
 
     monkeypatch.setattr(
         "ayvu.cli.run_translation_preflight",
-        lambda **_kwargs: SimpleNamespace(translator=object(), glossary=None),
+        lambda **_kwargs: SimpleNamespace(translator=object(), glossary=None, route=None),
     )
     monkeypatch.setattr("ayvu.cli.TranslationCache", lambda _path: FakeCache())
     monkeypatch.setattr("ayvu.cli.translate_epub", interrupt_translation)
@@ -1503,7 +1503,7 @@ def test_extract_command_reports_invalid_epub_without_traceback(tmp_path):
 def _mock_translation_pipeline(monkeypatch, calls: dict[str, object]) -> None:
     def fake_preflight(**kwargs: object) -> object:
         calls["preflight"] = kwargs
-        return SimpleNamespace(translator=object(), glossary=None)
+        return SimpleNamespace(translator=object(), glossary=None, route=None)
 
     def fake_translate(input_path: Path, output_path: Path, **kwargs: object) -> TranslationReport:
         calls["options"] = kwargs["options"]
@@ -1591,3 +1591,82 @@ def test_translate_common_mode_shows_detected_source_hint(minimal_epub_path, tmp
     assert result.exit_code == 0
     assert "Translation plan" in result.output
     assert "Idioma de origem detectado do EPUB: en" in result.output
+
+
+def _mock_pipeline_with_route(monkeypatch, route):
+    from ayvu.epub_io import TranslationReport as _Report
+
+    def fake_preflight(**_kwargs: object) -> object:
+        return SimpleNamespace(translator=object(), glossary=None, route=route)
+
+    def fake_translate(input_path, output_path, **kwargs) -> _Report:
+        return _Report(
+            output_path=output_path,
+            input_path=input_path,
+            detected_language=kwargs["options"].source,
+            target_language=kwargs["options"].target,
+        )
+
+    monkeypatch.setattr("ayvu.cli.run_translation_preflight", fake_preflight)
+    monkeypatch.setattr("ayvu.cli.TranslationCache", lambda _path: FakeCache())
+    monkeypatch.setattr("ayvu.cli.translate_epub", fake_translate)
+    monkeypatch.setattr(
+        "ayvu.cli.validate_output_epub",
+        lambda _path, on_progress=None: ValidationResult(ok=True, document_count=1),
+    )
+    monkeypatch.setattr("ayvu.cli._offer_markdown_report", lambda *_args, **_kwargs: None)
+
+
+def test_translate_developer_mode_prints_direct_route(minimal_epub_path, tmp_path, monkeypatch):
+    from ayvu.translator import TranslationRoute
+
+    monkeypatch.setattr("ayvu.cli.default_translated_books_dir", lambda: tmp_path / "Traduzidos")
+    _mock_pipeline_with_route(monkeypatch, TranslationRoute(source="en", target="pt"))
+
+    result = runner.invoke(app, ["--mode", "developer", "translate", str(minimal_epub_path)])
+
+    assert result.exit_code == 0
+    assert "Route: en -> pt" in result.output
+    assert "intermediário" not in result.output
+
+
+def test_translate_developer_mode_prints_intermediate_route_with_warning(
+    minimal_epub_path, tmp_path, monkeypatch
+):
+    from ayvu.translator import TranslationRoute
+
+    monkeypatch.setattr("ayvu.cli.default_translated_books_dir", lambda: tmp_path / "Traduzidos")
+    _mock_pipeline_with_route(
+        monkeypatch, TranslationRoute(source="fr", target="pt", intermediate="en")
+    )
+
+    result = runner.invoke(
+        app,
+        ["--mode", "developer", "translate", str(minimal_epub_path), "--source", "fr"],
+    )
+
+    assert result.exit_code == 0
+    assert "Route: fr -> en -> pt" in result.output
+    assert "qualidade pode ficar comprometida" in result.output
+
+
+def test_translate_common_mode_warns_about_intermediate_route(
+    minimal_epub_path, tmp_path, monkeypatch
+):
+    from ayvu.translator import TranslationRoute
+
+    monkeypatch.setattr("ayvu.cli.default_translated_books_dir", lambda: tmp_path / "Traduzidos")
+    _mock_pipeline_with_route(
+        monkeypatch, TranslationRoute(source="fr", target="pt", intermediate="en")
+    )
+
+    result = runner.invoke(
+        app,
+        ["--mode", "common", "translate", str(minimal_epub_path), "--source", "fr"],
+        input="y\n",
+    )
+
+    assert result.exit_code == 0
+    assert "A tradução passará por 2 etapas" in result.output
+    assert "fr -> en -> pt" in result.output
+    assert "qualidade pode ficar comprometida" in result.output

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -3,7 +3,7 @@ import pytest
 from ayvu.cache import CacheKey, TranslationCache
 from ayvu.domain import LanguagePair
 from ayvu.preflight import PreflightError, run_translation_preflight
-from ayvu.translator import TranslatorError
+from ayvu.translator import RoutedTranslator, TranslatorError, TranslatorLanguage
 
 
 class FakeTranslator:
@@ -18,6 +18,29 @@ class FakeTranslator:
 class FailingTranslator:
     def translate(self, _text: str, _source: str, _target: str) -> str:
         raise TranslatorError("language pair is not available")
+
+
+class TranslatorWithLanguages:
+    def __init__(self, languages: tuple[TranslatorLanguage, ...]) -> None:
+        self._languages = languages
+        self.translate_calls: list[tuple[str, str, str]] = []
+        self.list_calls = 0
+
+    def translate(self, text: str, source: str, target: str) -> str:
+        self.translate_calls.append((text, source, target))
+        return text
+
+    def list_languages(self) -> tuple[TranslatorLanguage, ...]:
+        self.list_calls += 1
+        return self._languages
+
+
+class TranslatorWithFailingLanguages:
+    def translate(self, text: str, _source: str, _target: str) -> str:
+        return text
+
+    def list_languages(self) -> tuple[TranslatorLanguage, ...]:
+        raise TranslatorError("connection refused")
 
 
 def raise_bad_epub(_path: object) -> object:
@@ -50,6 +73,7 @@ def test_preflight_checks_cache_epub_and_translator(monkeypatch, tmp_path):
         assert cache.get(probe_key) is None
     assert result.translator is translator
     assert translator.calls == [("Hello world", "en", "pt")]
+    assert result.route is not None and result.route.is_direct
 
 
 def test_preflight_dry_run_skips_translator_probe(monkeypatch, tmp_path):
@@ -132,3 +156,105 @@ def test_preflight_reports_epub_failure(monkeypatch, tmp_path):
     assert error.value.summary == "Não foi possível ler o EPUB informado."
     assert "bad epub" in error.value.detail
     assert "EPUB válido e legível" in error.value.next_step
+
+
+def test_preflight_uses_languages_to_resolve_direct_route(monkeypatch, tmp_path):
+    languages = (
+        TranslatorLanguage(code="en", name="English", targets=("pt",)),
+        TranslatorLanguage(code="pt", name="Portuguese", targets=("en",)),
+    )
+    translator = TranslatorWithLanguages(languages)
+    monkeypatch.setattr("ayvu.preflight.create_translator", lambda *_args, **_kwargs: translator)
+    monkeypatch.setattr("ayvu.preflight.inspect_epub", lambda _path: object())
+
+    result = run_translation_preflight(
+        epub_path=tmp_path / "book.epub",
+        cache_path=tmp_path / "cache.sqlite",
+        glossary_path=None,
+        translator_name="libretranslate",
+        url="http://localhost:5000",
+        timeout=1.0,
+        retries=0,
+        language_pair=LanguagePair(source="en", target="pt"),
+        dry_run=False,
+    )
+
+    assert translator.list_calls == 1
+    assert translator.translate_calls == []
+    assert result.route is not None and result.route.is_direct
+    assert result.translator is translator
+
+
+def test_preflight_wraps_translator_when_intermediate_route_is_needed(monkeypatch, tmp_path):
+    languages = (
+        TranslatorLanguage(code="fr", name="French", targets=("en",)),
+        TranslatorLanguage(code="en", name="English", targets=("pt",)),
+        TranslatorLanguage(code="pt", name="Portuguese", targets=("en",)),
+    )
+    translator = TranslatorWithLanguages(languages)
+    monkeypatch.setattr("ayvu.preflight.create_translator", lambda *_args, **_kwargs: translator)
+    monkeypatch.setattr("ayvu.preflight.inspect_epub", lambda _path: object())
+
+    result = run_translation_preflight(
+        epub_path=tmp_path / "book.epub",
+        cache_path=tmp_path / "cache.sqlite",
+        glossary_path=None,
+        translator_name="libretranslate",
+        url="http://localhost:5000",
+        timeout=1.0,
+        retries=0,
+        language_pair=LanguagePair(source="fr", target="pt"),
+        dry_run=False,
+    )
+
+    assert isinstance(result.translator, RoutedTranslator)
+    assert result.route is not None
+    assert result.route.intermediate == "en"
+
+
+def test_preflight_reports_missing_route_with_clear_message(monkeypatch, tmp_path):
+    languages = (
+        TranslatorLanguage(code="fr", name="French", targets=("de",)),
+        TranslatorLanguage(code="pt", name="Portuguese", targets=()),
+    )
+    translator = TranslatorWithLanguages(languages)
+    monkeypatch.setattr("ayvu.preflight.create_translator", lambda *_args, **_kwargs: translator)
+    monkeypatch.setattr("ayvu.preflight.inspect_epub", lambda _path: object())
+
+    with pytest.raises(PreflightError) as error:
+        run_translation_preflight(
+            epub_path=tmp_path / "book.epub",
+            cache_path=tmp_path / "cache.sqlite",
+            glossary_path=None,
+            translator_name="libretranslate",
+            url="http://localhost:5000",
+            timeout=1.0,
+            retries=0,
+            language_pair=LanguagePair(source="fr", target="pt"),
+            dry_run=False,
+        )
+
+    assert error.value.summary == "O par de idiomas não está disponível no tradutor."
+    assert "ayvu languages" in error.value.next_step
+
+
+def test_preflight_reports_translator_unreachable_when_list_languages_fails(monkeypatch, tmp_path):
+    translator = TranslatorWithFailingLanguages()
+    monkeypatch.setattr("ayvu.preflight.create_translator", lambda *_args, **_kwargs: translator)
+    monkeypatch.setattr("ayvu.preflight.inspect_epub", lambda _path: object())
+
+    with pytest.raises(PreflightError) as error:
+        run_translation_preflight(
+            epub_path=tmp_path / "book.epub",
+            cache_path=tmp_path / "cache.sqlite",
+            glossary_path=None,
+            translator_name="libretranslate",
+            url="http://localhost:5000",
+            timeout=1.0,
+            retries=0,
+            language_pair=LanguagePair(source="en", target="pt"),
+            dry_run=False,
+        )
+
+    assert error.value.summary == "O tradutor não respondeu."
+    assert "connection refused" in error.value.detail

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -3,7 +3,16 @@ from __future__ import annotations
 import requests
 import pytest
 
-from ayvu.translator import LibreTranslateTranslator, TranslatorError
+from ayvu.translator import (
+    LibreTranslateTranslator,
+    RouteResolutionError,
+    RoutedTranslator,
+    TranslationRoute,
+    Translator,
+    TranslatorError,
+    TranslatorLanguage,
+    resolve_translation_route,
+)
 
 
 class FakeSession:
@@ -210,3 +219,88 @@ def test_libretranslate_reports_languages_http_error() -> None:
         translator.list_languages()
 
     assert "LibreTranslate HTTP error 500: broken" in str(error.value)
+
+
+def _language(code: str, targets: tuple[str, ...]) -> TranslatorLanguage:
+    return TranslatorLanguage(code=code, name=code.upper(), targets=targets)
+
+
+def test_resolve_translation_route_finds_direct_route() -> None:
+    languages = (_language("en", ("pt", "es")), _language("pt", ("en",)))
+
+    route = resolve_translation_route(languages, "en", "pt")
+
+    assert route.is_direct
+    assert route.describe() == "en -> pt"
+
+
+def test_resolve_translation_route_uses_english_bridge_when_direct_missing() -> None:
+    languages = (
+        _language("fr", ("en",)),
+        _language("en", ("pt",)),
+        _language("pt", ("en",)),
+    )
+
+    route = resolve_translation_route(languages, "fr", "pt")
+
+    assert not route.is_direct
+    assert route.intermediate == "en"
+    assert route.describe() == "fr -> en -> pt"
+
+
+def test_resolve_translation_route_raises_when_no_route_available() -> None:
+    languages = (_language("fr", ("de",)), _language("pt", ()))
+
+    with pytest.raises(RouteResolutionError):
+        resolve_translation_route(languages, "fr", "pt")
+
+
+def test_resolve_translation_route_returns_direct_when_source_equals_target() -> None:
+    languages: tuple[TranslatorLanguage, ...] = ()
+
+    route = resolve_translation_route(languages, "pt", "pt")
+
+    assert route.is_direct
+
+
+class RecordingTranslator(Translator):
+    def __init__(self, responses: dict[tuple[str, str], str] | None = None) -> None:
+        self.calls: list[tuple[str, str, str]] = []
+        self._responses = responses or {}
+
+    def translate(self, text: str, source: str, target: str) -> str:
+        self.calls.append((text, source, target))
+        suffix = self._responses.get((source, target), target.upper())
+        return f"{text}|{suffix}"
+
+
+def test_routed_translator_forwards_single_call_for_direct_route() -> None:
+    base = RecordingTranslator()
+    route = TranslationRoute(source="en", target="pt")
+    translator = RoutedTranslator(base, route)
+
+    result = translator.translate("Hello", "en", "pt")
+
+    assert result == "Hello|PT"
+    assert base.calls == [("Hello", "en", "pt")]
+
+
+def test_routed_translator_chains_through_intermediate_language() -> None:
+    base = RecordingTranslator()
+    route = TranslationRoute(source="fr", target="pt", intermediate="en")
+    translator = RoutedTranslator(base, route)
+
+    result = translator.translate("Bonjour", "fr", "pt")
+
+    assert base.calls == [("Bonjour", "fr", "en"), ("Bonjour|EN", "en", "pt")]
+    assert result == "Bonjour|EN|PT"
+
+
+def test_routed_translator_bypasses_intermediate_for_other_pairs() -> None:
+    base = RecordingTranslator()
+    route = TranslationRoute(source="fr", target="pt", intermediate="en")
+    translator = RoutedTranslator(base, route)
+
+    translator.translate("Hello", "en", "pt")
+
+    assert base.calls == [("Hello", "en", "pt")]


### PR DESCRIPTION
## Objetivo

Validar antes da traducao se existe um caminho `source -> target` no tradutor configurado, e tentar uma rota intermediaria via ingles quando nao houver rota direta. Avisar claramente o usuario quando a rota intermediaria estiver em uso.

Closes #69

## O que mudou

- `src/ayvu/translator.py`:
  - `TranslationRoute` (dataclass): origem, destino, idioma intermediario (None = direta), `is_direct` e `describe()`.
  - `RouteResolutionError(TranslatorError)` para par indisponivel.
  - `resolve_translation_route(languages, source, target, intermediate_candidates=("en",))`: tenta direto, depois ponte via candidatos, levanta se nada funciona.
  - `RoutedTranslator(Translator)`: encapsula um tradutor e, quando a rota e intermediaria, faz dois saltos por texto (`source -> bridge -> target`). Pares fora da rota originalmente registrada caem para chamada direta.
- `src/ayvu/preflight.py`:
  - Substitui o probe `translate("Hello world", ...)` por resolucao de rota via `list_languages()` quando o tradutor expoe esse metodo.
  - Tradutores sem `list_languages` (fakes em testes) caem no probe HTTP antigo, mantendo compatibilidade.
  - Quando a rota e intermediaria, o tradutor real e encapsulado em `RoutedTranslator`.
  - `TranslationPreflightResult.route` agora carrega a rota resolvida.
  - Erros novos: "O par de idiomas nao esta disponivel no tradutor" (com proximo passo apontando para `ayvu languages`); a falha de `list_languages` cai como "O tradutor nao respondeu".
- `src/ayvu/cli.py`:
  - Apos preflight (translate e preview), imprime a rota via `_print_translation_route`:
    - Modo dev: linha `Route: source -> [bridge ->] target`.
    - Modo comum, rota intermediaria: aviso amarelo sobre 2 etapas e possivel perda de qualidade.

## Fora do escopo

- Lista de candidatos intermediarios fixada em `("en",)`. Suporte a outras pontes pode vir em issue separada.
- Cache continua keyado no par final `(text, source, target)`; nao cacheamos o passo intermediario isoladamente.

## Validacao

- `uv run pytest`: 157 testes passando.
- Testes novos relevantes:
  - `tests/test_translator.py`: resolver direta, via ingles, sem rota, `source == target`; `RoutedTranslator` single-call direta, two-call intermediaria, bypass para outros pares.
  - `tests/test_preflight.py`: tradutor sem `list_languages` cai no probe antigo (compat); rota direta via languages; rota intermediaria empacotando o tradutor; par indisponivel com mensagem clara; `list_languages` falhando -> "tradutor nao respondeu".
  - `tests/test_cli.py`: modo dev imprime "Route: ..."; modo dev intermediario imprime aviso; modo comum intermediario imprime aviso de qualidade.