### PR TITLE
Translate HTML by block preserving inline tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@ lancadas e secoes versionadas quando uma release for publicada.
 
 ### Atualizado
 
+- Traducao de HTML agora ocorre por bloco (paragrafos, titulos e itens de
+  lista), substituindo tags internas como `em`, `strong` e links por
+  placeholders e restaurando-as depois. O cache passa a usar o bloco como
+  unidade de traducao.
 - Saida padrao da traducao no modo comum agora e confirmada antes de iniciar.
 - Modo comum permite sobrescrever, escolher outro nome ou cancelar quando o EPUB
   de saida ja existe.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ O EPUB original nunca é alterado. A saída é gravada em um novo arquivo `.epub
 ## Recursos
 
 - Tradução de documentos XHTML/HTML internos do EPUB.
+- Tradução por bloco (parágrafos, títulos e listas) preservando tags internas como `em`, `strong` e links via placeholders.
 - Preservação de tags, CSS, imagens, links, sumário e nomes de arquivos internos.
 - Cache SQLite para retomar traduções interrompidas e evitar chamadas repetidas.
 - Glossário JSON opcional e fluxo guiado para padronizar termos técnicos.
@@ -401,7 +402,6 @@ ayvu/
 
 ## Limitações
 
-- A tradução por nós de texto pode perder contexto em frases divididas por tags.
 - EPUBs com XHTML malformado podem depender do comportamento do parser.
 - Livros técnicos costumam exigir glossário para manter termos consistentes.
 - A qualidade final depende do servidor de tradução usado.

--- a/docs/relatorio-tecnico.md
+++ b/docs/relatorio-tecnico.md
@@ -50,7 +50,6 @@ Ainda não possui:
 
 - biblioteca completa com importação automática, fila e histórico;
 - gerenciamento automático do LibreTranslate;
-- tradução por bloco preservando tags internas;
 - validação EPUB avançada com EPUBCheck;
 - backends alternativos além de LibreTranslate;
 - interface gráfica ou web.
@@ -225,7 +224,7 @@ uv run ayvu --mode common translate livro.epub
 
 `src/ayvu/epub_io.py` cuida de leitura, inspeção, extração, tradução estrutural e escrita do EPUB final.
 
-`src/ayvu/html_translate.py` traduz HTML/XHTML em nível de nó de texto visível, preservando tags e ignorando conteúdo que não deve ser traduzido.
+`src/ayvu/html_translate.py` traduz HTML/XHTML por bloco (parágrafos, títulos e itens de lista), substituindo tags inline por placeholders neutros e restaurando-as depois, preservando tags e atributos e ignorando conteúdo que não deve ser traduzido.
 
 `src/ayvu/library.py` varre as pastas de biblioteca configuradas, agrupa EPUB original e traduções por livro e resolve o comando usado para abrir EPUBs no app leitor.
 
@@ -321,7 +320,7 @@ A regra principal é:
 ```text
 Não achatar HTML.
 Não usar get_text() no fluxo de tradução.
-Traduzir somente nós de texto visíveis.
+Traduzir somente texto visível ao leitor.
 ```
 
 Tags ignoradas:
@@ -332,21 +331,21 @@ script, style, code, pre, kbd, samp, svg, math
 
 Também são ignorados comentários, `DOCTYPE`, declarações XML e processing instructions.
 
+A tradução acontece por bloco. Sequências contíguas de texto e tags inline formam uma unidade de tradução, como parágrafos, títulos e itens de lista. As tags inline, como `em`, `strong` e links, viram placeholders neutros antes de enviar ao tradutor e são restauradas depois, preservando atributos e estrutura. Tags inline ignoradas (`code`, `kbd`, `samp`) e elementos vazios (como `br`) entram como placeholder opaco e não são traduzidos. Texto solto entre elementos de bloco continua sendo traduzido, sem perda.
+
 Exemplo:
 
 ```html
 <p>Any programming book with <em>Patterns</em> in its name.</p>
 ```
 
-Hoje isso pode ser traduzido em três nós separados:
+O parágrafo inteiro é traduzido como uma unidade, no formato:
 
 ```text
