### PR TITLE
Add optional EPUB metadata translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ lancadas e secoes versionadas quando uma release for publicada.
   obrigatorios ausentes e termos proibidos encontrados na saida.
 - Menu guiado de glossarios no modo comum, com criacao, edicao, previa,
   validacao, salvamento local e selecao antes de traduzir.
+- Opcao `--translate-metadata` para traduzir o titulo do EPUB e a navegacao
+  EPUB 3 de forma explicita e conservadora.
 
 ### Atualizado
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,21 @@ plano da tradução (`From`/`To`) antes de começar e usa o idioma detectado com
 origem. Quando o metadado estiver ausente ou inválido, o Ayvu avisa e usa `en`
 como padrão; informe `--source` para escolher outro idioma de origem.
 
+Por padrão, o Ayvu preserva metadados do EPUB e o documento de navegação. Para
+traduzir também o título do livro no OPF e o texto do sumário EPUB3, use:
+
+```bash
+uv run ayvu translate livro.epub \
+  --target pt \
+  --translate-metadata
+```
+
+Essa opção é conservadora: traduz o primeiro `dc:title` e a navegação marcada no
+manifesto como `properties="nav"`, preservando identificadores, autores, editora
+e metadados técnicos. Alterar o título ou o sumário pode afetar a forma como
+leitores e bibliotecas organizam o livro; confira o EPUB gerado antes de usar a
+tradução como cópia principal.
+
 Gerar um preview traduzido:
 
 ```bash

--- a/docs/tutorial-modo-comum-e-dev.md
+++ b/docs/tutorial-modo-comum-e-dev.md
@@ -254,6 +254,21 @@ uv run ayvu translate livro.epub \
   --cache .cache/traducoes.sqlite
 ```
 
