### PR TITLE
Protect special terms during translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ O EPUB original nunca é alterado. A saída é gravada em um novo arquivo `.epub
 - Preservação de tags, CSS, imagens, links, sumário e nomes de arquivos internos.
 - Cache SQLite para retomar traduções interrompidas e evitar chamadas repetidas.
 - Glossário JSON opcional para padronizar termos técnicos.
+- Proteção de URLs, caminhos, comandos, versões, código inline e identificadores técnicos simples durante a tradução.
 - Nome de saída automático baseado no idioma de destino.
 - Preview traduzido de uma amostra inicial do EPUB.
 - Modo comum guiado e modo desenvolvedor direto.
@@ -230,6 +231,8 @@ O glossário é um arquivo JSON simples com pares de termos:
 ```
 
 Use `glossary.example.json` como base. O arquivo `glossary.json` local é ignorado pelo Git para evitar versionar preferências pessoais ou conteúdo privado.
+
+Antes de enviar cada trecho ao tradutor, o Ayvu protege termos especiais como URLs, caminhos de arquivo, comandos de terminal, versões como `v1.2.0`, código inline entre crases, placeholders e identificadores técnicos simples. Esses termos são restaurados antes da aplicação do glossário e antes de salvar a tradução no cache.
 
 ## Cache e Retomada
 

--- a/docs/relatorio-tecnico.md
+++ b/docs/relatorio-tecnico.md
@@ -357,6 +357,8 @@ source_lang + target_lang + SHA-256(texto original)
 
 O glossário é aplicado depois da tradução e também sobre textos recuperados do cache. Isso mantém o comportamento consistente entre texto novo e texto reaproveitado.
 
+Antes de enviar texto ao tradutor, `src/ayvu/html_translate.py` protege termos especiais com placeholders internos e os restaura depois da chamada HTTP. O escopo protegido inclui URLs, caminhos de arquivo, comandos de terminal, versões como `v1.2.0`, placeholders, código inline e identificadores técnicos simples. A tradução restaurada é gravada no cache antes da aplicação do glossário.
+
 Textos longos são divididos antes de serem enviados ao tradutor. A regra atual tenta dividir por:
 
 ```text
@@ -460,7 +462,7 @@ Se o servidor estiver indisponível, o Ayvu deve falhar com uma mensagem orienta
 
 ## 18. Testes e CI
 
-A suíte atual tem 100 testes definidos em `tests/`, cobrindo:
+A suíte atual tem 159 testes definidos em `tests/`, cobrindo:
 
 - cache SQLite;
 - chunking;
@@ -491,15 +493,14 @@ uv run pytest
 Prioridades que ainda fazem sentido:
 
 1. Traduzir blocos HTML preservando tags internas por placeholders.
-2. Proteger termos especiais antes da tradução: URLs, comandos, caminhos, versões, placeholders e código inline.
-3. Evoluir o glossário para regras explícitas de preservar, traduzir e proibir termos.
-4. Melhorar validação pós-tradução, incluindo links, capítulos vazios, imagens ausentes e texto não traduzido.
-5. Criar configuração persistente para idioma padrão, pastas e preferências.
-6. Melhorar cache com inspeção, limpeza, exportação e escopo por backend/modelo/glossário.
-7. Adicionar modo `--cache-only`.
-8. Suportar backends alternativos.
-9. Documentar arquitetura em um documento dedicado.
-10. Preparar empacotamento e releases públicas.
+2. Evoluir o glossário para regras explícitas de preservar, traduzir e proibir termos.
+3. Melhorar validação pós-tradução, incluindo links, capítulos vazios, imagens ausentes e texto não traduzido.
+4. Criar configuração persistente para idioma padrão, pastas e preferências.
+5. Melhorar cache com inspeção, limpeza, exportação e escopo por backend/modelo/glossário.
+6. Adicionar modo `--cache-only`.
+7. Suportar backends alternativos.
+8. Documentar arquitetura em um documento dedicado.
+9. Preparar empacotamento e releases públicas.
 
 ## 20. Possível suporte a PDF
 

--- a/src/ayvu/html_translate.py
+++ b/src/ayvu/html_translate.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from collections.abc import Callable
 from dataclasses import dataclass, field
 
@@ -13,7 +14,52 @@ from .translator import Translator
 
 
 IGNORED_TAGS = {"script", "style", "code", "pre", "kbd", "samp", "svg", "math"}
+PROTECTED_PLACEHOLDER_PREFIX = "__AYVU_PROTECTED_"
+PROTECTED_PLACEHOLDER_SUFFIX = "__"
 TextProgressCallback = Callable[[str], None]
+
+
+SPECIAL_TERM_PATTERNS = (
+    re.compile(r"`[^`\n]+`"),
+    re.compile(r"\{\{[^{}\n]+\}\}"),
+    re.compile(r"\{[A-Za-z_][A-Za-z0-9_]*\}"),
+    re.compile(r"%(?:\([A-Za-z_][A-Za-z0-9_]*\))?[sd]"),
+    re.compile(r"(?m)(?<!\S)(?:[$#>]\s*)[^\n]+"),
+    re.compile(
+        r"(?<![\w-])"
+        r"(?:ayvu|uv|git|docker|pip|python3?|pytest|curl|wget|npm|node|cargo|poetry)"
+        r"(?:\s+(?:[^\s`<>(),;!?]+))+",
+    ),
+    re.compile(r"https?://[^\s`<>()\"']+"),
+    re.compile(r"(?<![\w./-])(?:~|\.{1,2})?/[^\s`<>()\"']+"),
+    re.compile(r"(?<![\w./-])(?:[A-Za-z0-9_.-]+/)+[A-Za-z0-9_.-]+"),
+    re.compile(r"(?<![\w./-])[A-Za-z]:\\[^\s`<>()\"']+"),
+    re.compile(r"(?<![\w.-])v?\d+\.\d+(?:\.\d+)+(?:[-+][0-9A-Za-z.-]+)?\b"),
+    re.compile(r"(?<!\w)--?[A-Za-z][A-Za-z0-9-]*(?:=[^\s`<>()]+)?"),
+    re.compile(r"(?<!\w)\$[A-Z_][A-Z0-9_]*\b"),
+    re.compile(r"\b[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)+\b"),
+    re.compile(r"\b[A-Za-z_][A-Za-z0-9_]*\(\)"),
+    re.compile(r"\b[A-Za-z][A-Za-z0-9]*_[A-Za-z0-9_]*\b"),
+    re.compile(r"\b[A-Za-z]+[A-Z][A-Za-z0-9]*\b"),
+    re.compile(r"\b[A-Z][A-Z0-9_]{2,}\b"),
+)
+
+
+@dataclass(frozen=True)
+class ProtectedSpan:
+    start: int
+    end: int
+
+
+@dataclass(frozen=True)
+class ProtectedText:
+    text: str
+    terms: tuple[tuple[str, str], ...] = ()
+
+    def restore(self, translated: str) -> str:
+        for placeholder, original in self.terms:
+            translated = translated.replace(placeholder, original)
+        return translated
 
 
 @dataclass