-"Any programming book with "
-"Patterns"
-" in its name."
+Any programming book with __AYVU_TAG_0__Patterns__AYVU_TAG_1__ in its name.
 ```
 
-Essa escolha preserva a estrutura, mas pode perder contexto. A melhoria planejada é traduzir blocos com placeholders de tags, sem enviar HTML real ao tradutor.
+onde `__AYVU_TAG_0__` e `__AYVU_TAG_1__` representam `<em>` e `</em>`. Depois da tradução, os placeholders voltam a ser as tags originais. Isso dá mais contexto ao tradutor sem enviar HTML real e sem perder estrutura.
 
 ## 12. Cache, glossário e chunking
 
@@ -355,6 +354,8 @@ O cache SQLite usa chave baseada em:
 ```text
 source_lang + target_lang + SHA-256(texto original)
 ```
+
+Com a tradução por bloco, o "texto original" é o bloco inteiro com placeholders de tags, então a unidade do cache é o bloco, não mais o nó de texto isolado. Blocos sem tags mantêm a mesma chave de antes; blocos com tags geram chaves novas, o que evita reaproveitar por engano entradas antigas guardadas por nó.
 
 O glossário é aplicado depois da tradução e também sobre textos recuperados do cache. Isso mantém o comportamento consistente entre texto novo e texto reaproveitado.
 
@@ -477,13 +478,14 @@ Se o servidor estiver indisponível, o Ayvu deve falhar com uma mensagem orienta
 
 ## 18. Testes e CI
 
-A suíte atual tem 167 testes definidos em `tests/`, cobrindo:
+A suíte atual tem 189 testes definidos em `tests/`, cobrindo:
 
 - cache SQLite;
 - chunking;
 - glossário;
 - configuração local;
 - tradução de HTML;
+- tradução por bloco com placeholders de tags;
 - preservação de tags;
 - extração de texto visível;
 - caminhos internos de EPUB;
@@ -507,15 +509,14 @@ uv run pytest
 
 Prioridades que ainda fazem sentido:
 
-1. Traduzir blocos HTML preservando tags internas por placeholders.
-2. Evoluir o glossário para regras explícitas de preservar, traduzir e proibir termos.
-3. Melhorar validação pós-tradução, incluindo links, capítulos vazios, imagens ausentes e texto não traduzido.
-4. Criar configuração persistente para idioma padrão, pastas e preferências.
-5. Melhorar cache com inspeção, limpeza, exportação e escopo por backend/modelo/glossário.
-6. Adicionar modo `--cache-only`.
-7. Suportar backends alternativos.
-8. Documentar arquitetura em um documento dedicado.
-9. Preparar empacotamento e releases públicas.
+1. Evoluir o glossário para regras explícitas de preservar, traduzir e proibir termos.
+2. Melhorar validação pós-tradução, incluindo links, capítulos vazios, imagens ausentes e texto não traduzido.
+3. Criar configuração persistente para idioma padrão, pastas e preferências.
+4. Melhorar cache com inspeção, limpeza, exportação e escopo por backend/modelo/glossário.
+5. Adicionar modo `--cache-only`.
+6. Suportar backends alternativos.
+7. Documentar arquitetura em um documento dedicado.
+8. Preparar empacotamento e releases públicas.
 
 ## 20. Possível suporte a PDF
 

--- a/src/ayvu/html_translate.py
+++ b/src/ayvu/html_translate.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import copy
 import re
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from xml.sax.saxutils import escape
 
 from bs4 import BeautifulSoup, Comment, Declaration, Doctype, NavigableString, ProcessingInstruction
 
@@ -14,12 +16,28 @@ from .translator import Translator
 
 
 IGNORED_TAGS = {"script", "style", "code", "pre", "kbd", "samp", "svg", "math"}
+# Ignored tags that may appear inline inside a block. Their whole markup is kept
+# untranslated as an opaque token instead of acting as a block boundary.
+IGNORED_INLINE_TAGS = {"code", "kbd", "samp"}
+# Inline tags whose text is translated together with the surrounding block. The
+# tags themselves are replaced by neutral placeholders and restored afterwards.
+INLINE_TAGS = {
+    "a", "abbr", "b", "bdi", "bdo", "br", "cite", "data", "del", "dfn", "em",
+    "i", "ins", "mark", "q", "rp", "rt", "ruby", "s", "small", "span", "strike",
+    "strong", "sub", "sup", "time", "u", "var", "wbr",
+}
 PROTECTED_PLACEHOLDER_PREFIX = "__AYVU_PROTECTED_"
 PROTECTED_PLACEHOLDER_SUFFIX = "__"
+TAG_PLACEHOLDER_PREFIX = "__AYVU_TAG_"
+TAG_PLACEHOLDER_SUFFIX = "__"
+TAG_TOKEN_PATTERN = re.compile(r"__AYVU_TAG_(\d+)__")
+TAG_MARKUP_SENTINEL = "AYVU_TAG_MARKUP_SENTINEL"
+FRAGMENT_ROOT_TAG = "__ayvu_fragment_root__"
 TextProgressCallback = Callable[[str], None]
 
 
 SPECIAL_TERM_PATTERNS = (
+    TAG_TOKEN_PATTERN,
     re.compile(r"`[^`\n]+`"),
     re.compile(r"\{\{[^{}\n]+\}\}"),
     re.compile(r"\{[A-Za-z_][A-Za-z0-9_]*\}"),
@@ -115,16 +133,15 @@ def translate_html(
     soup = BeautifulSoup(html, "lxml-xml")
     stats = HtmlTranslationStats()
 
-    for text_node in list(soup.find_all(string=True)):
-        if not _is_translatable_text_node(text_node):
+    for run in _collect_translation_runs(soup):
+        template, tag_markup = _build_block_template(run)
+        if not _has_translatable_text(template):
             stats.skipped += 1
             continue
 
-        original = str(text_node)
-
         try:
             result = translate_text(
-                original,
+                template,
                 translator=translator,
                 cache=cache,
                 source=source,
@@ -134,7 +151,8 @@ def translate_html(
                 chunk_limit=chunk_limit,
             )
             if not dry_run:
-                text_node.replace_with(NavigableString(result.text))
+                fragment = _expand_tag_tokens(escape(result.text), tag_markup)
+                _replace_run(run, _parse_fragment_nodes(fragment))
             stats.glossary_usage.merge(result.glossary_usage)
             _record_success(stats, result.from_cache, dry_run, on_text_processed)
         except Exception as exc:
@@ -191,10 +209,138 @@ def _visible_text_nodes(soup: BeautifulSoup) -> list[NavigableString]:
     return [text_node for text_node in soup.find_all(string=True) if _is_visible_text_node(text_node)]
 
 
-def _is_translatable_text_node(text_node: NavigableString) -> bool:
-    if not _is_visible_text_node(text_node):
+def _collect_translation_runs(element) -> list[list]:
+    """Group consecutive inline siblings into translation runs.
+
+    Block-level and ignored-block children act as boundaries; we recurse into
+    them so their own inline content becomes separate runs. This keeps loose
+    text mixed with block elements from being lost.
+    """
+    runs: list[list] = []
+    current: list = []
+    for child in list(element.children):
+        if _is_run_member(child):
+            current.append(child)
+            continue
+        if current:
+            runs.append(current)
+            current = []
+        if _should_recurse_into(child):
+            runs.extend(_collect_translation_runs(child))
+    if current:
+        runs.append(current)
+    return runs
+
+
+def _is_run_member(node) -> bool:
+    if _is_special_string(node):
         return False
-    return bool(str(text_node).strip())
+    if isinstance(node, NavigableString):
+        return True
+    name = _tag_name(node)
+    if name in IGNORED_INLINE_TAGS:
+        return True
+    if name in INLINE_TAGS:
+        return not _contains_block_descendant(node)
+    return False
+
+
+def _should_recurse_into(node) -> bool:
+    name = _tag_name(node)
+    return bool(name) and name not in IGNORED_TAGS
+
+
+def _contains_block_descendant(node) -> bool:
+    return any(
+        _tag_name(descendant) not in INLINE_TAGS
+        and _tag_name(descendant) not in IGNORED_INLINE_TAGS
+        for descendant in node.find_all(True)
+    )
+
+
+def _build_block_template(run: list) -> tuple[str, list[str]]:
+    parts: list[str] = []
+    tag_markup: list[str] = []
+    for node in run:
+        _emit_template_node(node, parts, tag_markup)
+    return "".join(parts), tag_markup
+
+
+def _emit_template_node(node, parts: list[str], tag_markup: list[str]) -> None:
+    if _is_special_string(node):
+        parts.append(_register_tag_markup(tag_markup, str(node)))
+        return
+    if isinstance(node, NavigableString):
+        parts.append(str(node))
+        return
+    if _tag_name(node) in IGNORED_INLINE_TAGS or _is_void_element(node):
+        parts.append(_register_tag_markup(tag_markup, str(node)))
+        return
+
+    open_markup, close_markup = _split_tag_markup(node)
+    parts.append(_register_tag_markup(tag_markup, open_markup))
+    for child in list(node.children):
+        _emit_template_node(child, parts, tag_markup)
+    parts.append(_register_tag_markup(tag_markup, close_markup))
+
+
+def _register_tag_markup(tag_markup: list[str], markup: str) -> str:
+    placeholder = f"{TAG_PLACEHOLDER_PREFIX}{len(tag_markup)}{TAG_PLACEHOLDER_SUFFIX}"
+    tag_markup.append(markup)
+    return placeholder
+
+
+def _split_tag_markup(node) -> tuple[str, str]:
+    clone = copy.copy(node)
+    clone.clear()
+    clone.append(NavigableString(TAG_MARKUP_SENTINEL))
+    open_markup, _, close_markup = str(clone).partition(TAG_MARKUP_SENTINEL)
+    return open_markup, close_markup
+
+
+def _has_translatable_text(template: str) -> bool:
+    return bool(TAG_TOKEN_PATTERN.sub("", template).strip())
+
+
+def _expand_tag_tokens(text: str, tag_markup: list[str]) -> str:
+    def replace(match: re.Match[str]) -> str:
+        index = int(match.group(1))
+        if 0 <= index < len(tag_markup):
+            return tag_markup[index]
+        return match.group(0)
+
+    return TAG_TOKEN_PATTERN.sub(replace, text)
+
+
+def _parse_fragment_nodes(fragment: str) -> list:
+    soup = BeautifulSoup(f"<{FRAGMENT_ROOT_TAG}>{fragment}</{FRAGMENT_ROOT_TAG}>", "lxml-xml")
+    root = soup.find(FRAGMENT_ROOT_TAG)
+    if root is None:
+        return [NavigableString(fragment)]
+    return [child.extract() for child in list(root.children)]
+
+
+def _replace_run(run: list, new_nodes: list) -> None:
+    if not new_nodes:
+        return
+    anchor = run[0]
+    for node in new_nodes:
+        anchor.insert_before(node)
+    for node in run:
+        node.extract()
+
+
+def _is_special_string(node) -> bool:
+    return isinstance(node, (Comment, Declaration, Doctype, ProcessingInstruction))
+
+
+def _is_void_element(node) -> bool:
+    return not node.contents
+
+
+def _tag_name(node) -> str:
+    name = getattr(node, "name", None)
+    return name.lower() if isinstance(name, str) else ""
 
 
 def _is_visible_text_node(text_node: NavigableString) -> bool:

--- a/tests/test_epub_io.py
+++ b/tests/test_epub_io.py
@@ -171,8 +171,8 @@ def test_translate_epub_translates_minimal_generated_epub_without_mutating_input
         assert any(name.endswith("images/pixel.png") for name in names)
 
     assert "PT:Hello reader. Visit" in chapter
-    assert "PT:chapter two" in chapter
-    assert "chapter2.xhtml#answer" in chapter
+    # The paragraph is translated as one block, keeping the inline link and its text.
+    assert '<a href="chapter2.xhtml#answer">chapter two</a>' in chapter
     assert "../images/pixel.png" in chapter
 
 

--- a/tests/test_html_translate.py
+++ b/tests/test_html_translate.py
@@ -33,11 +33,18 @@ def test_translate_html_preserves_tags(tmp_path):
         output, stats = translate_html(html, translator, cache, "en", "pt", glossary={"Patterns": "Patterns"})
 
     result = output.decode("utf-8")
+    # The paragraph is translated as a single block, keeping inline tags intact.
     assert '<p class="calibre1">' in result
     assert "<em>Patterns</em>" in result
-    assert "Qualquer livro de programação com" in result
-    assert "no nome." in result
-    assert stats.translated == 3
+    assert stats.translated == 1
+    assert len(translator.calls) == 1
+    # The block is sent as one unit, with inline tags replaced by placeholders.
+    sent = translator.calls[0]
+    assert "Any programming book with" in sent
+    assert "Patterns" in sent
+    assert "in its name." in sent
+    assert "<em>" not in sent
+    assert "__AYVU_PROTECTED_" in sent
 
 
 def test_translate_html_ignores_script_style_code_pre(tmp_path):
@@ -215,3 +222,133 @@ def test_extract_visible_text_uses_translation_visibility_rules():
     """
 
     assert extract_visible_text(html) == ["Keep me"]
+
+
+def test_translate_html_translates_sentence_split_by_tags_as_one_unit(tmp_path):
+    html = "<html><body><p>This is <em>very</em> important here.</p></body></html>"
+    translator = FakeTranslator()
+    with TranslationCache(tmp_path / "cache.sqlite") as cache:
+        output, stats = translate_html(html, translator, cache, "en", "pt")
+
+    result = output.decode("utf-8")
+    assert "<em>very</em>" in result
+    assert stats.translated == 1
+    # The whole sentence reaches the translator once, not fragment by fragment.
+    assert len(translator.calls) == 1
+    sent = translator.calls[0]
+    assert "This is" in sent and "important here." in sent
+    assert "<em>" not in sent
+
+
+def test_translate_html_preserves_link_attributes_in_block(tmp_path):
+    html = '<html><body><p>Read <a href="ch1.xhtml" id="k1">chapter one</a> now.</p></body></html>'
+    translator = FakeTranslator()
+    with TranslationCache(tmp_path / "cache.sqlite") as cache:
+        output, _stats = translate_html(html, translator, cache, "en", "pt")
+
+    result = output.decode("utf-8")
+    assert '<a href="ch1.xhtml" id="k1">' in result
+    assert "</a>" in result
+    assert len(translator.calls) == 1
+    assert "ch1.xhtml" not in translator.calls[0]
+
+
+def test_translate_html_preserves_nested_inline_tags(tmp_path):
+    html = "<html><body><p>A <strong>very <em>bold</em></strong> idea.</p></body></html>"
+    translator = FakeTranslator()
+    with TranslationCache(tmp_path / "cache.sqlite") as cache:
+        output, stats = translate_html(html, translator, cache, "en", "pt")
+
+    result = output.decode("utf-8")
+    assert "<strong>" in result
+    assert "<em>bold</em>" in result
+    assert "</strong>" in result
+    assert stats.translated == 1
+    assert len(translator.calls) == 1
+
+
+def test_translate_html_keeps_inline_code_opaque_in_block(tmp_path):
+    html = "<html><body><p>Run <code>build()</code> before release.</p></body></html>"
+    translator = FakeTranslator()
+    with TranslationCache(tmp_path / "cache.sqlite") as cache:
+        output, stats = translate_html(html, translator, cache, "en", "pt")
+
+    result = output.decode("utf-8")
+    assert "<code>build()</code>" in result
+    assert stats.translated == 1
+    assert len(translator.calls) == 1
+    # The code element is sent as an opaque placeholder, never as translatable text.
+    assert "build()" not in translator.calls[0]
+
+
+def test_translate_html_preserves_void_tags_in_block(tmp_path):
+    html = "<html><body><p>line one<br/>line two</p></body></html>"
+    translator = FakeTranslator()
+    with TranslationCache(tmp_path / "cache.sqlite") as cache:
+        output, stats = translate_html(html, translator, cache, "en", "pt")
+
+    result = output.decode("utf-8")
+    assert "<br/>" in result
+    assert stats.translated == 1
+    assert len(translator.calls) == 1
+
+
+def test_translate_html_caches_block_with_tags(tmp_path):
+    html = "<html><body><p>Hello <em>world</em></p></body></html>"
+    translator = FakeTranslator()
+    with TranslationCache(tmp_path / "cache.sqlite") as cache:
+        translate_html(html, translator, cache, "en", "pt")
+        output, stats = translate_html(html, translator, cache, "en", "pt")
+
+    result = output.decode("utf-8")
+    assert "<em>world</em>" in result
+    assert stats.from_cache == 1
+    assert len(translator.calls) == 1
+
+
+def test_translate_html_does_not_reuse_old_per_node_cache_for_block(tmp_path):
+    html = "<html><body><p>Hello <em>world</em></p></body></html>"
+    translator = FakeTranslator()
+    with TranslationCache(tmp_path / "cache.sqlite") as cache:
+        # Simulate a stale per-text-node cache entry from the old translation flow.
+        stale_key = CacheKey(text="world", language_pair=LanguagePair(source="en", target="pt"))
+        cache.set(stale_key, "MUNDO_STALE")
+
+        output, stats = translate_html(html, translator, cache, "en", "pt")
+
+    result = output.decode("utf-8")
+    # The block has its own cache key, so the stale per-node entry is never used.
+    assert "MUNDO_STALE" not in result
+    assert "<em>world</em>" in result
+    assert stats.from_cache == 0
+    assert stats.translated == 1
+    assert len(translator.calls) == 1
+
+
+def test_translate_html_translates_loose_text_with_block_siblings(tmp_path):
+    html = "<html><body>Intro <p>Para</p> outro</body></html>"
+    translator = FakeTranslator()
+    with TranslationCache(tmp_path / "cache.sqlite") as cache:
+        output, stats = translate_html(html, translator, cache, "en", "pt")
+
+    result = output.decode("utf-8")
+    # Loose text around a block element must not be lost.
+    assert "PT:Intro" in result
+    assert "PT:Para" in result
+    assert "PT:outro" in result
+    assert stats.translated == 3
+
+
+def test_translate_html_protects_special_terms_inside_block(tmp_path):
+    html = "<html><body><p>Open https://example.com/docs with <em>care</em>.</p></body></html>"
+    translator = FakeTranslator()
+    with TranslationCache(tmp_path / "cache.sqlite") as cache:
+        output, _stats = translate_html(html, translator, cache, "en", "pt")
+
+    result = output.decode("utf-8")
+    assert "https://example.com/docs" in result
+    assert "<em>care</em>" in result
+    assert len(translator.calls) == 1
+    # Both the URL and the inline tag are hidden behind placeholders during translation.
+    assert "https://example.com/docs" not in translator.calls[0]
+    assert "<em>" not in translator.calls[0]


### PR DESCRIPTION
## Objective

Improve translation quality by translating whole blocks (paragraphs, headings, list items) instead of isolated text nodes, while keeping inline tags such as `em`, `strong` and links intact.

## What changed

- `translate_html` now groups consecutive runs of text and inline elements into a single translation unit, recursing into block-level children so loose text is never lost.
- Inline tags are replaced by neutral placeholders (`__AYVU_TAG_n__`) before translation and restored afterwards, preserving attributes and structure. Ignored inline tags (`code`, `kbd`, `samp`) and void elements (`br`) stay opaque; placeholders are protected as special terms so they survive the translator call.
- The translated text is XML-escaped, placeholders are expanded back to markup, and the fragment is re-parsed and spliced in, preserving the XHTML namespace.
- The cache key is now the block template, so blocks with tags no longer reuse stale per-node entries; tagless blocks keep their previous key.
- Tests updated for block semantics, with new cases for sentences split by tags, link attributes, nested inline, opaque inline code, void tags, block cache reuse, per-node cache isolation, loose text, and in-block special-term protection.
- Docs synced: README, technical report (sections 11, 12, 18, 19), and changelog.

## Out of scope

- Translating image alt text, EPUB title/navigation, and translation profiles (issues #75, #76, #77).
- The per-node behavior of `extract_visible_text` / Markdown extraction is unchanged.

## Validation

- `uv run pytest`: 189 passing. Five `tests/test_cli.py` tests fail only at a narrow terminal width because `rich` wraps long paths across lines; they pass at a wide width and reproduce on `main`, so they are pre-existing and unrelated to this change.
- `git diff --check`: no errors.

## Related issue

Closes #74
