### PR TITLE
Add guided glossary management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ lancadas e secoes versionadas quando uma release for publicada.
   mantendo compatibilidade com o formato simples de pares de termos.
 - Relatorio de uso do glossario com contagem de termos aplicados, termos
   obrigatorios ausentes e termos proibidos encontrados na saida.
+- Menu guiado de glossarios no modo comum, com criacao, edicao, previa,
+  validacao, salvamento local e selecao antes de traduzir.
 
 ### Atualizado
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ O EPUB original nunca é alterado. A saída é gravada em um novo arquivo `.epub
 - Tradução de documentos XHTML/HTML internos do EPUB.
 - Preservação de tags, CSS, imagens, links, sumário e nomes de arquivos internos.
 - Cache SQLite para retomar traduções interrompidas e evitar chamadas repetidas.
-- Glossário JSON opcional para padronizar termos técnicos.
+- Glossário JSON opcional e fluxo guiado para padronizar termos técnicos.
 - Proteção de URLs, caminhos, comandos, versões, código inline e identificadores técnicos simples durante a tradução.
 - Nome de saída automático baseado no idioma de destino.
 - Preview traduzido de uma amostra inicial do EPUB.
@@ -149,7 +149,7 @@ previews, e a pasta base organiza biblioteca, previews, relatórios e traduçõe
 perguntar de novo.
 
 Ao executar apenas `uv run ayvu`, o Ayvu abre um primeiro menu guiado com opções para traduzir
-livro, gerar preview, abrir biblioteca, acessar configurações, mostrar ajuda ou sair. A biblioteca
+livro, gerar preview, abrir biblioteca, gerenciar glossários, acessar configurações, mostrar ajuda ou sair. A biblioteca
 lista EPUBs das pastas `Original` e `Traduzidos`, mostra as versões disponíveis de cada livro e
 permite abrir o original ou uma tradução no leitor configurado ou no leitor padrão detectado no
 sistema. A opção `Settings` permite ver e alterar idioma padrão, pasta base dos livros, nomes das
@@ -179,7 +179,30 @@ uv run ayvu translate livro.epub \
   --output livro-ptbr.epub
 ```
 
-Usar glossário:
+Usar glossário no modo comum:
+
+```bash
+uv run ayvu
+```
+
+Escolha `Glossaries` para criar ou editar um glossário guiado. O Ayvu pede o termo original,
+permite informar uma tradução preferida ou preservar o termo sem tradução, mostra uma prévia,
+valida o conteúdo e salva o JSON em:
+
+```text
+$XDG_CONFIG_HOME/ayvu/glossaries
+```
+
+Quando `XDG_CONFIG_HOME` não estiver definido, o fallback é:
+
+```text
+~/.config/ayvu/glossaries
+```
+
+Se houver glossários salvos, o fluxo guiado de tradução permite escolher um deles antes de
+confirmar a saída do EPUB.
+
+Usar glossário no modo desenvolvedor:
 
 ```bash
 cp glossary.example.json glossary.json
@@ -250,7 +273,9 @@ Use `translate` para definir uma tradução preferida e `preserve` para manter u
 
 Quando um glossário é usado, o relatório final conta quantas aplicações de `translate` e `preserve` ocorreram, inclusive em textos vindos do cache. O relatório também avisa termos obrigatórios ausentes e termos proibidos encontrados na saída.
 
-Use `glossary.example.json` como base. O arquivo `glossary.json` local é ignorado pelo Git para evitar versionar preferências pessoais ou conteúdo privado.
+Use `Glossaries` no modo comum para criar glossários guiados ou `glossary.example.json`
+como base para o modo desenvolvedor. O arquivo `glossary.json` local e os glossários privados
+são ignorados pelo Git para evitar versionar preferências pessoais ou conteúdo privado.
 
 Antes de enviar cada trecho ao tradutor, o Ayvu protege termos especiais como URLs, caminhos de arquivo, comandos de terminal, versões como `v1.2.0`, código inline entre crases, placeholders e identificadores técnicos simples. Esses termos são restaurados antes da aplicação do glossário e antes de salvar a tradução no cache.
 
@@ -340,6 +365,9 @@ Sem caminhos explícitos, a pasta base e os nomes de pastas configurados definem
 previews, traduções, relatórios Markdown e estados de processamento, além das pastas usadas pela
 biblioteca. O campo `reader_app` define o comando usado para abrir EPUBs pela biblioteca quando o
 leitor padrão do sistema não for suficiente.
+
+Glossários criados pelo modo comum ficam ao lado da configuração, em `glossaries/`, e podem ser
+selecionados antes de iniciar uma tradução guiada.
 
 ## Testes
 

--- a/docs/tutorial-modo-comum-e-dev.md
+++ b/docs/tutorial-modo-comum-e-dev.md
@@ -43,7 +43,7 @@ Abra o menu inicial:
 uv run ayvu
 ```
 
