### PR TITLE
Translate image alt text optionally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,9 @@ lancadas e secoes versionadas quando uma release for publicada.
   validacao, salvamento local e selecao antes de traduzir.
 - Opcao `--translate-metadata` para traduzir o titulo do EPUB e a navegacao
   EPUB 3 de forma explicita e conservadora.
+- Opcao `--translate-alt-text` para traduzir o texto alternativo (`alt`) das
+  imagens, preservando a imagem e demais atributos e contando os textos no
+  relatorio. Leitura de texto dentro da imagem (OCR) fica fora do escopo.
 
 ### Atualizado
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,21 @@ e metadados técnicos. Alterar o título ou o sumário pode afetar a forma como
 leitores e bibliotecas organizam o livro; confira o EPUB gerado antes de usar a
 tradução como cópia principal.
 
+Por padrão, o Ayvu preserva o texto alternativo (`alt`) das imagens. Para também
+traduzir essas descrições de acessibilidade, use:
+
+```bash
+uv run ayvu translate livro.epub \
+  --target pt \
+  --translate-alt-text
+```
+
+Essa opção traduz apenas o atributo `alt` das tags `<img>`, preservando a imagem,
+o `src` e os demais atributos. Imagens decorativas (`alt=""`) são ignoradas. O
+relatório passa a mostrar quantos textos alternativos foram traduzidos. Ler o
+texto que está dentro da imagem (OCR) está fora do escopo e fica para uma feature
+futura.
+
 Gerar um preview traduzido:
 
 ```bash

--- a/docs/tutorial-modo-comum-e-dev.md
+++ b/docs/tutorial-modo-comum-e-dev.md
@@ -269,6 +269,21 @@ EPUB3 marcado como `properties="nav"`, mantendo identificadores, autores,
 editora e metadados técnicos. Use com cuidado: alguns leitores e bibliotecas
 usam o título e o sumário para organizar o livro.
 
+### Traduzir texto alternativo de imagens opcionalmente
+
+```bash
+uv run ayvu translate livro.epub \
+  --source en \
+  --target pt \
+  --translate-alt-text
+```
+
+Sem `--translate-alt-text`, o Ayvu preserva o atributo `alt` das imagens. Com a
+opção ativa, traduz apenas o `alt` das tags `<img>`, mantendo a imagem, o `src` e
+os demais atributos; imagens decorativas (`alt=""`) são ignoradas. O relatório
+mostra a quantidade de textos alternativos traduzidos. Ler o texto que está
+dentro da imagem (OCR) continua fora do escopo.
+
 ### Sobrescrever saída existente
 
 ```bash

--- a/src/ayvu/cli.py
+++ b/src/ayvu/cli.py
@@ -222,6 +222,11 @@ def translate(
         "--translate-metadata",
         help="Also translate the EPUB title metadata and navigation text.",
     ),
+    translate_alt_text: bool = typer.Option(
+        False,
+        "--translate-alt-text",
+        help="Also translate the alt text of images. Text inside images (OCR) is out of scope.",
+    ),
     chunk_limit: int = typer.Option(3000, "--chunk-limit", help="Maximum characters sent per request."),
 ) -> None:
     """Translate EPUB visible text while preserving EPUB structure."""
@@ -245,6 +250,7 @@ def translate(
         mode=mode,
         config=config,
         translate_metadata=translate_metadata,
+        translate_alt_text=translate_alt_text,
     )
 
 
@@ -338,6 +344,7 @@ def _run_translation(
     mode: UserMode,
     config: AyvuConfig | None = None,
     translate_metadata: bool = False,
+    translate_alt_text: bool = False,
 ) -> None:
     config = config or _load_existing_config_or_default()
     resolved_source, source_inferred = _resolve_source_language(source, epub_path, mode=mode)
