### PR TITLE
Report glossary usage in translation reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ lancadas e secoes versionadas quando uma release for publicada.
   `CONTRIBUTING.md`.
 - Glossario avancado com regras `translate`, `preserve` e `forbidden`,
   mantendo compatibilidade com o formato simples de pares de termos.
+- Relatorio de uso do glossario com contagem de termos aplicados, termos
+  obrigatorios ausentes e termos proibidos encontrados na saida.
 
 ### Atualizado
 

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ uv run ayvu translate livro.epub \
   --dry-run
 ```
 
-Ao final da tradução, o Ayvu mostra um relatório no terminal com o EPUB original, idiomas, saída calculada, capítulos processados, textos traduzidos, cache e erros. No **Modo Comum**, também pergunta se deve salvar esse relatório em Markdown em `~/Documentos/Livros/Relatorios`.
+Ao final da tradução, o Ayvu mostra um relatório no terminal com o EPUB original, idiomas, saída calculada, capítulos processados, textos traduzidos, cache, erros e resumo do uso do glossário quando houver glossário configurado. No **Modo Comum**, também pergunta se deve salvar esse relatório em Markdown em `~/Documentos/Livros/Relatorios`.
 
 Extrair texto visível para Markdown:
 
@@ -233,10 +233,12 @@ Também aceita regras explícitas por termo:
 {
   "Game Loop": {
     "rule": "translate",
-    "translation": "loop de jogo"
+    "translation": "loop de jogo",
+    "required": true
   },
   "Observer": {
-    "rule": "preserve"
+    "rule": "preserve",
+    "required": true
   },
   "AntiPattern": {
     "rule": "forbidden"
@@ -244,7 +246,9 @@ Também aceita regras explícitas por termo:
 }
 ```
 
-Use `translate` para definir uma tradução preferida e `preserve` para manter um termo padronizado no texto final. A regra `forbidden` marca termos que não devem aparecer na saída e já é carregada e validada pelo glossário; relatórios de ocorrências ficam em uma etapa separada.
+Use `translate` para definir uma tradução preferida e `preserve` para manter um termo padronizado no texto final. Use `required: true` em regras `translate` ou `preserve` quando o termo esperado deve aparecer na saída traduzida. A regra `forbidden` marca termos que não devem aparecer na saída.
+
+Quando um glossário é usado, o relatório final conta quantas aplicações de `translate` e `preserve` ocorreram, inclusive em textos vindos do cache. O relatório também avisa termos obrigatórios ausentes e termos proibidos encontrados na saída.
 
 Use `glossary.example.json` como base. O arquivo `glossary.json` local é ignorado pelo Git para evitar versionar preferências pessoais ou conteúdo privado.
 

--- a/docs/relatorio-tecnico.md
+++ b/docs/relatorio-tecnico.md
@@ -361,9 +361,14 @@ O glossário é aplicado depois da tradução e também sobre textos recuperados
 O formato simples de glossário (`"Termo": "tradução"`) continua sendo aceito e
 equivale à regra `translate`. O formato avançado aceita objetos por termo com
 `rule: "translate"` e `translation`, `rule: "preserve"` ou
-`rule: "forbidden"`. As regras `translate` e `preserve` alteram o texto final; a
-regra `forbidden` fica disponível para detecção de termos proibidos e para
-relatórios futuros.
+`rule: "forbidden"`. As regras `translate` e `preserve` alteram o texto final e
+podem usar `required: true` para exigir que o termo esperado apareça na saída. A
+regra `forbidden` detecta termos que não devem aparecer no texto final.
+
+O relatório de tradução acumula estatísticas de glossário por texto, capítulo e
+EPUB. Ele contabiliza aplicações de `translate` e `preserve`, inclusive em textos
+vindos do cache, e avisa termos obrigatórios ausentes ou termos proibidos
+encontrados na saída.
 
 Antes de enviar texto ao tradutor, `src/ayvu/html_translate.py` protege termos especiais com placeholders internos e os restaura depois da chamada HTTP. O escopo protegido inclui URLs, caminhos de arquivo, comandos de terminal, versões como `v1.2.0`, placeholders, código inline e identificadores técnicos simples. A tradução restaurada é gravada no cache antes da aplicação do glossário.
 
@@ -416,10 +421,12 @@ Ao final da tradução, o Ayvu mostra um relatório no terminal com:
 - textos pulados no dry-run;
 - erros;
 - avisos de validação (capítulo vazio, link interno quebrado, imagem ausente).