-O menu permite iniciar uma tradução, gerar preview, ver ajuda, abrir biblioteca e acessar configurações. A biblioteca lista EPUBs das pastas configuradas para originais e traduções, mostra as versões disponíveis e permite abrir o arquivo escolhido no leitor configurado ou no leitor padrão detectado no sistema. As configurações permitem alterar idioma padrão, pasta base dos livros, nomes das pastas das funcionalidades e app leitor de EPUB.
+O menu permite iniciar uma tradução, gerar preview, abrir biblioteca, gerenciar glossários, ver ajuda e acessar configurações. A biblioteca lista EPUBs das pastas configuradas para originais e traduções, mostra as versões disponíveis e permite abrir o arquivo escolhido no leitor configurado ou no leitor padrão detectado no sistema. As configurações permitem alterar idioma padrão, pasta base dos livros, nomes das pastas das funcionalidades e app leitor de EPUB.
 
 No primeiro uso, o Ayvu pergunta o idioma padrão de leitura/tradução e a pasta base dos livros. Em seguida, mostra os nomes das pastas das funcionalidades e permite manter os padrões ou alterá-los uma única vez antes de salvar a configuração. Essa pasta é usada para organizar biblioteca, previews, relatórios, traduções e estados de processamento.
 
@@ -69,7 +69,7 @@ Abra o preview no seu leitor de EPUB e confira capa, sumário, primeiro capítul
 
 ### Traduzir o livro completo
 
-Pelo menu inicial, escolha traduzir livro e informe o caminho do EPUB. O Ayvu mostra o idioma de destino padrão como primeira opção e também oferece `Outro idioma`. Ao escolher outro idioma, ele lista os idiomas do LibreTranslate com nome, código e estado. Depois disso, confirma onde o arquivo traduzido será salvo.
+Pelo menu inicial, escolha traduzir livro e informe o caminho do EPUB. O Ayvu mostra o idioma de destino padrão como primeira opção e também oferece `Outro idioma`. Ao escolher outro idioma, ele lista os idiomas do LibreTranslate com nome, código e estado. Se houver glossários salvos, o Ayvu permite escolher um deles antes de confirmar onde o arquivo traduzido será salvo.
 
 Antes de iniciar uma tradução real, o Ayvu verifica EPUB, idioma, glossário, cache e tradutor. Se algo estiver errado, ele falha cedo com uma mensagem curta e um próximo passo.
 
@@ -104,7 +104,24 @@ Use este fluxo quando estiver traduzindo livros técnicos ou quiser controlar me
 
 ### Usar glossário
 
