### PR TITLE
Add advanced glossary rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ lancadas e secoes versionadas quando uma release for publicada.
 - Documento de fluxo de issues, branches, pull requests e releases.
 - Arquivos iniciais de manutencao do projeto: `LICENSE`, `CHANGELOG.md` e
   `CONTRIBUTING.md`.
+- Glossario avancado com regras `translate`, `preserve` e `forbidden`,
+  mantendo compatibilidade com o formato simples de pares de termos.
 
 ### Atualizado
 
@@ -54,6 +56,7 @@ lancadas e secoes versionadas quando uma release for publicada.
   Markdown.
 - README e relatorio tecnico foram atualizados para refletir modos de uso,
   retomada, configuracao, biblioteca, validacao, CI e roadmap.
+- `glossary.example.json` agora demonstra o formato avancado de glossario.
 
 ### Corrigido
 

--- a/README.md
+++ b/README.md
@@ -218,17 +218,33 @@ uv run ayvu extract livro.epub \
 
 ## Glossário
 
-O glossário é um arquivo JSON simples com pares de termos:
+O glossário aceita o formato simples de pares de termos, mantido por compatibilidade:
 
 ```json
 {
   "Game Loop": "loop de jogo",
-  "Design Pattern": "padrão de projeto",
-  "Observer": "Observer",
-  "Command": "Command",
-  "State": "State"
+  "Observer": "Observer"
 }
 ```
+
+Também aceita regras explícitas por termo:
+
+```json
+{
+  "Game Loop": {
+    "rule": "translate",
+    "translation": "loop de jogo"
+  },
+  "Observer": {
+    "rule": "preserve"
+  },
+  "AntiPattern": {
+    "rule": "forbidden"
+  }
+}
+```
+
+Use `translate` para definir uma tradução preferida e `preserve` para manter um termo padronizado no texto final. A regra `forbidden` marca termos que não devem aparecer na saída e já é carregada e validada pelo glossário; relatórios de ocorrências ficam em uma etapa separada.
 
 Use `glossary.example.json` como base. O arquivo `glossary.json` local é ignorado pelo Git para evitar versionar preferências pessoais ou conteúdo privado.
 

--- a/docs/relatorio-tecnico.md
+++ b/docs/relatorio-tecnico.md
@@ -233,7 +233,8 @@ uv run ayvu --mode common translate livro.epub
 
 `src/ayvu/cache.py` persiste traduções em SQLite usando idioma de origem, idioma de destino e hash do texto original.
 
-`src/ayvu/glossary.py` lê e aplica glossário JSON simples.
+`src/ayvu/glossary.py` lê glossários JSON no formato simples e no formato com
+regras explícitas `translate`, `preserve` e `forbidden`.
 
 `src/ayvu/chunking.py` divide textos longos preservando ordem e evitando cortar palavras quando possível.
 
@@ -357,6 +358,13 @@ source_lang + target_lang + SHA-256(texto original)
 
 O glossário é aplicado depois da tradução e também sobre textos recuperados do cache. Isso mantém o comportamento consistente entre texto novo e texto reaproveitado.
 
+O formato simples de glossário (`"Termo": "tradução"`) continua sendo aceito e
+equivale à regra `translate`. O formato avançado aceita objetos por termo com
+`rule: "translate"` e `translation`, `rule: "preserve"` ou
+`rule: "forbidden"`. As regras `translate` e `preserve` alteram o texto final; a
+regra `forbidden` fica disponível para detecção de termos proibidos e para
+relatórios futuros.
+
 Antes de enviar texto ao tradutor, `src/ayvu/html_translate.py` protege termos especiais com placeholders internos e os restaura depois da chamada HTTP. O escopo protegido inclui URLs, caminhos de arquivo, comandos de terminal, versões como `v1.2.0`, placeholders, código inline e identificadores técnicos simples. A tradução restaurada é gravada no cache antes da aplicação do glossário.
 
 Textos longos são divididos antes de serem enviados ao tradutor. A regra atual tenta dividir por:
@@ -462,7 +470,7 @@ Se o servidor estiver indisponível, o Ayvu deve falhar com uma mensagem orienta
 
 ## 18. Testes e CI
 
-A suíte atual tem 159 testes definidos em `tests/`, cobrindo:
+A suíte atual tem 167 testes definidos em `tests/`, cobrindo:
 
 - cache SQLite;
 - chunking;

--- a/docs/tutorial-modo-comum-e-dev.md
+++ b/docs/tutorial-modo-comum-e-dev.md
@@ -110,13 +110,31 @@ Crie um glossário a partir do exemplo versionado:
 cp glossary.example.json glossary.json
 ```
 
-Edite `glossary.json` com os termos que deseja padronizar. Exemplo:
+Edite `glossary.json` com os termos que deseja padronizar. O formato simples
+continua aceito:
 
 ```json
 {
   "Game Loop": "loop de jogo",
   "Design Pattern": "padrão de projeto",
   "Observer": "Observer"
+}
+```
+
+Para regras explícitas, use `translate`, `preserve` ou `forbidden` por termo:
+
+```json
+{
+  "Game Loop": {
+    "rule": "translate",
+    "translation": "loop de jogo"
+  },
+  "Observer": {
+    "rule": "preserve"
+  },
+  "AntiPattern": {
+    "rule": "forbidden"
+  }
 }
 ```
 
@@ -132,6 +150,8 @@ uv run ayvu translate livro.epub \
 ```
 
 O glossário é aplicado depois da tradução e também sobre textos vindos do cache.
+A regra `forbidden` é carregada e validada pelo glossário, mas o relatório de
+ocorrências fica para uma etapa separada.
 
 ### Usar cache de forma consistente
 

--- a/glossary.example.json
+++ b/glossary.example.json
@@ -1,9 +1,29 @@
 {
-  "Game Loop": "loop de jogo",
-  "Design Pattern": "padrão de projeto",
-  "Observer": "Observer",
-  "Command": "Command",
-  "State": "State",
-  "Singleton": "Singleton",
-  "Object Pool": "pool de objetos"
+  "Game Loop": {
+    "rule": "translate",
+    "translation": "loop de jogo"
+  },
+  "Design Pattern": {
+    "rule": "translate",
+    "translation": "padrão de projeto"
+  },
+  "Observer": {
+    "rule": "preserve"
+  },
+  "Command": {
+    "rule": "preserve"
+  },
+  "State": {
+    "rule": "preserve"
+  },
+  "Singleton": {
+    "rule": "preserve"
+  },
+  "Object Pool": {
+    "rule": "translate",
+    "translation": "pool de objetos"
+  },
+  "AntiPattern": {
+    "rule": "forbidden"
+  }
 }

--- a/src/ayvu/glossary.py
+++ b/src/ayvu/glossary.py
@@ -2,30 +2,87 @@ from __future__ import annotations
 
 import json
 import re
-from dataclasses import dataclass, field
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
 from pathlib import Path
 
 
-@dataclass(frozen=True)
+GLOSSARY_RULE_PRESERVE = "preserve"
+GLOSSARY_RULE_TRANSLATE = "translate"
+GLOSSARY_RULE_FORBIDDEN = "forbidden"
+GLOSSARY_RULES = {GLOSSARY_RULE_PRESERVE, GLOSSARY_RULE_TRANSLATE, GLOSSARY_RULE_FORBIDDEN}
+
+
+@dataclass(frozen=True, slots=True)
+class GlossaryEntry:
+    term: str
+    rule: str
+    translation: str | None = None
+
+    @property
+    def replacement(self) -> str | None:
+        if self.rule == GLOSSARY_RULE_TRANSLATE:
+            return self.translation
+        if self.rule == GLOSSARY_RULE_PRESERVE:
+            return self.term
+        return None
+
+
+@dataclass(frozen=True, init=False)
 class Glossary:
-    terms: dict[str, str] = field(default_factory=dict)
+    entries: tuple[GlossaryEntry, ...]
+
+    def __init__(
+        self,
+        entries: Mapping[str, str] | Iterable[GlossaryEntry] | None = None,
+    ) -> None:
+        if entries is None:
+            parsed_entries: tuple[GlossaryEntry, ...] = ()
+        elif isinstance(entries, Mapping):
+            parsed_entries = tuple(
+                GlossaryEntry(
+                    term=str(term),
+                    rule=GLOSSARY_RULE_TRANSLATE,
+                    translation=str(translation),
+                )
+                for term, translation in entries.items()
+            )
+        else:
+            parsed_entries = tuple(entries)
+        object.__setattr__(self, "entries", parsed_entries)
+
+    @property
+    def terms(self) -> dict[str, str]:
+        return {
+            entry.term: replacement
+            for entry in self.entries
+            if (replacement := entry.replacement) is not None
+        }
 
     def apply(self, text: str) -> str:
-        if not self.terms:
+        replace_entries = [entry for entry in self._ordered_entries() if entry.replacement is not None]
+        if not replace_entries:
             return text
         result = text
-        for source_term, target_term in self._ordered_terms():
-            if not source_term:
+        for entry in replace_entries:
+            if not entry.term or entry.replacement is None:
                 continue
-            pattern = re.compile(rf"(?<!\w){re.escape(source_term)}(?!\w)", re.IGNORECASE)
-            result = pattern.sub(lambda match: _match_case(match.group(0), target_term), result)
+            pattern = _term_pattern(entry.term)
+            result = pattern.sub(lambda match: _match_case(match.group(0), entry.replacement), result)
         return result
 
-    def _ordered_terms(self) -> list[tuple[str, str]]:
-        return sorted(self.terms.items(), key=lambda item: len(item[0]), reverse=True)
+    def forbidden_terms_in(self, text: str) -> list[str]:
+        return [
+            entry.term
+            for entry in self._ordered_entries()
+            if entry.rule == GLOSSARY_RULE_FORBIDDEN and _term_pattern(entry.term).search(text)
+        ]
+
+    def _ordered_entries(self) -> list[GlossaryEntry]:
+        return sorted(self.entries, key=lambda entry: len(entry.term), reverse=True)
 
     def __bool__(self) -> bool:
-        return bool(self.terms)
+        return bool(self.entries)
 
 
 class GlossaryError(ValueError):
@@ -49,15 +106,63 @@ def load_glossary(path: str | Path | None) -> Glossary:
 
     if not isinstance(data, dict):
         raise GlossaryError("Glossary JSON must be an object mapping terms to translations")
-    return Glossary({str(key): str(value) for key, value in data.items()})
+    return Glossary(_parse_glossary_entries(data))
 
 
-def apply_glossary(text: str, glossary: Glossary | dict[str, str] | None) -> str:
+def apply_glossary(text: str, glossary: Glossary | Mapping[object, object] | None) -> str:
     if not glossary:
         return text
     if isinstance(glossary, Glossary):
         return glossary.apply(text)
-    return Glossary({str(key): str(value) for key, value in glossary.items()}).apply(text)
+    return Glossary(_parse_glossary_entries(glossary)).apply(text)
+
+
+def _parse_glossary_entries(data: Mapping[object, object]) -> tuple[GlossaryEntry, ...]:
+    return tuple(_parse_glossary_entry(str(term), value) for term, value in data.items())
+
+
+def _parse_glossary_entry(term: str, value: object) -> GlossaryEntry:
+    _validate_term(term)
+    if isinstance(value, str):
+        return GlossaryEntry(term=term, rule=GLOSSARY_RULE_TRANSLATE, translation=value)
+    if not isinstance(value, dict):
+        raise GlossaryError(
+            f"Glossary entry for '{term}' must be a string translation or an object with a rule"
+        )
+
+    rule = value.get("rule")
+    if not isinstance(rule, str):
+        raise GlossaryError(f"Glossary entry for '{term}' must include a string rule")
+    if rule not in GLOSSARY_RULES:
+        allowed_rules = ", ".join(sorted(GLOSSARY_RULES))
+        raise GlossaryError(f"Glossary entry for '{term}' uses unsupported rule '{rule}': {allowed_rules}")
+
+    allowed_fields = {"rule", "translation"} if rule == GLOSSARY_RULE_TRANSLATE else {"rule"}
+    unknown_fields = sorted(set(value) - allowed_fields)
+    if unknown_fields:
+        fields = ", ".join(unknown_fields)
+        raise GlossaryError(f"Glossary entry for '{term}' has unsupported fields: {fields}")
+
+    if rule == GLOSSARY_RULE_TRANSLATE:
+        translation = value.get("translation")
+        if not isinstance(translation, str):
+            raise GlossaryError(
+                f"Glossary entry for '{term}' with rule 'translate' must include a string translation"
+            )
+        return GlossaryEntry(term=term, rule=rule, translation=translation)
+
+    return GlossaryEntry(term=term, rule=rule)
+
+
+def _validate_term(term: str) -> None:
+    if not term:
+        raise GlossaryError("Glossary terms must not be empty")
+    if term != term.strip():
+        raise GlossaryError(f"Glossary term '{term}' must not start or end with whitespace")
+
+
+def _term_pattern(term: str) -> re.Pattern[str]:
+    return re.compile(rf"(?<!\w){re.escape(term)}(?!\w)", re.IGNORECASE)
 
 
 def _match_case(original: str, replacement: str) -> str:

--- a/tests/test_glossary.py
+++ b/tests/test_glossary.py
@@ -1,6 +1,15 @@
 import pytest
 
-from ayvu.glossary import Glossary, GlossaryError, apply_glossary, load_glossary
+from ayvu.glossary import (
+    GLOSSARY_RULE_FORBIDDEN,
+    GLOSSARY_RULE_PRESERVE,
+    GLOSSARY_RULE_TRANSLATE,
+    Glossary,
+    GlossaryEntry,
+    GlossaryError,
+    apply_glossary,
+    load_glossary,
+)
 
 
 def test_apply_glossary_replaces_terms():
@@ -27,6 +36,82 @@ def test_load_glossary_returns_glossary_object(tmp_path):
 
     assert isinstance(glossary, Glossary)
     assert glossary.apply("OBSERVER") == "OBSERVER"
+
+
+def test_load_glossary_supports_advanced_rules(tmp_path):
+    glossary_path = tmp_path / "glossary.json"
+    glossary_path.write_text(
+        """
+        {
+          "Game Loop": {"rule": "translate", "translation": "loop de jogo"},
+          "Observer": {"rule": "preserve"},
+          "Foo": {"rule": "forbidden"}
+        }
+        """,
+        encoding="utf-8",
+    )
+
+    glossary = load_glossary(glossary_path)
+
+    assert glossary.entries == (
+        GlossaryEntry("Game Loop", GLOSSARY_RULE_TRANSLATE, "loop de jogo"),
+        GlossaryEntry("Observer", GLOSSARY_RULE_PRESERVE),
+        GlossaryEntry("Foo", GLOSSARY_RULE_FORBIDDEN),
+    )
+    assert glossary.apply("The Game Loop keeps observer.") == "The loop de jogo keeps Observer."
+    assert glossary.forbidden_terms_in("Avoid foo in the output.") == ["Foo"]
+
+
+def test_apply_glossary_preserve_rule_keeps_configured_term():
+    glossary = Glossary(
+        [
+            GlossaryEntry("Observer", GLOSSARY_RULE_PRESERVE),
+            GlossaryEntry("Game Loop", GLOSSARY_RULE_TRANSLATE, "loop de jogo"),
+        ]
+    )
+
+    assert apply_glossary("observer uses the Game Loop.", glossary) == "Observer uses the loop de jogo."
+
+
+def test_apply_glossary_accepts_advanced_mapping_directly():
+    glossary = {
+        "Observer": {"rule": "preserve"},
+        "Game Loop": {"rule": "translate", "translation": "loop de jogo"},
+    }
+
+    assert apply_glossary("observer uses the Game Loop.", glossary) == "Observer uses the loop de jogo."
+
+
+def test_load_glossary_rejects_unknown_rule(tmp_path):
+    glossary_path = tmp_path / "glossary.json"
+    glossary_path.write_text('{"Observer": {"rule": "unknown"}}', encoding="utf-8")
+
+    with pytest.raises(GlossaryError, match="unsupported rule 'unknown'"):
+        load_glossary(glossary_path)
+
+
+def test_load_glossary_rejects_translate_rule_without_translation(tmp_path):
+    glossary_path = tmp_path / "glossary.json"
+    glossary_path.write_text('{"Observer": {"rule": "translate"}}', encoding="utf-8")
+
+    with pytest.raises(GlossaryError, match="must include a string translation"):
+        load_glossary(glossary_path)
+
+
+def test_load_glossary_rejects_unsupported_fields(tmp_path):
+    glossary_path = tmp_path / "glossary.json"
+    glossary_path.write_text('{"Observer": {"rule": "preserve", "translation": "Observador"}}', encoding="utf-8")
+
+    with pytest.raises(GlossaryError, match="unsupported fields: translation"):
+        load_glossary(glossary_path)
+
+
+def test_load_glossary_rejects_empty_terms(tmp_path):
+    glossary_path = tmp_path / "glossary.json"
+    glossary_path.write_text('{"": "empty"}', encoding="utf-8")
+
+    with pytest.raises(GlossaryError, match="must not be empty"):
+        load_glossary(glossary_path)
 
 
 def test_load_glossary_missing_file_has_clear_error(tmp_path):