@@ -349,6 +356,7 @@ def _run_translation(
         fail_fast=fail_fast,
         chunk_limit=chunk_limit,
         translate_metadata=translate_metadata,
+        translate_alt_text=translate_alt_text,
     )
     output_plan = OutputPlan.for_translation(
         epub_path,
@@ -600,6 +608,8 @@ def _print_report(
     table.add_row("Chapters processed", str(report.chapters_processed))
     table.add_row("Texts translated", str(report.texts_translated))
     table.add_row("Texts from cache", str(report.texts_from_cache))
+    if report.alt_texts_translated:
+        table.add_row("Alt texts translated", str(report.alt_texts_translated))
     table.add_row("Errors", str(len(report.errors)))
     table.add_row("Validation warnings", str(len(validation_warnings)))
     if _has_glossary_summary(report):
@@ -1461,6 +1471,7 @@ def _resume_translation(state: TranslationResumeState, mode: UserMode) -> None:
             chunk_limit=state.chunk_limit,
             mode=mode,
             translate_metadata=state.translate_metadata,
+            translate_alt_text=state.translate_alt_text,
         )
     except typer.Exit:
         console.print(
@@ -1586,9 +1597,13 @@ def _render_markdown_report(
         f"- Chapters processed: {report.chapters_processed}",
         f"- Texts translated: {report.texts_translated}",
         f"- Texts from cache: {report.texts_from_cache}",
+    ]
+    if report.alt_texts_translated:
+        lines.append(f"- Alt texts translated: {report.alt_texts_translated}")
+    lines.extend([
         f"- Errors: {len(report.errors)}",
         f"- Validation warnings: {len(validation_warnings)}",
-    ]
+    ])
     if _has_glossary_summary(report):
         lines.extend(
             [

--- a/src/ayvu/domain.py
+++ b/src/ayvu/domain.py
@@ -92,6 +92,7 @@ class TranslationOptions:
     chunk_limit: int = 3000
     max_documents: int | None = None
     translate_metadata: bool = False
+    translate_alt_text: bool = False
 
     @property
     def source(self) -> str:

--- a/src/ayvu/epub_io.py
+++ b/src/ayvu/epub_io.py
@@ -75,6 +75,7 @@ class TranslationReport:
     texts_translated: int = 0
     texts_from_cache: int = 0
     texts_skipped: int = 0
+    alt_texts_translated: int = 0
     errors: list[str] = field(default_factory=list)
     glossary_terms_configured: int = 0
     glossary_usage: GlossaryUsage = field(default_factory=GlossaryUsage)
@@ -90,6 +91,7 @@ class TranslationReport:
         self.texts_translated += stats.translated
         self.texts_from_cache += stats.from_cache
         self.texts_skipped += stats.skipped
+        self.alt_texts_translated += stats.alt_translated
         self.errors.extend(stats.errors)
         self.glossary_usage.merge(stats.glossary_usage)
         self.chapters_processed += 1
@@ -230,6 +232,7 @@ def translate_epub(
                     fail_fast=options.fail_fast,
                     chunk_limit=options.chunk_limit,
                     on_text_processed=on_text_processed,
+                    translate_alt_text=options.translate_alt_text,
                 )
                 if not options.dry_run:
                     replacements.add(document.archive_path, translated_content)

--- a/src/ayvu/html_translate.py
+++ b/src/ayvu/html_translate.py
@@ -85,6 +85,7 @@ class HtmlTranslationStats:
     translated: int = 0
     from_cache: int = 0
     skipped: int = 0
+    alt_translated: int = 0
     errors: list[str] = field(default_factory=list)
     glossary_usage: GlossaryUsage = field(default_factory=GlossaryUsage)
 
@@ -129,6 +130,7 @@ def translate_html(
     chunk_limit: int = 3000,
     on_error: Callable[[Exception], None] | None = None,
     on_text_processed: TextProgressCallback | None = None,
+    translate_alt_text: bool = False,
 ) -> tuple[bytes, HtmlTranslationStats]:
     soup = BeautifulSoup(html, "lxml-xml")
     stats = HtmlTranslationStats()
@@ -162,6 +164,22 @@ def translate_html(
                 on_error(exc)
             if fail_fast:
                 raise
+
+    if translate_alt_text:
+        _translate_image_alt_text(
+            soup,
+            translator=translator,
+            cache=cache,
+            source=source,
+            target=target,
+            glossary=glossary,
+            dry_run=dry_run,
+            fail_fast=fail_fast,
+            chunk_limit=chunk_limit,
+            stats=stats,
+            on_error=on_error,
+            on_text_processed=on_text_processed,
+        )
 
     return soup.encode(formatter="minimal"), stats
 
@@ -203,6 +221,59 @@ def translate_text(
     cache.set(cache_key, translated)
     application = apply_glossary_with_usage(translated, glossary)
     return TextTranslationResult(text=parts.restore(application.text), glossary_usage=application.usage)
+
+
+def _translate_image_alt_text(
+    soup: BeautifulSoup,
+    translator: Translator,
+    cache: TranslationCache,
+    source: str,
+    target: str,
+    glossary: Glossary | None,
+    dry_run: bool,
+    fail_fast: bool,
+    chunk_limit: int,
+    stats: HtmlTranslationStats,
+    on_error: Callable[[Exception], None] | None,
+    on_text_processed: TextProgressCallback | None,
+) -> None:
+    """Translate the ``alt`` text of ``img`` elements as plain text.
+
+    Only the alternative description is translated; the image, its ``src`` and
+    every other attribute are preserved. Reading text rendered inside the image
+    (OCR) is intentionally out of scope.
+    """
+    for image in _image_elements(soup):
+        alt = image.get("alt")
+        if not isinstance(alt, str) or not alt.strip():
+            continue
+        try:
+            result = translate_text(
+                alt,
+                translator=translator,
+                cache=cache,
+                source=source,
+                target=target,
+                glossary=glossary,
+                dry_run=dry_run,
+                chunk_limit=chunk_limit,
+            )
+            if not dry_run:
+                image["alt"] = result.text
+            stats.glossary_usage.merge(result.glossary_usage)
+            stats.alt_translated += 1
+            _record_success(stats, result.from_cache, dry_run, on_text_processed)
+        except Exception as exc:
+            stats.errors.append(str(exc))
+            _notify_text_processed(on_text_processed, "error")
+            if on_error:
+                on_error(exc)
+            if fail_fast:
+                raise
+
+
+def _image_elements(soup: BeautifulSoup) -> list:
+    return [node for node in soup.find_all(True) if _tag_name(node) == "img"]
 
 
 def _visible_text_nodes(soup: BeautifulSoup) -> list[NavigableString]:

--- a/src/ayvu/resume.py
+++ b/src/ayvu/resume.py
@@ -53,6 +53,7 @@ class TranslationResumeState:
     retries: int
     chunk_limit: int
     translate_metadata: bool
+    translate_alt_text: bool
     created_at: str
     updated_at: str
 
@@ -88,6 +89,7 @@ class TranslationResumeState:
             retries=retries,
             chunk_limit=options.chunk_limit,
             translate_metadata=options.translate_metadata,
+            translate_alt_text=options.translate_alt_text,
             created_at=now,
             updated_at=now,
         )
@@ -122,6 +124,7 @@ class TranslationResumeState:
             retries=_required_int(data, "retries"),
             chunk_limit=_required_int(data, "chunk_limit"),
             translate_metadata=_optional_bool(data, "translate_metadata", default=False),
+            translate_alt_text=_optional_bool(data, "translate_alt_text", default=False),
             created_at=_required_text(data, "created_at"),
             updated_at=_required_text(data, "updated_at"),
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1666,6 +1666,20 @@ def test_translate_metadata_flag_reaches_translation_options(minimal_epub_path, 
     assert calls["options"].translate_metadata
 
 
+def test_translate_alt_text_flag_reaches_translation_options(minimal_epub_path, tmp_path, monkeypatch):
+    monkeypatch.setattr("ayvu.cli.default_translated_books_dir", lambda: tmp_path / "Traduzidos")
+    calls: dict[str, object] = {}
+    _mock_translation_pipeline(monkeypatch, calls)
+
+    result = runner.invoke(
+        app,
+        ["--mode", "developer", "translate", str(minimal_epub_path), "--translate-alt-text"],
+    )
+
+    assert result.exit_code == 0
+    assert calls["options"].translate_alt_text
+
+
 def test_translate_warns_when_epub_language_metadata_is_missing(tmp_path, monkeypatch):
     epub_path = tmp_path / "no-lang.epub"
     book = epub.EpubBook()

--- a/tests/test_epub_io.py
+++ b/tests/test_epub_io.py
@@ -237,6 +237,65 @@ def test_translate_epub_translates_metadata_and_navigation_when_enabled(
     assert 'PT:<a href="text/chapter1.xhtml">Chapter One</a>' in navigation
 
 
+def _read_chapter_one(epub_path: Path) -> str:
+    with ZipFile(epub_path) as output_epub:
+        chapter_name = next(
+            name for name in output_epub.namelist() if name.endswith("text/chapter1.xhtml")
+        )
+        return output_epub.read(chapter_name).decode("utf-8")
+
+
+def test_translate_epub_preserves_image_alt_by_default(
+    minimal_epub_path: Path,
+    tmp_path: Path,
+):
+    output_path = tmp_path / "minimal-pt.epub"
+    translator = PrefixTranslator()
+    options = TranslationOptions(language_pair=LanguagePair(source="en", target="pt"))
+
+    with TranslationCache(tmp_path / "cache.sqlite") as cache:
+        report = translate_epub(
+            minimal_epub_path,
+            output_path,
+            translator=translator,
+            cache=cache,
+            options=options,
+        )
+
+    chapter = _read_chapter_one(output_path)
+    assert 'alt="Pixel"' in chapter
+    assert ("Pixel", "en", "pt") not in translator.calls
+    assert report.alt_texts_translated == 0
+
+
+def test_translate_epub_translates_image_alt_when_enabled(
+    minimal_epub_path: Path,
+    tmp_path: Path,
+):
+    output_path = tmp_path / "minimal-pt.epub"
+    translator = PrefixTranslator()
+    options = TranslationOptions(
+        language_pair=LanguagePair(source="en", target="pt"),
+        translate_alt_text=True,
+    )
+
+    with TranslationCache(tmp_path / "cache.sqlite") as cache:
+        report = translate_epub(
+            minimal_epub_path,
+            output_path,
+            translator=translator,
+            cache=cache,
+            options=options,
+        )
+
+    chapter = _read_chapter_one(output_path)
+    # The alt text is translated while the image and its src are preserved.
+    assert 'alt="PT:Pixel"' in chapter
+    assert "../images/pixel.png" in chapter
+    assert ("Pixel", "en", "pt") in translator.calls
+    assert report.alt_texts_translated == 1
+
+
 def test_normalize_language_code_extracts_primary_subtag_from_bcp47():
     assert normalize_language_code("pt-BR") == "pt"
     assert normalize_language_code("en_US") == "en"

--- a/tests/test_html_translate.py
+++ b/tests/test_html_translate.py
@@ -352,3 +352,70 @@ def test_translate_html_protects_special_terms_inside_block(tmp_path):
     # Both the URL and the inline tag are hidden behind placeholders during translation.
     assert "https://example.com/docs" not in translator.calls[0]
     assert "<em>" not in translator.calls[0]
+
+
+def test_translate_html_preserves_image_alt_by_default(tmp_path):
+    html = '<html><body><p><img src="cover.png" alt="A red house" /></p></body></html>'
+    translator = FakeTranslator()
+    with TranslationCache(tmp_path / "cache.sqlite") as cache:
+        output, stats = translate_html(html, translator, cache, "en", "pt")
+
+    result = output.decode("utf-8")
+    assert 'alt="A red house"' in result
+    assert "A red house" not in translator.calls
+    assert stats.alt_translated == 0
+
+
+def test_translate_html_translates_image_alt_when_enabled(tmp_path):
+    html = '<html><body><p><img src="cover.png" alt="A red house" /></p></body></html>'
+    translator = FakeTranslator()
+    with TranslationCache(tmp_path / "cache.sqlite") as cache:
+        output, stats = translate_html(
+            html, translator, cache, "en", "pt", translate_alt_text=True
+        )
+
+    result = output.decode("utf-8")
+    # The alt text is translated while src and the image element are preserved.
+    assert 'alt="PT:A red house"' in result
+    assert 'src="cover.png"' in result
+    assert "A red house" in translator.calls
+    assert stats.alt_translated == 1
+    assert stats.translated == 1
+
+
+def test_translate_html_skips_empty_or_missing_image_alt(tmp_path):
+    html = (
+        '<html><body><p>'
+        '<img src="decor.png" alt="" />'
+        '<img src="logo.png" />'
+        "</p></body></html>"
+    )
+    translator = FakeTranslator()
+    with TranslationCache(tmp_path / "cache.sqlite") as cache:
+        output, stats = translate_html(
+            html, translator, cache, "en", "pt", translate_alt_text=True
+        )
+
+    result = output.decode("utf-8")
+    assert 'alt=""' in result
+    assert translator.calls == []
+    assert stats.alt_translated == 0
+
+
+def test_translate_html_uses_cache_for_image_alt(tmp_path):
+    html = '<html><body><p><img src="cover.png" alt="A red house" /></p></body></html>'
+    translator = FakeTranslator()
+    with TranslationCache(tmp_path / "cache.sqlite") as cache:
+        cache.set(
+            CacheKey(text="A red house", language_pair=LanguagePair(source="en", target="pt")),
+            "Uma casa vermelha",
+        )
+        output, stats = translate_html(
+            html, translator, cache, "en", "pt", translate_alt_text=True
+        )
+
+    result = output.decode("utf-8")
+    assert 'alt="Uma casa vermelha"' in result
+    assert translator.calls == []
+    assert stats.alt_translated == 1
+    assert stats.from_cache == 1

--- a/tests/test_resume.py
+++ b/tests/test_resume.py
@@ -28,6 +28,7 @@ def make_state(tmp_path: Path, stem: str = "book") -> TranslationResumeState:
             fail_fast=True,
             chunk_limit=1200,
             translate_metadata=True,
+            translate_alt_text=True,
         ),
         overwrite=True,
         timeout=9.5,
@@ -52,6 +53,7 @@ def test_resume_state_round_trip(tmp_path):
     assert loaded.overwrite
     assert loaded.chunk_limit == 1200
     assert loaded.translate_metadata
+    assert loaded.translate_alt_text
     assert loaded.timeout == 9.5
     assert loaded.retries == 3
 
@@ -102,6 +104,18 @@ def test_resume_state_load_defaults_missing_translate_metadata_to_false(tmp_path
     loaded = store.load(path)
 
     assert not loaded.translate_metadata
+
+
+def test_resume_state_load_defaults_missing_translate_alt_text_to_false(tmp_path):
+    path = tmp_path / "old.ayvu-state.json"
+    data = make_state(tmp_path).to_dict()
+    data.pop("translate_alt_text")
+    path.write_text(json.dumps(data), encoding="utf-8")
+    store = ResumeStateStore(tmp_path)
+
+    loaded = store.load(path)
+
+    assert not loaded.translate_alt_text
 
 
 def test_resume_state_scan_finds_running_and_invalid_states(tmp_path):


### PR DESCRIPTION
## Objective

Allow translating the alt text of images optionally, without trying to read text rendered inside the image.

## What changed

- Add the `--translate-alt-text` option to the `translate` command. When enabled, the `alt` attribute of `<img>` elements is translated as plain text through the existing `translate_text` flow (cache, glossary, chunking, dry-run).
- Preserve the image and every other attribute (`src`, etc.); only the `alt` value changes. Decorative images (empty `alt`) and images without `alt` are skipped.
- Count translated alt texts in `HtmlTranslationStats.alt_translated` and surface them in the report as a new "Alt texts translated" row (terminal and Markdown), shown only when greater than zero.
- Carry the option through `TranslationOptions` and the resume state (`translate_alt_text`, optional, defaults to `false` for backward compatibility).

## Out of scope

- Reading text rendered inside images (OCR / image translation) is intentionally left for a future AI/OCR feature.
- Exposing the option in the guided common-mode menu (kept consistent with `--translate-metadata`, which is also direct-command only).

## Validation

- `uv run pytest`: 201 tests passing (8 new).
- `git diff --check`: no errors.

## Related issue

Closes #76