-Crie um glossário a partir do exemplo versionado:
+No modo comum, escolha `Glossaries` no menu inicial. O Ayvu salva glossários guiados em:
+
+```text
+$XDG_CONFIG_HOME/ayvu/glossaries
+```
+
+Se `XDG_CONFIG_HOME` não estiver definido, o fallback é:
+
+```text
+~/.config/ayvu/glossaries
+```
+
+Ao criar ou editar um glossário, informe o termo original e escolha entre uma tradução
+preferida ou preservar o termo sem tradução. O Ayvu mostra uma prévia dos termos, valida o
+JSON e salva o arquivo. Na próxima tradução guiada, se houver glossários salvos, escolha o
+glossário desejado antes de iniciar o processamento.
+
+No modo desenvolvedor, crie um glossário a partir do exemplo versionado:
 
 ```bash
 cp glossary.example.json glossary.json

--- a/src/ayvu/cli.py
+++ b/src/ayvu/cli.py
@@ -11,7 +11,7 @@ from rich.table import Table
 
 from .cache import TranslationCache
 from .cli_progress import TranslationProgress, TranslationProgressSnapshot
-from .config import DEFAULT_BOOKS_DIR, AyvuConfig, ConfigError, ConfigStore, FolderNames
+from .config import DEFAULT_BOOKS_DIR, AyvuConfig, ConfigError, ConfigStore, FolderNames, default_glossaries_dir
 from .domain import (
     LanguagePair,
     OutputPlan,
@@ -21,6 +21,15 @@ from .domain import (
     default_translated_books_dir,
 )
 from .epub_io import TranslationReport, detect_epub_language, extract_markdown, inspect_epub, translate_epub
+from .glossary import (
+    GLOSSARY_RULE_PRESERVE,
+    GLOSSARY_RULE_TRANSLATE,
+    Glossary,
+    GlossaryEntry,
+    GlossaryError,
+    load_glossary,
+    save_glossary,
+)
 from .library import LibraryBook, LibraryOpenError, open_library_epub, scan_library
 from .preflight import PreflightError, run_translation_preflight
 from .resume import (
@@ -45,7 +54,8 @@ GUIDED_TRANSLATE_OPTION = "1"
 GUIDED_PREVIEW_OPTION = "2"
 GUIDED_LIBRARY_OPTION = "3"
 GUIDED_SETTINGS_OPTION = "4"
-GUIDED_HELP_OPTION = "5"
+GUIDED_GLOSSARY_OPTION = "5"
+GUIDED_HELP_OPTION = "6"
 GUIDED_EXIT_OPTION = "0"
 GUIDED_DEFAULT_LANGUAGE_OPTION = "1"
 GUIDED_OTHER_LANGUAGE_OPTION = "2"
@@ -55,6 +65,12 @@ SETTINGS_BOOKS_DIR_OPTION = "2"
 SETTINGS_FOLDERS_OPTION = "3"
 SETTINGS_READER_OPTION = "4"
 SETTINGS_EXIT_OPTION = "0"
+GLOSSARY_CREATE_OPTION = "1"
+GLOSSARY_EDIT_OPTION = "2"
+GLOSSARY_PREVIEW_OPTION = "3"
+GLOSSARY_BACK_OPTION = "0"
+GLOSSARY_RULE_TRANSLATE_OPTION = "1"
+GLOSSARY_RULE_PRESERVE_OPTION = "2"
 EXISTING_OUTPUT_OVERWRITE_OPTION = "1"
 EXISTING_OUTPUT_RENAME_OPTION = "2"
 EXISTING_OUTPUT_CANCEL_OPTION = "0"
@@ -765,6 +781,7 @@ def _print_guided_main_menu() -> None:
     table.add_row(GUIDED_PREVIEW_OPTION, "Generate preview")
     table.add_row(GUIDED_LIBRARY_OPTION, "Open library")
     table.add_row(GUIDED_SETTINGS_OPTION, "Settings")
+    table.add_row(GUIDED_GLOSSARY_OPTION, "Glossaries")
     table.add_row(GUIDED_HELP_OPTION, "Show command help")
     table.add_row(GUIDED_EXIT_OPTION, "Exit")
     console.print(table)
@@ -787,6 +804,10 @@ def _handle_guided_main_choice(choice: str, ctx: typer.Context, config: AyvuConf
         _run_guided_settings(config)
         return True
 
+    if choice == GUIDED_GLOSSARY_OPTION:
+        _run_guided_glossaries()
+        return True
+
     if choice == GUIDED_HELP_OPTION:
         console.print(ctx.get_help())
         return True
@@ -803,6 +824,7 @@ def _handle_guided_main_choice(choice: str, ctx: typer.Context, config: AyvuConf
 def _run_guided_translation(config: AyvuConfig) -> None:
     epub_path = Path(typer.prompt("EPUB path")).expanduser()
     target = _choose_guided_target_language(config.default_target_language)
+    glossary_path = _choose_guided_translation_glossary()
     _run_translation(
         epub_path=epub_path,
         output=None,
@@ -811,7 +833,7 @@ def _run_guided_translation(config: AyvuConfig) -> None:
         translator_name="libretranslate",
         url=DEFAULT_TRANSLATOR_URL,
         cache_path=Path(".cache/traducoes.sqlite"),
-        glossary_path=None,
+        glossary_path=glossary_path,
         dry_run=False,
         fail_fast=False,
         overwrite=False,
@@ -827,6 +849,248 @@ def _run_guided_preview(config: AyvuConfig) -> None:
     epub_path = Path(typer.prompt("EPUB path")).expanduser()
     target = _choose_guided_target_language(config.default_target_language)
     _run_preview(epub_path, target=target, mode=UserMode.COMMON, config=config)
+
+
+def _run_guided_glossaries() -> None:
+    directory = default_glossaries_dir()
+    _print_guided_glossary_menu(directory)
+    choice = typer.prompt("Choose a glossary action", default=GLOSSARY_BACK_OPTION).strip()
+    if choice == GLOSSARY_CREATE_OPTION:
+        _create_guided_glossary(directory)
+        return
+    if choice == GLOSSARY_EDIT_OPTION:
+        _edit_guided_glossary(directory)
+        return
+    if choice == GLOSSARY_PREVIEW_OPTION:
+        _preview_guided_glossary(directory)
+        return
+    if choice == GLOSSARY_BACK_OPTION:
+        console.print("Glossaries closed.")
+        return
+
+    console.print("[red]Invalid glossary action.[/red] Choose 1, 2, 3, or 0.")
+
+
+def _print_guided_glossary_menu(directory: Path) -> None:
+    console.print(f"[yellow]Glossaries folder:[/yellow] {directory}")
+    table = Table(title="Glossaries")
+    table.add_column("Option")
+    table.add_column("Action")
+    table.add_row(GLOSSARY_CREATE_OPTION, "Create glossary")
+    table.add_row(GLOSSARY_EDIT_OPTION, "Edit saved glossary")
+    table.add_row(GLOSSARY_PREVIEW_OPTION, "Preview saved glossary")
+    table.add_row(GLOSSARY_BACK_OPTION, "Back")
+    console.print(table)
+
+
+def _create_guided_glossary(directory: Path) -> Path | None:
+    path = _prompt_new_glossary_path(directory)
+    if path is None:
+        return None
+
+    glossary = _prompt_guided_glossary_terms(Glossary())
+    return _save_guided_glossary(path, glossary)
+
+
+def _edit_guided_glossary(directory: Path) -> Path | None:
+    files = _list_glossary_files(directory)
+    if not files:
+        console.print("[yellow]No saved glossaries found.[/yellow]")
+        return None
+
+    path = _prompt_saved_glossary_path(files)
+    if path is None:
+        return None
+
+    glossary = _load_guided_glossary(path)
+    if glossary is None:
+        return None
+
+    updated = _prompt_guided_glossary_terms(glossary)
+    return _save_guided_glossary(path, updated)
+
+
+def _preview_guided_glossary(directory: Path) -> None:
+    files = _list_glossary_files(directory)
+    if not files:
+        console.print("[yellow]No saved glossaries found.[/yellow]")
+        return
+
+    path = _prompt_saved_glossary_path(files)
+    if path is None:
+        return
+
+    glossary = _load_guided_glossary(path)
+    if glossary is None:
+        return
+    _print_guided_glossary_preview(glossary)
+
+
+def _choose_guided_translation_glossary() -> Path | None:
+    files = _list_glossary_files(default_glossaries_dir())
+    if not files:
+        return None
+
+    console.print("[yellow]Saved glossaries are available.[/yellow]")
+    while True:
+        path = _prompt_saved_glossary_path(files, back_label="Run without glossary")
+        if path is None:
+            return None
+        if _load_guided_glossary(path) is not None:
+            console.print(f"[green]Glossary selected:[/green] {path}")
+            return path
+        console.print("Choose another glossary or run without glossary.")
+
+
+def _prompt_new_glossary_path(directory: Path) -> Path | None:
+    while True:
+        raw_name = typer.prompt("Glossary name", default="glossary").strip()
+        stem = _safe_filename_part(Path(raw_name).stem or raw_name).lower()
+        path = directory / f"{stem}.json"
+        if not path.exists():
+            return path
+
+        console.print(f"[yellow]Glossary already exists:[/yellow] {path}")
+        if not typer.confirm("Choose another glossary name?", default=True):
+            console.print("Glossary was not created.")
+            return None
+
+
+def _prompt_guided_glossary_terms(glossary: Glossary) -> Glossary:
+    entries = list(glossary.entries)
+    if entries:
+        _print_guided_glossary_preview(Glossary(entries))
+
+    while True:
+        term = typer.prompt("Original term (leave empty to finish)", default="").strip()
+        if not term:
+            if entries:
+                return Glossary(entries)
+            console.print("[yellow]No glossary terms were added.[/yellow]")
+            return Glossary()
+
+        entry = _prompt_guided_glossary_entry(term)
+        replaced = _upsert_glossary_entry(entries, entry)
+        if replaced:
+            console.print(f"[green]Term updated:[/green] {entry.term}")
+        else:
+            console.print(f"[green]Term added:[/green] {entry.term}")
+        _print_guided_glossary_preview(Glossary(entries))
+
+        if not typer.confirm("Add another term?", default=True):
+            return Glossary(entries)
+
+
+def _prompt_guided_glossary_entry(term: str) -> GlossaryEntry:
+    console.print(f"{GLOSSARY_RULE_TRANSLATE_OPTION}. Use a preferred translation")
+    console.print(f"{GLOSSARY_RULE_PRESERVE_OPTION}. Preserve without translation")
+    while True:
+        rule_choice = typer.prompt("Choose term rule", default=GLOSSARY_RULE_TRANSLATE_OPTION).strip()
+        if rule_choice == GLOSSARY_RULE_TRANSLATE_OPTION:
+            translation = _prompt_required_text("Desired translation")
+            return GlossaryEntry(term=term, rule=GLOSSARY_RULE_TRANSLATE, translation=translation)
+        if rule_choice == GLOSSARY_RULE_PRESERVE_OPTION:
+            return GlossaryEntry(term=term, rule=GLOSSARY_RULE_PRESERVE)
+        console.print("[red]Invalid term rule.[/red] Choose 1 or 2.")
+
+
+def _prompt_required_text(prompt: str) -> str:
+    while True:
+        value = typer.prompt(prompt).strip()
+        if value:
+            return value
+        console.print("[red]Value must not be empty.[/red]")
+
+
+def _upsert_glossary_entry(entries: list[GlossaryEntry], entry: GlossaryEntry) -> bool:
+    for index, existing in enumerate(entries):
+        if existing.term.casefold() == entry.term.casefold():
+            entries[index] = entry
+            return True
+    entries.append(entry)
+    return False
+
+
+def _save_guided_glossary(path: Path, glossary: Glossary) -> Path | None:
+    if not glossary.entries:
+        console.print("[yellow]Glossary was not saved because it has no terms.[/yellow]")
+        return None
+
+    _print_guided_glossary_preview(glossary)
+    if not typer.confirm("Save this glossary?", default=True):
+        console.print("Glossary was not saved.")
+        return None
+
+    try:
+        saved_path = save_glossary(path, glossary)
+    except GlossaryError as exc:
+        console.print(f"[red]Glossary validation failed:[/red] {exc}")
+        return None
+
+    console.print(f"[green]Glossary saved:[/green] {saved_path}")
+    return saved_path
+
+
+def _load_guided_glossary(path: Path) -> Glossary | None:
+    try:
+        return load_glossary(path)
+    except GlossaryError as exc:
+        console.print(f"[red]Could not load glossary:[/red] {exc}")
+        return None
+
+
+def _prompt_saved_glossary_path(files: tuple[Path, ...], back_label: str = "Back") -> Path | None:
+    _print_saved_glossaries(files)
+    console.print(f"{GLOSSARY_BACK_OPTION}. {back_label}")
+
+    while True:
+        choice = typer.prompt("Choose glossary", default=GLOSSARY_BACK_OPTION).strip()
+        if choice == GLOSSARY_BACK_OPTION:
+            return None
+        if choice.isdigit() and 1 <= int(choice) <= len(files):
+            return files[int(choice) - 1]
+        console.print(f"[red]Invalid glossary.[/red] Choose 1-{len(files)} or 0.")
+
+
+def _print_saved_glossaries(files: tuple[Path, ...]) -> None:
+    table = Table(title="Saved glossaries")
+    table.add_column("Option")
+    table.add_column("Name")
+    table.add_column("Terms")
+    for index, path in enumerate(files, start=1):
+        table.add_row(str(index), path.stem, _glossary_term_count(path))
+    console.print(table)
+
+
+def _glossary_term_count(path: Path) -> str:
+    glossary = _load_guided_glossary(path)
+    if glossary is None:
+        return "invalid"
+    return str(len(glossary.entries))
+
+
+def _print_guided_glossary_preview(glossary: Glossary) -> None:
+    if not glossary.entries:
+        console.print("[yellow]Glossary has no terms yet.[/yellow]")
+        return
+
+    table = Table(title="Glossary preview")
+    table.add_column("Term")
+    table.add_column("Rule")
+    table.add_column("Translation")
+    for entry in glossary.entries:
+        table.add_row(entry.term, entry.rule, entry.translation or "-")
+    console.print(table)
+
+
+def _list_glossary_files(directory: Path) -> tuple[Path, ...]:
+    if not directory.exists():
+        return ()
+    try:
+        return tuple(sorted(path for path in directory.glob("*.json") if path.is_file()))
+    except OSError as exc:
+        console.print(f"[yellow]Could not list glossaries:[/yellow] {exc}")
+        return ()
 
 
 def _run_guided_library(config: AyvuConfig) -> None:

--- a/src/ayvu/config.py
+++ b/src/ayvu/config.py
@@ -12,6 +12,7 @@ DEFAULT_TARGET_LANGUAGE = "pt"
 DEFAULT_BOOKS_DIR = "~/Documentos/Livros"
 DEFAULT_CONFIG_DIR = "ayvu"
 DEFAULT_CONFIG_FILE = "config.json"
+DEFAULT_GLOSSARIES_DIR = "glossaries"
 
 
 class ConfigError(ValueError):
@@ -156,6 +157,10 @@ def default_config_path(env: Mapping[str, str] | None = None, home: Path | None 
     else:
         base_dir = (home or Path.home()) / ".config"
     return base_dir / DEFAULT_CONFIG_DIR / DEFAULT_CONFIG_FILE
+
+
+def default_glossaries_dir(env: Mapping[str, str] | None = None, home: Path | None = None) -> Path:
+    return default_config_path(env=env, home=home).parent / DEFAULT_GLOSSARIES_DIR
 
 
 def _optional_text(data: dict[str, object], key: str, default: str) -> str:

--- a/src/ayvu/glossary.py
+++ b/src/ayvu/glossary.py
@@ -193,6 +193,28 @@ def load_glossary(path: str | Path | None) -> Glossary:
     return Glossary(_parse_glossary_entries(data))
 
 
+def save_glossary(path: str | Path, glossary: Glossary) -> Path:
+    glossary_path = Path(path)
+    data = glossary_to_dict(glossary)
+    try:
+        glossary_path.parent.mkdir(parents=True, exist_ok=True)
+        glossary_path.write_text(
+            json.dumps(data, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        raise GlossaryError(f"Could not write glossary file: {glossary_path}") from exc
+    return glossary_path
+
+
+def glossary_to_dict(glossary: Glossary) -> dict[str, object]:
+    data: dict[str, object] = {}
+    for entry in glossary.entries:
+        data[entry.term] = _glossary_entry_to_value(entry)
+    _parse_glossary_entries(data)
+    return data
+
+
 def apply_glossary(text: str, glossary: Glossary | Mapping[object, object] | None) -> str:
     return apply_glossary_with_usage(text, glossary).text
 
@@ -210,6 +232,30 @@ def apply_glossary_with_usage(
 
 def _parse_glossary_entries(data: Mapping[object, object]) -> tuple[GlossaryEntry, ...]:
     return tuple(_parse_glossary_entry(str(term), value) for term, value in data.items())
+
+
+def _glossary_entry_to_value(entry: GlossaryEntry) -> object:
+    if entry.rule == GLOSSARY_RULE_TRANSLATE:
+        if entry.translation is None:
+            raise GlossaryError(
+                f"Glossary entry for '{entry.term}' with rule 'translate' must include a string translation"
+            )
+        value: dict[str, object] = {
+            "rule": GLOSSARY_RULE_TRANSLATE,
+            "translation": entry.translation,
+        }
+        if entry.required:
+            value["required"] = True
+        return value
+    if entry.rule == GLOSSARY_RULE_PRESERVE:
+        value = {"rule": GLOSSARY_RULE_PRESERVE}
+        if entry.required:
+            value["required"] = True
+        return value
+    if entry.rule == GLOSSARY_RULE_FORBIDDEN:
+        return {"rule": GLOSSARY_RULE_FORBIDDEN}
+    allowed_rules = ", ".join(sorted(GLOSSARY_RULES))
+    raise GlossaryError(f"Glossary entry for '{entry.term}' uses unsupported rule '{entry.rule}': {allowed_rules}")
 
 
 def _parse_glossary_entry(term: str, value: object) -> GlossaryEntry:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -544,6 +544,87 @@ def test_root_command_starts_guided_translation(tmp_path, monkeypatch):
     assert options.target == "pt"
 
 
+def test_root_command_creates_guided_glossary(isolated_config, tmp_path, monkeypatch):
+    monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: tmp_path / "missing")
+
+    result = runner.invoke(
+        app,
+        [],
+        input="5\n1\nTechnical Terms\nGame Loop\n1\nloop de jogo\ny\nObserver\n2\nn\ny\n",
+    )
+
+    glossary_path = isolated_config.parent / "glossaries" / "technical-terms.json"
+    assert result.exit_code == 0
+    assert "Glossaries" in result.output
+    assert "Glossary preview" in result.output
+    assert "Glossary saved:" in result.output
+    assert json.loads(glossary_path.read_text(encoding="utf-8")) == {
+        "Game Loop": {"rule": "translate", "translation": "loop de jogo"},
+        "Observer": {"rule": "preserve"},
+    }
+
+
+def test_root_command_edits_guided_glossary(isolated_config, tmp_path, monkeypatch):
+    monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: tmp_path / "missing")
+    glossary_dir = isolated_config.parent / "glossaries"
+    glossary_dir.mkdir()
+    glossary_path = glossary_dir / "technical.json"
+    glossary_path.write_text('{"Observer": {"rule": "preserve"}}\n', encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        [],
+        input="5\n2\n1\nObject Pool\n1\npool de objetos\nn\ny\n",
+    )
+
+    assert result.exit_code == 0
+    assert "Edit saved glossary" in result.output
+    assert "Saved glossaries" in result.output
+    assert "Term added:" in result.output
+    assert json.loads(glossary_path.read_text(encoding="utf-8")) == {
+        "Observer": {"rule": "preserve"},
+        "Object Pool": {"rule": "translate", "translation": "pool de objetos"},
+    }
+
+
+def test_root_command_selects_saved_glossary_for_guided_translation(isolated_config, tmp_path, monkeypatch):
+    epub_path = tmp_path / "book.epub"
+    output_dir = tmp_path / "Traduzidos"
+    processing_dir = tmp_path / "Processando"
+    epub_path.write_bytes(b"fake epub")
+    glossary_dir = isolated_config.parent / "glossaries"
+    glossary_dir.mkdir()
+    glossary_path = glossary_dir / "technical.json"
+    glossary_path.write_text('{"Observer": {"rule": "preserve"}}\n', encoding="utf-8")
+    calls: dict[str, object] = {}
+
+    def fake_preflight(**kwargs: object) -> object:
+        calls["preflight"] = kwargs
+        return SimpleNamespace(translator=object(), glossary=object(), route=None)
+
+    def fake_translate(input_path: Path, output_path: Path, **kwargs: object) -> TranslationReport:
+        calls["input_path"] = input_path
+        calls["output_path"] = output_path
+        calls["glossary"] = kwargs["glossary"]
+        return TranslationReport(output_path=output_path, input_path=input_path, target_language="pt")
+
+    monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: processing_dir)
+    monkeypatch.setattr("ayvu.cli.default_translated_books_dir", lambda: output_dir)
+    monkeypatch.setattr("ayvu.cli.run_translation_preflight", fake_preflight)
+    monkeypatch.setattr("ayvu.cli.TranslationCache", lambda _path: FakeCache())
+    monkeypatch.setattr("ayvu.cli.translate_epub", fake_translate)
+    monkeypatch.setattr("ayvu.cli.validate_output_epub", lambda _path, on_progress=None: ValidationResult(ok=True, document_count=1))
+    monkeypatch.setattr("ayvu.cli._offer_markdown_report", lambda *_args, **_kwargs: None)
+
+    result = runner.invoke(app, [], input=f"1\n{epub_path}\n1\n1\ny\n")
+
+    assert result.exit_code == 0
+    assert "Saved glossaries are available." in result.output
+    assert "Glossary selected:" in result.output
+    assert calls["preflight"]["glossary_path"] == glossary_path
+    assert calls["glossary"] is not None
+
+
 def test_root_command_shows_empty_guided_library(isolated_config, tmp_path):
     books_dir = tmp_path / "Biblioteca"
     isolated_config.write_text(
@@ -842,7 +923,7 @@ def test_root_command_ignores_invalid_config(isolated_config, tmp_path, monkeypa
 def test_root_command_can_show_help_from_guided_menu(tmp_path, monkeypatch):
     monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: tmp_path / "missing")
 
-    result = runner.invoke(app, [], input="5\n")
+    result = runner.invoke(app, [], input="6\n")
 
     assert result.exit_code == 0
     assert "Show command help" in result.output

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,6 +9,7 @@ from ayvu.config import (
     ConfigStore,
     FolderNames,
     default_config_path,
+    default_glossaries_dir,
 )
 
 
@@ -22,6 +23,12 @@ def test_default_config_path_falls_back_to_home_config(tmp_path):
     path = default_config_path({}, home=tmp_path)
 
     assert path == tmp_path / ".config" / "ayvu" / "config.json"
+
+
+def test_default_glossaries_dir_uses_ayvu_config_folder():
+    path = default_glossaries_dir({"XDG_CONFIG_HOME": "/tmp/custom-config"})
+
+    assert path == Path("/tmp/custom-config/ayvu/glossaries")
 
 
 def test_default_config_defines_initial_preferences():

--- a/tests/test_glossary.py
+++ b/tests/test_glossary.py
@@ -10,7 +10,9 @@ from ayvu.glossary import (
     GlossaryUsage,
     apply_glossary,
     apply_glossary_with_usage,
+    glossary_to_dict,
     load_glossary,
+    save_glossary,
 )
 
 
@@ -89,6 +91,27 @@ def test_load_glossary_supports_required_terms(tmp_path):
         GlossaryEntry("Game Loop", GLOSSARY_RULE_TRANSLATE, "loop de jogo", required=True),
         GlossaryEntry("Observer", GLOSSARY_RULE_PRESERVE, required=True),
     )
+
+
+def test_save_glossary_writes_valid_advanced_json(tmp_path):
+    glossary_path = tmp_path / "glossaries" / "technical.json"
+    glossary = Glossary(
+        [
+            GlossaryEntry("Game Loop", GLOSSARY_RULE_TRANSLATE, "loop de jogo"),
+            GlossaryEntry("Observer", GLOSSARY_RULE_PRESERVE),
+            GlossaryEntry("AntiPattern", GLOSSARY_RULE_FORBIDDEN),
+        ]
+    )
+
+    saved_path = save_glossary(glossary_path, glossary)
+
+    assert saved_path == glossary_path
+    assert glossary_to_dict(glossary) == {
+        "Game Loop": {"rule": "translate", "translation": "loop de jogo"},
+        "Observer": {"rule": "preserve"},
+        "AntiPattern": {"rule": "forbidden"},
+    }
+    assert load_glossary(glossary_path).entries == glossary.entries
 
 
 def test_apply_glossary_with_usage_counts_terms_and_scans_output():


### PR DESCRIPTION
## Objective

Let common-mode users create, edit, preview, validate, save, and select glossaries without manually writing JSON.

## What changed

- Added a common-mode `Glossaries` menu for creating, editing, and previewing saved glossaries.
- Added guided term prompts for preferred translations and preserve-without-translation rules.
- Added a default local glossaries folder under the Ayvu config directory.
- Added glossary serialization and validated saving helpers.
- Let guided translation select a saved glossary before processing.
- Updated tests and user documentation for the guided glossary flow.

## Out of scope

- Removing glossary terms from the guided editor.
- Configurable glossary storage outside the Ayvu config directory.
- Guided creation of forbidden or required glossary rules.

## Validation

- `uv run pytest`: 180 tests passing.
- `git diff --check`: no errors.

## Related issue

Closes #73