@@ -122,11 +168,12 @@ def translate_text(
     if dry_run:
         return TextTranslationResult(text=text)
 
+    protected = _protect_special_terms(parts.core)
     translated_chunks = [
         translator.translate(chunk, source, target)
-        for chunk in split_text(parts.core, limit=chunk_limit)
+        for chunk in split_text(protected.text, limit=chunk_limit)
     ]
-    translated = "".join(translated_chunks)
+    translated = protected.restore("".join(translated_chunks))
     cache.set(cache_key, translated)
     translated = apply_glossary(translated, glossary)
     return TextTranslationResult(text=parts.restore(translated))
@@ -152,6 +199,65 @@ def _is_visible_text_node(text_node: NavigableString) -> bool:
             return False
         parent = parent.parent
     return True
+
+
+def _protect_special_terms(text: str) -> ProtectedText:
+    spans = _special_term_spans(text)
+    if not spans:
+        return ProtectedText(text=text)
+
+    protected_parts: list[str] = []
+    terms: list[tuple[str, str]] = []
+    cursor = 0
+    for span in spans:
+        placeholder = _protected_placeholder(len(terms))
+        protected_parts.append(text[cursor : span.start])
+        protected_parts.append(placeholder)
+        terms.append((placeholder, text[span.start : span.end]))
+        cursor = span.end
+
+    protected_parts.append(text[cursor:])
+    return ProtectedText(text="".join(protected_parts), terms=tuple(terms))
+
+
+def _special_term_spans(text: str) -> list[ProtectedSpan]:
+    spans: list[ProtectedSpan] = []
+    for pattern in SPECIAL_TERM_PATTERNS:
+        for match in pattern.finditer(text):
+            span = _clean_match_span(text, match.start(), match.end())
+            if span is None or _overlaps_any(span, spans):
+                continue
+            spans.append(span)
+    return sorted(spans, key=lambda span: span.start)
+
+
+def _clean_match_span(text: str, start: int, end: int) -> ProtectedSpan | None:
+    while start < end and text[start].isspace():
+        start += 1
+    while start < end and text[end - 1] in ".,;:!?":
+        end -= 1
+    while (
+        start < end
+        and text[end - 1] in ")]}"
+        and _has_unmatched_closer(text[start:end], text[end - 1])
+    ):
+        end -= 1
+    if start >= end:
+        return None
+    return ProtectedSpan(start=start, end=end)
+
+
+def _has_unmatched_closer(value: str, closer: str) -> bool:
+    opener = {")": "(", "]": "[", "}": "{"}[closer]
+    return value.count(closer) > value.count(opener)
+
+
+def _overlaps_any(candidate: ProtectedSpan, spans: list[ProtectedSpan]) -> bool:
+    return any(candidate.start < span.end and candidate.end > span.start for span in spans)
+
+
+def _protected_placeholder(index: int) -> str:
+    return f"{PROTECTED_PLACEHOLDER_PREFIX}{index}{PROTECTED_PLACEHOLDER_SUFFIX}"
 
 
 def _notify_text_processed(callback: TextProgressCallback | None, status: str) -> None:

--- a/tests/test_html_translate.py
+++ b/tests/test_html_translate.py
@@ -80,6 +80,48 @@ def test_translate_text_result_reports_cache_hit(tmp_path):
     assert translator.calls == []
 
 
+def test_translate_text_protects_special_terms_before_translating(tmp_path):
+    text = (
+        "Use `uv run ayvu --help`, open https://example.com/docs, edit "
+        "src/ayvu/html_translate.py, run git status, keep v1.2.0, call "
+        "translate_text(), and pass CacheKey."
+    )
+    protected_terms = [
+        "`uv run ayvu --help`",
+        "https://example.com/docs",
+        "src/ayvu/html_translate.py",
+        "git status",
+        "v1.2.0",
+        "translate_text()",
+        "CacheKey",
+    ]
+
+    translator = FakeTranslator()
+    with TranslationCache(tmp_path / "cache.sqlite") as cache:
+        result = translate_text(text, translator, cache, "en", "pt")
+
+    translated_input = translator.calls[0]
+    for term in protected_terms:
+        assert term not in translated_input
+        assert term in result.text
+    assert "__AYVU_PROTECTED_" in translated_input
+    assert "__AYVU_PROTECTED_" not in result.text
+
+
+def test_translate_text_caches_restored_protected_terms(tmp_path):
+    text = "Call translate_text() at https://example.com/docs."
+    translator = FakeTranslator()
+
+    with TranslationCache(tmp_path / "cache.sqlite") as cache:
+        first_result = translate_text(text, translator, cache, "en", "pt")
+        second_result = translate_text(text, translator, cache, "en", "pt")
+
+    assert first_result.text == "PT:Call translate_text() at https://example.com/docs."
+    assert second_result.text == first_result.text
+    assert second_result.from_cache
+    assert translator.calls == ["Call __AYVU_PROTECTED_0__ at __AYVU_PROTECTED_1__."]
+
+
 def test_translate_html_does_not_translate_doctype_or_comments(tmp_path):
     html = '<?xml version="1.0" encoding="utf-8"?><!DOCTYPE html><html><body><!-- Keep me --><p>Keep me</p></body></html>'
     translator = FakeTranslator()


### PR DESCRIPTION
## Objective

Protect technical terms that should remain intact before text is sent to the translator, then restore them before glossary application and cache reuse.

## What changed

- Added special-term placeholder protection in `html_translate.translate_text` for URLs, file paths, terminal commands, versions, placeholders, inline code, and simple technical identifiers.
- Restored protected terms before writing the translated result to the cache and before applying the glossary.
- Added focused tests covering the protected term categories and cache reuse without placeholder leakage.
- Updated the README and technical report to document the implemented behavior.

## Out of scope

- Block-level HTML translation with tag placeholders remains separate work.
- Advanced glossary preserve/translate/forbidden rules remain separate work.
- Unrelated local changes in `CHANGELOG.md` and `CONTRIBUTING.md` are not included.

## Validation

- `uv run pytest tests/test_html_translate.py`: 8 passed.
- `uv run pytest`: 159 passed.
- `git diff --check`: no errors.

## Related issue

Closes #70