+- quando houver glossário, termos configurados, aplicações, obrigatórios
+  ausentes e termos proibidos encontrados.
 
 A validação roda antes do relatório final, então os avisos aparecem na tabela do terminal e, no modo comum, também no relatório Markdown. Qualquer aviso faz a execução terminar com código 1.
 
-No modo comum, o Ayvu também oferece salvar esse relatório em Markdown em `~/Documentos/Livros/Relatorios`, sem sobrescrever relatórios anteriores.
+No modo comum, o Ayvu também oferece salvar esse relatório em Markdown em `~/Documentos/Livros/Relatorios`, sem sobrescrever relatórios anteriores. O relatório Markdown repete o resumo de glossário e inclui seções com termos aplicados e avisos quando existirem.
 
 ## 16. Bug crítico: EPUB com tela branca
 

--- a/docs/tutorial-modo-comum-e-dev.md
+++ b/docs/tutorial-modo-comum-e-dev.md
@@ -127,10 +127,12 @@ Para regras explícitas, use `translate`, `preserve` ou `forbidden` por termo:
 {
   "Game Loop": {
     "rule": "translate",
-    "translation": "loop de jogo"
+    "translation": "loop de jogo",
+    "required": true
   },
   "Observer": {
-    "rule": "preserve"
+    "rule": "preserve",
+    "required": true
   },
   "AntiPattern": {
     "rule": "forbidden"
@@ -150,8 +152,9 @@ uv run ayvu translate livro.epub \
 ```
 
 O glossário é aplicado depois da tradução e também sobre textos vindos do cache.
-A regra `forbidden` é carregada e validada pelo glossário, mas o relatório de
-ocorrências fica para uma etapa separada.
+Use `required: true` em regras `translate` ou `preserve` quando o termo esperado
+deve aparecer na saída. Ao final, o relatório conta termos aplicados e avisa
+termos obrigatórios ausentes ou termos `forbidden` encontrados no texto final.
 
 ### Usar cache de forma consistente
 

--- a/glossary.example.json
+++ b/glossary.example.json
@@ -1,14 +1,16 @@
 {
   "Game Loop": {
     "rule": "translate",
-    "translation": "loop de jogo"
+    "translation": "loop de jogo",
+    "required": true
   },
   "Design Pattern": {
     "rule": "translate",
     "translation": "padrão de projeto"
   },
   "Observer": {
-    "rule": "preserve"
+    "rule": "preserve",
+    "required": true
   },
   "Command": {
     "rule": "preserve"

--- a/src/ayvu/cli.py
+++ b/src/ayvu/cli.py
@@ -578,13 +578,42 @@ def _print_report(
     table.add_row("Texts from cache", str(report.texts_from_cache))
     table.add_row("Errors", str(len(report.errors)))
     table.add_row("Validation warnings", str(len(validation_warnings)))
+    if _has_glossary_summary(report):
+        table.add_row("Glossary terms configured", str(report.glossary_terms_configured))
+        table.add_row("Glossary terms applied", str(report.glossary_usage.total_applied))
+        table.add_row(
+            "Required glossary terms missing",
+            str(len(report.glossary_usage.required_terms_missing)),
+        )
+        table.add_row(
+            "Forbidden glossary terms found",
+            str(report.glossary_usage.total_forbidden_found),
+        )
     console.print(table)
 
     for error in report.errors:
         console.print(f"[yellow]Error:[/yellow] {error}")
 
+    _print_glossary_warnings(report)
+
     if validation_warnings:
         _print_validation_warnings(validation_warnings)
+
+
+def _has_glossary_summary(report: TranslationReport) -> bool:
+    return report.glossary_terms_configured > 0 or report.glossary_usage.has_activity
+
+
+def _print_glossary_warnings(report: TranslationReport) -> None:
+    usage = report.glossary_usage
+    if not usage.required_terms_missing and not usage.forbidden_terms_found:
+        return
+
+    console.print("[yellow]Glossary warnings:[/yellow]")
+    if usage.required_terms_missing:
+        console.print(f"  - Required terms missing: {_format_terms(usage.required_terms_missing)}")
+    if usage.forbidden_terms_found:
+        console.print(f"  - Forbidden terms found: {_format_counted_terms(usage.forbidden_terms_found)}")
 
 
 def _print_interrupted_translation(
@@ -1287,10 +1316,37 @@ def _render_markdown_report(
         f"- Errors: {len(report.errors)}",
         f"- Validation warnings: {len(validation_warnings)}",
     ]
+    if _has_glossary_summary(report):
+        lines.extend(
+            [
+                f"- Glossary terms configured: {report.glossary_terms_configured}",
+                f"- Glossary terms applied: {report.glossary_usage.total_applied}",
+                f"- Required glossary terms missing: {len(report.glossary_usage.required_terms_missing)}",
+                f"- Forbidden glossary terms found: {report.glossary_usage.total_forbidden_found}",
+            ]
+        )
 
     if report.errors:
         lines.extend(["", "## Errors"])
         lines.extend(f"- {_single_line(error)}" for error in report.errors)
+
+    if report.glossary_usage.applied_terms:
+        lines.extend(["", "## Glossary usage"])
+        lines.extend(
+            f"- {_single_line(term)}: {count}"
+            for term, count in sorted(report.glossary_usage.applied_terms.items())
+        )
+
+    if report.glossary_usage.required_terms_missing or report.glossary_usage.forbidden_terms_found:
+        lines.extend(["", "## Glossary warnings"])
+        if report.glossary_usage.required_terms_missing:
+            lines.append(
+                f"- Required terms missing: {_format_terms(report.glossary_usage.required_terms_missing)}"
+            )
+        if report.glossary_usage.forbidden_terms_found:
+            lines.append(
+                f"- Forbidden terms found: {_format_counted_terms(report.glossary_usage.forbidden_terms_found)}"
+            )
 
     if validation_warnings:
         lines.extend(["", "## Validation warnings"])
@@ -1391,6 +1447,16 @@ def _prompt_output_path(default_path: Path) -> Path:
 
 def _single_line(value: str) -> str:
     return " ".join(value.split())
+
+
+def _format_terms(terms: list[str]) -> str:
+    return ", ".join(_single_line(term) for term in terms) if terms else "-"
+
+
+def _format_counted_terms(counts: dict[str, int]) -> str:
+    if not counts:
+        return "-"
+    return ", ".join(f"{_single_line(term)} ({count})" for term, count in sorted(counts.items()))
 
 
 def _resolve_existing_output_conflict(output_plan: OutputPlan, overwrite: bool, mode: UserMode) -> OutputPlan:

--- a/src/ayvu/epub_io.py
+++ b/src/ayvu/epub_io.py
@@ -11,7 +11,7 @@ from ebooklib import epub
 
 from .cache import TranslationCache
 from .domain import TranslationOptions
-from .glossary import Glossary
+from .glossary import Glossary, GlossaryUsage
 from .html_translate import HtmlTranslationStats, extract_visible_text, translate_html
 from .translator import Translator
 
@@ -64,6 +64,8 @@ class TranslationReport:
     texts_from_cache: int = 0
     texts_skipped: int = 0
     errors: list[str] = field(default_factory=list)
+    glossary_terms_configured: int = 0
+    glossary_usage: GlossaryUsage = field(default_factory=GlossaryUsage)
     output_path: Path | None = None
     input_path: Path | None = None
     detected_language: str | None = None
@@ -77,6 +79,7 @@ class TranslationReport:
         self.texts_from_cache += stats.from_cache
         self.texts_skipped += stats.skipped
         self.errors.extend(stats.errors)
+        self.glossary_usage.merge(stats.glossary_usage)
         self.chapters_processed += 1
 
 
@@ -148,6 +151,7 @@ def translate_epub(
         input_path=source_path,
         detected_language=_first_metadata(book, "DC", "language"),
         target_language=options.target,
+        glossary_terms_configured=len(glossary.entries) if glossary else 0,
     )
     opf_base_path = _get_opf_base_path(source_path)
     replacements = EpubReplacements()
@@ -192,6 +196,8 @@ def translate_epub(
                     raise
 
     if not options.dry_run:
+        if glossary:
+            report.glossary_usage.finalize_required_terms(glossary)
         destination_path.parent.mkdir(parents=True, exist_ok=True)
         _copy_epub_with_replacements(source_path, destination_path, replacements)
 

--- a/src/ayvu/glossary.py
+++ b/src/ayvu/glossary.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import re
 from collections.abc import Iterable, Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 
@@ -18,6 +18,7 @@ class GlossaryEntry:
     term: str
     rule: str
     translation: str | None = None
+    required: bool = False
 
     @property
     def replacement(self) -> str | None:
@@ -26,6 +27,68 @@ class GlossaryEntry:
         if self.rule == GLOSSARY_RULE_PRESERVE:
             return self.term
         return None
+
+    @property
+    def required_output(self) -> str | None:
+        if not self.required:
+            return None
+        return self.replacement
+
+
+@dataclass
+class GlossaryUsage:
+    applied_terms: dict[str, int] = field(default_factory=dict)
+    required_terms_present: dict[str, int] = field(default_factory=dict)
+    required_terms_missing: list[str] = field(default_factory=list)
+    forbidden_terms_found: dict[str, int] = field(default_factory=dict)
+
+    @property
+    def total_applied(self) -> int:
+        return sum(self.applied_terms.values())
+
+    @property
+    def total_forbidden_found(self) -> int:
+        return sum(self.forbidden_terms_found.values())
+
+    @property
+    def has_activity(self) -> bool:
+        return bool(
+            self.applied_terms
+            or self.required_terms_present
+            or self.required_terms_missing
+            or self.forbidden_terms_found
+        )
+
+    def record_applied(self, term: str, count: int) -> None:
+        _add_count(self.applied_terms, term, count)
+
+    def record_required_present(self, term: str, count: int) -> None:
+        _add_count(self.required_terms_present, term, count)
+
+    def record_forbidden_found(self, term: str, count: int) -> None:
+        _add_count(self.forbidden_terms_found, term, count)
+
+    def merge(self, other: "GlossaryUsage") -> None:
+        _merge_counts(self.applied_terms, other.applied_terms)
+        _merge_counts(self.required_terms_present, other.required_terms_present)
+        _merge_counts(self.forbidden_terms_found, other.forbidden_terms_found)
+        for term in other.required_terms_missing:
+            if term not in self.required_terms_missing:
+                self.required_terms_missing.append(term)
+
+    def finalize_required_terms(self, glossary: "Glossary") -> None:
+        self.required_terms_missing = [
+            entry.term
+            for entry in glossary.entries
+            if entry.required_output is not None
+            and self.required_terms_present.get(entry.term, 0) == 0
+        ]
+
+
+@dataclass(frozen=True)
+class GlossaryApplication:
+    text: str
+    usage: GlossaryUsage = field(default_factory=GlossaryUsage)
 
 
 @dataclass(frozen=True, init=False)
@@ -60,16 +123,27 @@ class Glossary:
         }
 
     def apply(self, text: str) -> str:
+        return self.apply_with_usage(text).text
+
+    def apply_with_usage(self, text: str) -> GlossaryApplication:
+        usage = GlossaryUsage()
         replace_entries = [entry for entry in self._ordered_entries() if entry.replacement is not None]
         if not replace_entries:
-            return text
+            usage.merge(self.scan_output(text))
+            return GlossaryApplication(text=text, usage=usage)
+
         result = text
         for entry in replace_entries:
             if not entry.term or entry.replacement is None:
                 continue
             pattern = _term_pattern(entry.term)
-            result = pattern.sub(lambda match: _match_case(match.group(0), entry.replacement), result)
-        return result
+            result, count = pattern.subn(
+                lambda match: _match_case(match.group(0), entry.replacement),
+                result,
+            )
+            usage.record_applied(entry.term, count)
+        usage.merge(self.scan_output(result))
+        return GlossaryApplication(text=result, usage=usage)
 
     def forbidden_terms_in(self, text: str) -> list[str]:
         return [
@@ -77,6 +151,16 @@ class Glossary:
             for entry in self._ordered_entries()
             if entry.rule == GLOSSARY_RULE_FORBIDDEN and _term_pattern(entry.term).search(text)
         ]
+
+    def scan_output(self, text: str) -> GlossaryUsage:
+        usage = GlossaryUsage()
+        for entry in self._ordered_entries():
+            required_output = entry.required_output
+            if required_output is not None:
+                usage.record_required_present(entry.term, _count_term(required_output, text))
+            if entry.rule == GLOSSARY_RULE_FORBIDDEN:
+                usage.record_forbidden_found(entry.term, _count_term(entry.term, text))
+        return usage
 
     def _ordered_entries(self) -> list[GlossaryEntry]:
         return sorted(self.entries, key=lambda entry: len(entry.term), reverse=True)
@@ -110,11 +194,18 @@ def load_glossary(path: str | Path | None) -> Glossary:
 
 
 def apply_glossary(text: str, glossary: Glossary | Mapping[object, object] | None) -> str:
+    return apply_glossary_with_usage(text, glossary).text
+
+
+def apply_glossary_with_usage(
+    text: str,
+    glossary: Glossary | Mapping[object, object] | None,
+) -> GlossaryApplication:
     if not glossary:
-        return text
+        return GlossaryApplication(text=text)
     if isinstance(glossary, Glossary):
-        return glossary.apply(text)
-    return Glossary(_parse_glossary_entries(glossary)).apply(text)
+        return glossary.apply_with_usage(text)
+    return Glossary(_parse_glossary_entries(glossary)).apply_with_usage(text)
 
 
 def _parse_glossary_entries(data: Mapping[object, object]) -> tuple[GlossaryEntry, ...]:
@@ -137,21 +228,22 @@ def _parse_glossary_entry(term: str, value: object) -> GlossaryEntry:
         allowed_rules = ", ".join(sorted(GLOSSARY_RULES))
         raise GlossaryError(f"Glossary entry for '{term}' uses unsupported rule '{rule}': {allowed_rules}")
 
-    allowed_fields = {"rule", "translation"} if rule == GLOSSARY_RULE_TRANSLATE else {"rule"}
+    allowed_fields = _allowed_fields_for_rule(rule)
     unknown_fields = sorted(set(value) - allowed_fields)
     if unknown_fields:
         fields = ", ".join(unknown_fields)
         raise GlossaryError(f"Glossary entry for '{term}' has unsupported fields: {fields}")
 
+    required = _parse_required(term, value.get("required", False))
     if rule == GLOSSARY_RULE_TRANSLATE:
         translation = value.get("translation")
         if not isinstance(translation, str):
             raise GlossaryError(
                 f"Glossary entry for '{term}' with rule 'translate' must include a string translation"
             )
-        return GlossaryEntry(term=term, rule=rule, translation=translation)
+        return GlossaryEntry(term=term, rule=rule, translation=translation, required=required)
 
-    return GlossaryEntry(term=term, rule=rule)
+    return GlossaryEntry(term=term, rule=rule, required=required)
 
 
 def _validate_term(term: str) -> None:
@@ -159,6 +251,34 @@ def _validate_term(term: str) -> None:
         raise GlossaryError("Glossary terms must not be empty")
     if term != term.strip():
         raise GlossaryError(f"Glossary term '{term}' must not start or end with whitespace")
+
+
+def _allowed_fields_for_rule(rule: str) -> set[str]:
+    if rule == GLOSSARY_RULE_TRANSLATE:
+        return {"rule", "translation", "required"}
+    if rule == GLOSSARY_RULE_PRESERVE:
+        return {"rule", "required"}
+    return {"rule"}
+
+
+def _parse_required(term: str, value: object) -> bool:
+    if not isinstance(value, bool):
+        raise GlossaryError(f"Glossary entry for '{term}' field 'required' must be a boolean")
+    return value
+
+
+def _add_count(counts: dict[str, int], term: str, count: int) -> None:
+    if count > 0:
+        counts[term] = counts.get(term, 0) + count
+
+
+def _merge_counts(target: dict[str, int], source: Mapping[str, int]) -> None:
+    for term, count in source.items():
+        _add_count(target, term, count)
+
+
+def _count_term(term: str, text: str) -> int:
+    return len(_term_pattern(term).findall(text))
 
 
 def _term_pattern(term: str) -> re.Pattern[str]:

--- a/src/ayvu/html_translate.py
+++ b/src/ayvu/html_translate.py
@@ -9,7 +9,7 @@ from bs4 import BeautifulSoup, Comment, Declaration, Doctype, NavigableString, P
 from .cache import CacheKey, TranslationCache
 from .chunking import split_text
 from .domain import LanguagePair
-from .glossary import Glossary, apply_glossary
+from .glossary import Glossary, GlossaryUsage, apply_glossary_with_usage
 from .translator import Translator
 
 
@@ -68,6 +68,7 @@ class HtmlTranslationStats:
     from_cache: int = 0
     skipped: int = 0
     errors: list[str] = field(default_factory=list)
+    glossary_usage: GlossaryUsage = field(default_factory=GlossaryUsage)
 
 
 @dataclass(frozen=True)
@@ -90,6 +91,7 @@ class TextParts:
 class TextTranslationResult:
     text: str
     from_cache: bool = False
+    glossary_usage: GlossaryUsage = field(default_factory=GlossaryUsage)
 
 
 def extract_visible_text(html: str | bytes) -> list[str]:
@@ -133,6 +135,7 @@ def translate_html(
             )
             if not dry_run:
                 text_node.replace_with(NavigableString(result.text))
+            stats.glossary_usage.merge(result.glossary_usage)
             _record_success(stats, result.from_cache, dry_run, on_text_processed)
         except Exception as exc:
             stats.errors.append(str(exc))
@@ -163,7 +166,12 @@ def translate_text(
     cache_key = CacheKey(text=parts.core, language_pair=language_pair)
     cached = cache.get(cache_key)
     if cached is not None:
-        return TextTranslationResult(text=parts.restore(apply_glossary(cached, glossary)), from_cache=True)
+        application = apply_glossary_with_usage(cached, glossary)
+        return TextTranslationResult(
+            text=parts.restore(application.text),
+            from_cache=True,
+            glossary_usage=application.usage,
+        )
 
     if dry_run:
         return TextTranslationResult(text=text)
@@ -175,8 +183,8 @@ def translate_text(
     ]
     translated = protected.restore("".join(translated_chunks))
     cache.set(cache_key, translated)
-    translated = apply_glossary(translated, glossary)
-    return TextTranslationResult(text=parts.restore(translated))
+    application = apply_glossary_with_usage(translated, glossary)
+    return TextTranslationResult(text=parts.restore(application.text), glossary_usage=application.usage)
 
 
 def _visible_text_nodes(soup: BeautifulSoup) -> list[NavigableString]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,6 +15,7 @@ from ayvu.cli import (
 )
 from ayvu.domain import LanguagePair, OutputPlan, TranslationOptions, UserMode
 from ayvu.epub_io import TranslationReport
+from ayvu.glossary import GlossaryUsage
 from ayvu.library import LibraryOpenError
 from ayvu.preflight import PreflightError
 from ayvu.resume import COMPLETED_STATUS, ResumeStateStore, TranslationResumeState
@@ -1217,11 +1218,18 @@ def test_translate_command_continues_when_existing_output_is_confirmed(tmp_path)
 
 
 def test_render_markdown_report_includes_translation_context():
+    glossary_usage = GlossaryUsage(
+        applied_terms={"Game Loop": 2, "Observer": 1},
+        required_terms_missing=["Object Pool"],
+        forbidden_terms_found={"AntiPattern": 1},
+    )
     report = TranslationReport(
         chapters_processed=2,
         texts_translated=3,
         texts_from_cache=1,
         errors=["chapter.xhtml: failed\nwhile translating"],
+        glossary_terms_configured=4,
+        glossary_usage=glossary_usage,
         output_path=Path("books/book-pt.epub"),
         input_path=Path("books/book.epub"),
         detected_language="en",
@@ -1239,6 +1247,16 @@ def test_render_markdown_report_includes_translation_context():
     assert "- Texts translated: 3" in markdown
     assert "- Texts from cache: 1" in markdown
     assert "- Errors: 1" in markdown
+    assert "- Glossary terms configured: 4" in markdown
+    assert "- Glossary terms applied: 3" in markdown
+    assert "- Required glossary terms missing: 1" in markdown
+    assert "- Forbidden glossary terms found: 1" in markdown
+    assert "## Glossary usage" in markdown
+    assert "- Game Loop: 2" in markdown
+    assert "- Observer: 1" in markdown
+    assert "## Glossary warnings" in markdown
+    assert "- Required terms missing: Object Pool" in markdown
+    assert "- Forbidden terms found: AntiPattern (1)" in markdown
     assert "- chapter.xhtml: failed while translating" in markdown
 
 

--- a/tests/test_epub_io.py
+++ b/tests/test_epub_io.py
@@ -18,6 +18,7 @@ from ayvu.epub_io import (
     normalize_language_code,
     translate_epub,
 )
+from ayvu.glossary import GLOSSARY_RULE_FORBIDDEN, GLOSSARY_RULE_PRESERVE, Glossary, GlossaryEntry
 
 
 class FakeBook:
@@ -224,3 +225,32 @@ def test_translate_epub_limits_documents_for_preview(minimal_epub_path: Path, tm
     assert "PT:Hello reader. Visit" in chapter_one
     assert "PT:Goodbye reader." not in chapter_two
     assert "Goodbye reader." in chapter_two
+
+
+def test_translate_epub_reports_glossary_usage(minimal_epub_path: Path, tmp_path: Path):
+    output_path = tmp_path / "minimal-pt.epub"
+    translator = PrefixTranslator()
+    options = TranslationOptions(language_pair=LanguagePair(source="en", target="pt"))
+    glossary = Glossary(
+        [
+            GlossaryEntry("PT:Hello reader", GLOSSARY_RULE_PRESERVE, required=True),
+            GlossaryEntry("Missing Term", GLOSSARY_RULE_PRESERVE, required=True),
+            GlossaryEntry("PT:Chapter Two", GLOSSARY_RULE_FORBIDDEN),
+        ]
+    )
+
+    with TranslationCache(tmp_path / "cache.sqlite") as cache:
+        report = translate_epub(
+            minimal_epub_path,
+            output_path,
+            translator=translator,
+            cache=cache,
+            options=options,
+            glossary=glossary,
+        )
+
+    assert report.glossary_terms_configured == 3
+    assert report.glossary_usage.applied_terms["PT:Hello reader"] == 1
+    assert report.glossary_usage.required_terms_present["PT:Hello reader"] == 1
+    assert report.glossary_usage.required_terms_missing == ["Missing Term"]
+    assert report.glossary_usage.forbidden_terms_found["PT:Chapter Two"] >= 1

--- a/tests/test_glossary.py
+++ b/tests/test_glossary.py
@@ -7,7 +7,9 @@ from ayvu.glossary import (
     Glossary,
     GlossaryEntry,
     GlossaryError,
+    GlossaryUsage,
     apply_glossary,
+    apply_glossary_with_usage,
     load_glossary,
 )
 
@@ -62,6 +64,68 @@ def test_load_glossary_supports_advanced_rules(tmp_path):
     assert glossary.forbidden_terms_in("Avoid foo in the output.") == ["Foo"]
 
 
+def test_load_glossary_supports_required_terms(tmp_path):
+    glossary_path = tmp_path / "glossary.json"
+    glossary_path.write_text(
+        """
+        {
+          "Game Loop": {
+            "rule": "translate",
+            "translation": "loop de jogo",
+            "required": true
+          },
+          "Observer": {
+            "rule": "preserve",
+            "required": true
+          }
+        }
+        """,
+        encoding="utf-8",
+    )
+
+    glossary = load_glossary(glossary_path)
+
+    assert glossary.entries == (
+        GlossaryEntry("Game Loop", GLOSSARY_RULE_TRANSLATE, "loop de jogo", required=True),
+        GlossaryEntry("Observer", GLOSSARY_RULE_PRESERVE, required=True),
+    )
+
+
+def test_apply_glossary_with_usage_counts_terms_and_scans_output():
+    glossary = Glossary(
+        [
+            GlossaryEntry("Game Loop", GLOSSARY_RULE_TRANSLATE, "loop de jogo", required=True),
+            GlossaryEntry("Observer", GLOSSARY_RULE_PRESERVE, required=True),
+            GlossaryEntry("AntiPattern", GLOSSARY_RULE_FORBIDDEN),
+        ]
+    )
+
+    application = apply_glossary_with_usage(
+        "The game loop keeps observer and mentions AntiPattern.",
+        glossary,
+    )
+
+    assert application.text == "The loop de jogo keeps Observer and mentions AntiPattern."
+    assert application.usage.applied_terms == {"Game Loop": 1, "Observer": 1}
+    assert application.usage.required_terms_present == {"Game Loop": 1, "Observer": 1}
+    assert application.usage.forbidden_terms_found == {"AntiPattern": 1}
+
+
+def test_glossary_usage_reports_missing_required_terms():
+    glossary = Glossary(
+        [
+            GlossaryEntry("Game Loop", GLOSSARY_RULE_TRANSLATE, "loop de jogo", required=True),
+            GlossaryEntry("Observer", GLOSSARY_RULE_PRESERVE, required=True),
+        ]
+    )
+    usage = GlossaryUsage()
+    usage.merge(glossary.scan_output("A loop de jogo is present."))
+
+    usage.finalize_required_terms(glossary)
+
+    assert usage.required_terms_missing == ["Observer"]
+
+
 def test_apply_glossary_preserve_rule_keeps_configured_term():
     glossary = Glossary(
         [
@@ -103,6 +167,28 @@ def test_load_glossary_rejects_unsupported_fields(tmp_path):
     glossary_path.write_text('{"Observer": {"rule": "preserve", "translation": "Observador"}}', encoding="utf-8")
 
     with pytest.raises(GlossaryError, match="unsupported fields: translation"):
+        load_glossary(glossary_path)
+
+
+def test_load_glossary_rejects_non_boolean_required(tmp_path):
+    glossary_path = tmp_path / "glossary.json"
+    glossary_path.write_text(
+        '{"Observer": {"rule": "preserve", "required": "yes"}}',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(GlossaryError, match="field 'required' must be a boolean"):
+        load_glossary(glossary_path)
+
+
+def test_load_glossary_rejects_required_for_forbidden_terms(tmp_path):
+    glossary_path = tmp_path / "glossary.json"
+    glossary_path.write_text(
+        '{"AntiPattern": {"rule": "forbidden", "required": true}}',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(GlossaryError, match="unsupported fields: required"):
         load_glossary(glossary_path)
 
 

--- a/tests/test_html_translate.py
+++ b/tests/test_html_translate.py
@@ -1,6 +1,12 @@
 from ayvu.cache import CacheKey, TranslationCache
 from ayvu.domain import LanguagePair
-from ayvu.glossary import GLOSSARY_RULE_PRESERVE, GLOSSARY_RULE_TRANSLATE, Glossary, GlossaryEntry
+from ayvu.glossary import (
+    GLOSSARY_RULE_FORBIDDEN,
+    GLOSSARY_RULE_PRESERVE,
+    GLOSSARY_RULE_TRANSLATE,
+    Glossary,
+    GlossaryEntry,
+)
 from ayvu.html_translate import extract_visible_text, translate_html, translate_text
 from ayvu.translator import Translator
 
@@ -99,6 +105,43 @@ def test_translate_text_applies_advanced_glossary_rules_to_cache_hits(tmp_path):
     assert result.text == "Observer uses the loop de jogo"
     assert result.from_cache
     assert translator.calls == []
+
+
+def test_translate_text_reports_glossary_usage_from_cache_hits(tmp_path):
+    translator = FakeTranslator()
+    glossary = Glossary(
+        [
+            GlossaryEntry("Observer", GLOSSARY_RULE_PRESERVE, required=True),
+            GlossaryEntry("Game Loop", GLOSSARY_RULE_TRANSLATE, "loop de jogo", required=True),
+            GlossaryEntry("AntiPattern", GLOSSARY_RULE_FORBIDDEN),
+        ]
+    )
+
+    with TranslationCache(tmp_path / "cache.sqlite") as cache:
+        cache_key = CacheKey(text="Keep me", language_pair=LanguagePair(source="en", target="pt"))
+        cache.set(cache_key, "observer uses the Game Loop and AntiPattern")
+
+        result = translate_text("Keep me", translator, cache, "en", "pt", glossary=glossary)
+
+    assert result.glossary_usage.applied_terms == {"Game Loop": 1, "Observer": 1}
+    assert result.glossary_usage.required_terms_present == {"Game Loop": 1, "Observer": 1}
+    assert result.glossary_usage.forbidden_terms_found == {"AntiPattern": 1}
+
+
+def test_translate_html_accumulates_glossary_usage(tmp_path):
+    html = "<html><body><p>Keep me</p><p>Keep me</p></body></html>"
+    translator = FakeTranslator()
+    glossary = Glossary(
+        [
+            GlossaryEntry("Mantenha-me", GLOSSARY_RULE_PRESERVE, required=True),
+        ]
+    )
+
+    with TranslationCache(tmp_path / "cache.sqlite") as cache:
+        _output, stats = translate_html(html, translator, cache, "en", "pt", glossary=glossary)
+
+    assert stats.glossary_usage.applied_terms == {"Mantenha-me": 2}
+    assert stats.glossary_usage.required_terms_present == {"Mantenha-me": 2}
 
 
 def test_translate_text_protects_special_terms_before_translating(tmp_path):


### PR DESCRIPTION
## Objective

Report how glossary rules affect EPUB translations so users can verify applied terms and spot consistency problems.

## What changed

- Added glossary usage accounting for applied translate and preserve rules, including text restored from cache.
- Added optional required: true support for translate and preserve glossary entries, with missing required terms reported after translation.
- Added forbidden term detection in translated output and surfaced glossary summaries in terminal and Markdown reports.
- Updated glossary docs, example glossary, changelog, and tests for the new report behavior.

## Out of scope

- No JSON report format was added because Ayvu does not currently expose a JSON translation report.
- No guided glossary creation or editing flow was added.

## Validation

- uv run pytest: 175 tests passing.
- git diff --check: no errors.

## Related issue

Closes #72