--- a/tests/test_html_translate.py
+++ b/tests/test_html_translate.py
@@ -1,5 +1,6 @@
 from ayvu.cache import CacheKey, TranslationCache
 from ayvu.domain import LanguagePair
+from ayvu.glossary import GLOSSARY_RULE_PRESERVE, GLOSSARY_RULE_TRANSLATE, Glossary, GlossaryEntry
 from ayvu.html_translate import extract_visible_text, translate_html, translate_text
 from ayvu.translator import Translator
 
@@ -76,6 +77,26 @@ def test_translate_text_result_reports_cache_hit(tmp_path):
         result = translate_text(" Keep me ", translator, cache, "en", "pt")
 
     assert result.text == " Mantenha-me "
+    assert result.from_cache
+    assert translator.calls == []
+
+
+def test_translate_text_applies_advanced_glossary_rules_to_cache_hits(tmp_path):
+    translator = FakeTranslator()
+    glossary = Glossary(
+        [
+            GlossaryEntry("Observer", GLOSSARY_RULE_PRESERVE),
+            GlossaryEntry("Game Loop", GLOSSARY_RULE_TRANSLATE, "loop de jogo"),
+        ]
+    )
+
+    with TranslationCache(tmp_path / "cache.sqlite") as cache:
+        cache_key = CacheKey(text="Keep me", language_pair=LanguagePair(source="en", target="pt"))
+        cache.set(cache_key, "observer uses the Game Loop")
+
+        result = translate_text("Keep me", translator, cache, "en", "pt", glossary=glossary)
+
+    assert result.text == "Observer uses the loop de jogo"
     assert result.from_cache
     assert translator.calls == []
 


### PR DESCRIPTION
## Objective

Support explicit glossary rules for preserving terms, applying preferred translations, and marking forbidden terms while keeping the existing simple glossary format compatible.

## What changed

- Added `GlossaryEntry` and explicit `translate`, `preserve`, and `forbidden` rules in the glossary domain.
- Kept the current simple JSON format as a compatibility alias for `translate` rules.
- Added validation for unsupported rules, missing translations, unsupported fields, and invalid terms.
- Added forbidden-term detection for later reporting work.
- Covered advanced rules in glossary tests and cache-hit HTML translation tests.
- Updated the README, tutorial, technical report, changelog, and glossary example.

## Out of scope

- Reporting glossary usage, missing required terms, or forbidden-term warnings remains separate work for the follow-up reporting issue.
- Guided glossary creation in common mode remains separate work.

## Validation

- `uv run pytest tests/test_glossary.py tests/test_html_translate.py`: 21 passed.
- `uv run pytest`: 167 passed.
- `git diff --check`: no errors.

## Related issue

Closes #71