+### Traduzir título e sumário opcionalmente
+
+```bash
+uv run ayvu translate livro.epub \
+  --source en \
+  --target pt \
+  --translate-metadata
+```
+
+Sem `--translate-metadata`, o Ayvu preserva o título do OPF e o documento de
+navegação. Com a opção ativa, traduz o primeiro `dc:title` e o texto do sumário
+EPUB3 marcado como `properties="nav"`, mantendo identificadores, autores,
+editora e metadados técnicos. Use com cuidado: alguns leitores e bibliotecas
+usam o título e o sumário para organizar o livro.
+
 ### Sobrescrever saída existente
 
 ```bash

--- a/src/ayvu/cli.py
+++ b/src/ayvu/cli.py
@@ -217,6 +217,11 @@ def translate(
     overwrite: bool = typer.Option(False, "--overwrite", help="Allow replacing an existing output file."),
     timeout: float = typer.Option(30.0, "--timeout", help="Translator HTTP timeout in seconds."),
     retries: int = typer.Option(2, "--retries", help="Simple HTTP retry count."),
+    translate_metadata: bool = typer.Option(
+        False,
+        "--translate-metadata",
+        help="Also translate the EPUB title metadata and navigation text.",
+    ),
     chunk_limit: int = typer.Option(3000, "--chunk-limit", help="Maximum characters sent per request."),
 ) -> None:
     """Translate EPUB visible text while preserving EPUB structure."""
@@ -239,6 +244,7 @@ def translate(
         chunk_limit=chunk_limit,
         mode=mode,
         config=config,
+        translate_metadata=translate_metadata,
     )
 
 
@@ -331,6 +337,7 @@ def _run_translation(
     chunk_limit: int,
     mode: UserMode,
     config: AyvuConfig | None = None,
+    translate_metadata: bool = False,
 ) -> None:
     config = config or _load_existing_config_or_default()
     resolved_source, source_inferred = _resolve_source_language(source, epub_path, mode=mode)
@@ -341,6 +348,7 @@ def _run_translation(
         dry_run=dry_run,
         fail_fast=fail_fast,
         chunk_limit=chunk_limit,
+        translate_metadata=translate_metadata,
     )
     output_plan = OutputPlan.for_translation(
         epub_path,
@@ -1452,6 +1460,7 @@ def _resume_translation(state: TranslationResumeState, mode: UserMode) -> None:
             retries=state.retries,
             chunk_limit=state.chunk_limit,
             mode=mode,
+            translate_metadata=state.translate_metadata,
         )
     except typer.Exit:
         console.print(

--- a/src/ayvu/domain.py
+++ b/src/ayvu/domain.py
@@ -91,6 +91,7 @@ class TranslationOptions:
     fail_fast: bool = False
     chunk_limit: int = 3000
     max_documents: int | None = None
+    translate_metadata: bool = False
 
     @property
     def source(self) -> str:

--- a/src/ayvu/epub_io.py
+++ b/src/ayvu/epub_io.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
+from urllib.parse import unquote
 from zipfile import ZIP_STORED, ZipFile
 import xml.etree.ElementTree as ET
 
@@ -12,13 +13,24 @@ from ebooklib import epub
 from .cache import TranslationCache
 from .domain import TranslationOptions
 from .glossary import Glossary, GlossaryUsage
-from .html_translate import HtmlTranslationStats, extract_visible_text, translate_html
+from .html_translate import (
+    HtmlTranslationStats,
+    TextTranslationResult,
+    extract_visible_text,
+    translate_html,
+    translate_text,
+)
 from .translator import Translator
 
 
 ChapterStartCallback = Callable[[int, int, str], None]
 ChapterDoneCallback = Callable[[int, int, str, HtmlTranslationStats], None]
 TextProgressCallback = Callable[[str], None]
+OPF_NAMESPACE = "http://www.idpf.org/2007/opf"
+DC_NAMESPACE = "http://purl.org/dc/elements/1.1/"
+
+ET.register_namespace("", OPF_NAMESPACE)
+ET.register_namespace("dc", DC_NAMESPACE)
 
 
 @dataclass
@@ -81,6 +93,13 @@ class TranslationReport:
         self.errors.extend(stats.errors)
         self.glossary_usage.merge(stats.glossary_usage)
         self.chapters_processed += 1
+
+    def record_text(self, result: TextTranslationResult) -> None:
+        if result.from_cache:
+            self.texts_from_cache += 1
+        else:
+            self.texts_translated += 1
+        self.glossary_usage.merge(result.glossary_usage)
 
 
 @dataclass
@@ -153,14 +172,41 @@ def translate_epub(
         target_language=options.target,
         glossary_terms_configured=len(glossary.entries) if glossary else 0,
     )
-    opf_base_path = _get_opf_base_path(source_path)
+    opf_archive_path = _get_opf_archive_path(source_path)
+    opf_base_path = _opf_base_path(opf_archive_path)
     replacements = EpubReplacements()
-
-    documents = _limited_documents(_document_entries(book, opf_base_path), options.max_documents)
-    total_documents = len(documents)
 
     with ZipFile(source_path, "r") as source_epub:
         archive_names = set(source_epub.namelist())
+        navigation_documents = _navigation_document_entries(source_epub, opf_archive_path, opf_base_path)
+        documents = _limited_documents(
+            _documents_for_translation(
+                _document_entries(book, opf_base_path),
+                navigation_documents,
+                translate_metadata=options.translate_metadata,
+            ),
+            options.max_documents,
+        )
+        total_documents = len(documents)
+
+        if options.translate_metadata and opf_archive_path and opf_archive_path in archive_names:
+            try:
+                translated_opf = _translate_opf_title(
+                    source_epub.read(opf_archive_path),
+                    translator=translator,
+                    cache=cache,
+                    options=options,
+                    glossary=glossary,
+                    report=report,
+                    on_text_processed=on_text_processed,
+                )
+                if translated_opf is not None and not options.dry_run:
+                    replacements.add(opf_archive_path, translated_opf)
+            except Exception as exc:
+                report.record_error(f"metadata title: {exc}")
+                _notify_text_processed(on_text_processed, "error")
+                if options.fail_fast:
+                    raise
 
         for index, document in enumerate(documents, start=1):
             if document.archive_path not in archive_names:
@@ -227,6 +273,10 @@ def _clean_extracted_text(text: str) -> str:
 
 
 def _get_opf_base_path(epub_path: Path) -> PurePosixPath:
+    return _opf_base_path(_get_opf_archive_path(epub_path))
+
+
+def _get_opf_archive_path(epub_path: Path) -> str | None:
     with ZipFile(epub_path, "r") as source_epub:
         container_xml = source_epub.read("META-INF/container.xml")
 
@@ -236,10 +286,16 @@ def _get_opf_base_path(epub_path: Path) -> PurePosixPath:
     if rootfile is None:
         rootfile = root.find(".//rootfile")
     if rootfile is None:
-        return PurePosixPath(".")
+        return None
 
-    full_path = rootfile.attrib.get("full-path", "")
-    parent = PurePosixPath(full_path).parent
+    full_path = rootfile.attrib.get("full-path", "").strip()
+    return full_path or None
+
+
+def _opf_base_path(opf_archive_path: str | None) -> PurePosixPath:
+    if opf_archive_path is None:
+        return PurePosixPath(".")
+    parent = PurePosixPath(opf_archive_path).parent
     return parent if str(parent) != "." else PurePosixPath(".")
 
 
@@ -262,6 +318,129 @@ def _limited_documents(documents: list[EpubDocument], max_documents: int | None)
     if max_documents is None:
         return documents
     return documents[:max(0, max_documents)]
+
+
+def _documents_for_translation(
+    documents: list[EpubDocument],
+    navigation_documents: list[EpubDocument],
+    translate_metadata: bool,
+) -> list[EpubDocument]:
+    navigation_paths = {document.archive_path for document in navigation_documents}
+    if not translate_metadata:
+        return [document for document in documents if document.archive_path not in navigation_paths]
+
+    selected = list(documents)
+    selected_paths = {document.archive_path for document in selected}
+    for document in navigation_documents:
+        if document.archive_path not in selected_paths:
+            selected.append(document)
+            selected_paths.add(document.archive_path)
+    return selected
+
+
+def _navigation_document_entries(
+    source_epub: ZipFile,
+    opf_archive_path: str | None,
+    opf_base_path: PurePosixPath,
+) -> list[EpubDocument]:
+    if opf_archive_path is None or opf_archive_path not in source_epub.namelist():
+        return []
+
+    try:
+        root = ET.fromstring(source_epub.read(opf_archive_path))
+    except ET.ParseError:
+        return []
+
+    manifest = _first_child_by_local_name(root, "manifest")
+    if manifest is None:
+        return []
+
+    documents: list[EpubDocument] = []
+    for item in manifest:
+        if _local_name(item.tag) != "item":
+            continue
+        properties = item.attrib.get("properties", "")
+        if "nav" not in properties.split():
+            continue
+        href = item.attrib.get("href", "").strip()
+        if not href:
+            continue
+        archive_path = _document_zip_path(opf_base_path, _manifest_href_path(href))
+        documents.append(EpubDocument(name=href, archive_path=archive_path))
+    return documents
+
+
+def _manifest_href_path(href: str) -> str:
+    clean = href.split("#", 1)[0].split("?", 1)[0]
+    return PurePosixPath(unquote(clean)).as_posix()
+
+
+def _translate_opf_title(
+    opf_content: bytes,
+    translator: Translator,
+    cache: TranslationCache,
+    options: TranslationOptions,
+    glossary: Glossary | None,
+    report: TranslationReport,
+    on_text_processed: TextProgressCallback | None,
+) -> bytes | None:
+    root = ET.fromstring(opf_content)
+    title = _first_metadata_title(root)
+    if title is None or title.text is None or not title.text.strip():
+        return None
+
+    result = translate_text(
+        title.text,
+        translator=translator,
+        cache=cache,
+        source=options.source,
+        target=options.target,
+        glossary=glossary,
+        dry_run=options.dry_run,
+        chunk_limit=options.chunk_limit,
+    )
+    title.text = result.text
+    report.record_text(result)
+    _notify_text_processed(on_text_processed, _text_progress_status(result, options.dry_run))
+    return ET.tostring(root, encoding="utf-8", xml_declaration=_has_xml_declaration(opf_content))
+
+
+def _first_metadata_title(root: ET.Element) -> ET.Element | None:
+    metadata = _first_child_by_local_name(root, "metadata")
+    if metadata is None:
+        return None
+    for child in metadata:
+        if _local_name(child.tag) == "title":
+            return child
+    return None
+
+
+def _first_child_by_local_name(root: ET.Element, name: str) -> ET.Element | None:
+    for child in root.iter():
+        if _local_name(child.tag) == name:
+            return child
+    return None
+
+
+def _local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def _has_xml_declaration(content: bytes) -> bool:
+    return content.lstrip().startswith(b"<?xml")
+
+
+def _text_progress_status(result: TextTranslationResult, dry_run: bool) -> str:
+    if result.from_cache:
+        return "cache"
+    if dry_run:
+        return "dry_run"
+    return "translated"
+
+
+def _notify_text_processed(callback: TextProgressCallback | None, status: str) -> None:
+    if callback:
+        callback(status)
 
 
 def _copy_epub_with_replacements(

--- a/src/ayvu/resume.py
+++ b/src/ayvu/resume.py
@@ -52,6 +52,7 @@ class TranslationResumeState:
     timeout: float
     retries: int
     chunk_limit: int
+    translate_metadata: bool
     created_at: str
     updated_at: str
 
@@ -86,6 +87,7 @@ class TranslationResumeState:
             timeout=timeout,
             retries=retries,
             chunk_limit=options.chunk_limit,
+            translate_metadata=options.translate_metadata,
             created_at=now,
             updated_at=now,
         )
@@ -119,6 +121,7 @@ class TranslationResumeState:
             timeout=_required_number(data, "timeout"),
             retries=_required_int(data, "retries"),
             chunk_limit=_required_int(data, "chunk_limit"),
+            translate_metadata=_optional_bool(data, "translate_metadata", default=False),
             created_at=_required_text(data, "created_at"),
             updated_at=_required_text(data, "updated_at"),
         )
@@ -201,6 +204,15 @@ def _required_int(data: dict[str, object], key: str) -> int:
 
 def _required_bool(data: dict[str, object], key: str) -> bool:
     value = _required_value(data, key)
+    if not isinstance(value, bool):
+        raise ResumeStateError(f"Resume state field {key} must be true or false.")
+    return value
+
+
+def _optional_bool(data: dict[str, object], key: str, default: bool) -> bool:
+    if key not in data:
+        return default
+    value = data[key]
     if not isinstance(value, bool):
         raise ResumeStateError(f"Resume state field {key} must be true or false.")
     return value

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -358,6 +358,7 @@ def test_root_command_resumes_detected_translation_when_confirmed(tmp_path, monk
     assert options.source == state.source
     assert options.target == state.target
     assert options.chunk_limit == state.chunk_limit
+    assert options.translate_metadata == state.translate_metadata
     assert saved_state.status == COMPLETED_STATUS
 
 
@@ -1649,6 +1650,20 @@ def test_translate_explicit_source_overrides_epub_metadata(minimal_epub_path, tm
     assert result.exit_code == 0
     assert calls["options"].source == "fr"
     assert "inferido do EPUB" not in result.output
+
+
+def test_translate_metadata_flag_reaches_translation_options(minimal_epub_path, tmp_path, monkeypatch):
+    monkeypatch.setattr("ayvu.cli.default_translated_books_dir", lambda: tmp_path / "Traduzidos")
+    calls: dict[str, object] = {}
+    _mock_translation_pipeline(monkeypatch, calls)
+
+    result = runner.invoke(
+        app,
+        ["--mode", "developer", "translate", str(minimal_epub_path), "--translate-metadata"],
+    )
+
+    assert result.exit_code == 0
+    assert calls["options"].translate_metadata
 
 
 def test_translate_warns_when_epub_language_metadata_is_missing(tmp_path, monkeypatch):

--- a/tests/test_epub_io.py
+++ b/tests/test_epub_io.py
@@ -12,6 +12,9 @@ from ayvu.epub_io import (
     TranslationReport,
     _document_entries,
     _document_zip_path,
+    _get_opf_archive_path,
+    _navigation_document_entries,
+    _opf_base_path,
     detect_epub_language,
     extract_markdown,
     inspect_epub,
@@ -50,6 +53,14 @@ class PrefixTranslator:
     def translate(self, text: str, source: str, target: str) -> str:
         self.calls.append((text, source, target))
         return f"PT:{text}"
+
+
+def _read_navigation_document(epub_path: Path) -> str:
+    opf_archive_path = _get_opf_archive_path(epub_path)
+    with ZipFile(epub_path) as source_epub:
+        documents = _navigation_document_entries(source_epub, opf_archive_path, _opf_base_path(opf_archive_path))
+        assert documents
+        return source_epub.read(documents[0].archive_path).decode("utf-8")
 
 
 def test_document_zip_path_for_root_opf():
@@ -160,7 +171,7 @@ def test_translate_epub_translates_minimal_generated_epub_without_mutating_input
     assert report.detected_language == "en"
     assert report.target_language == "pt"
     assert report.chapters_processed >= 2
-    assert report.texts_translated >= 5
+    assert report.texts_translated >= 4
     assert report.errors == []
     assert translator.calls
 
@@ -174,6 +185,56 @@ def test_translate_epub_translates_minimal_generated_epub_without_mutating_input
     # The paragraph is translated as one block, keeping the inline link and its text.
     assert '<a href="chapter2.xhtml#answer">chapter two</a>' in chapter
     assert "../images/pixel.png" in chapter
+
+
+def test_translate_epub_preserves_metadata_and_navigation_by_default(
+    minimal_epub_path: Path,
+    tmp_path: Path,
+):
+    output_path = tmp_path / "minimal-pt.epub"
+    translator = PrefixTranslator()
+    options = TranslationOptions(language_pair=LanguagePair(source="en", target="pt"))
+
+    with TranslationCache(tmp_path / "cache.sqlite") as cache:
+        translate_epub(
+            minimal_epub_path,
+            output_path,
+            translator=translator,
+            cache=cache,
+            options=options,
+        )
+
+    assert inspect_epub(output_path).title == "Minimal Test Book"
+    assert ("Minimal Test Book", "en", "pt") not in translator.calls
+    navigation = _read_navigation_document(output_path)
+    assert "Chapter One" in navigation
+    assert "PT:Chapter One" not in navigation
+
+
+def test_translate_epub_translates_metadata_and_navigation_when_enabled(
+    minimal_epub_path: Path,
+    tmp_path: Path,
+):
+    output_path = tmp_path / "minimal-pt.epub"
+    translator = PrefixTranslator()
+    options = TranslationOptions(
+        language_pair=LanguagePair(source="en", target="pt"),
+        translate_metadata=True,
+    )
+
+    with TranslationCache(tmp_path / "cache.sqlite") as cache:
+        translate_epub(
+            minimal_epub_path,
+            output_path,
+            translator=translator,
+            cache=cache,
+            options=options,
+        )
+
+    assert inspect_epub(output_path).title == "PT:Minimal Test Book"
+    assert ("Minimal Test Book", "en", "pt") in translator.calls
+    navigation = _read_navigation_document(output_path)
+    assert 'PT:<a href="text/chapter1.xhtml">Chapter One</a>' in navigation
 
 
 def test_normalize_language_code_extracts_primary_subtag_from_bcp47():

--- a/tests/test_resume.py
+++ b/tests/test_resume.py
@@ -27,6 +27,7 @@ def make_state(tmp_path: Path, stem: str = "book") -> TranslationResumeState:
             dry_run=False,
             fail_fast=True,
             chunk_limit=1200,
+            translate_metadata=True,
         ),
         overwrite=True,
         timeout=9.5,
@@ -50,6 +51,7 @@ def test_resume_state_round_trip(tmp_path):
     assert loaded.fail_fast
     assert loaded.overwrite
     assert loaded.chunk_limit == 1200
+    assert loaded.translate_metadata
     assert loaded.timeout == 9.5
     assert loaded.retries == 3
 
@@ -88,6 +90,18 @@ def test_resume_state_load_reports_missing_required_field(tmp_path):
 
     assert "Invalid resume state file" in str(error.value)
     assert "cache_path is required" in str(error.value)
+
+
+def test_resume_state_load_defaults_missing_translate_metadata_to_false(tmp_path):
+    path = tmp_path / "old.ayvu-state.json"
+    data = make_state(tmp_path).to_dict()
+    data.pop("translate_metadata")
+    path.write_text(json.dumps(data), encoding="utf-8")
+    store = ResumeStateStore(tmp_path)
+
+    loaded = store.load(path)
+
+    assert not loaded.translate_metadata
 
 
 def test_resume_state_scan_finds_running_and_invalid_states(tmp_path):


### PR DESCRIPTION
## Objective

Allow EPUB title metadata and EPUB 3 navigation text to be translated only when the user explicitly requests it.

## What changed

- Added the `--translate-metadata` option to the `translate` command.
- Preserved OPF title metadata and EPUB navigation by default.
- Translated the first OPF `dc:title` and the EPUB 3 `properties="nav"` document when the option is enabled.
- Stored the metadata translation choice in resume state while keeping older state files compatible.
- Updated user documentation and changelog entries for the new option and its risks.

## Out of scope

- Translating authors, identifiers, publishers, or other technical metadata.
- Changing preview behavior.
- Broad EPUB metadata rewriting beyond the explicit title and navigation scope.

## Validation

- `uv run pytest`: 193 tests passing.
- `git diff --check`: no errors.

## Related issue

Closes #75