### PR TITLE
Add translation profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ lancadas e secoes versionadas quando uma release for publicada.
   obrigatorios ausentes e termos proibidos encontrados na saida.
 - Menu guiado de glossarios no modo comum, com criacao, edicao, previa,
   validacao, salvamento local e selecao antes de traduzir.
+- Perfis de traducao em `config.json`, com selecao por `--profile`, idioma de
+  destino padrao, glossario associado e campo de estilo informativo.
 - Opcao `--translate-metadata` para traduzir o titulo do EPUB e a navegacao
   EPUB 3 de forma explicita e conservadora.
 - Opcao `--translate-alt-text` para traduzir o texto alternativo (`alt`) das

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ O EPUB original nunca é alterado. A saída é gravada em um novo arquivo `.epub
 - Preservação de tags, CSS, imagens, links, sumário e nomes de arquivos internos.
 - Cache SQLite para retomar traduções interrompidas e evitar chamadas repetidas.
 - Glossário JSON opcional e fluxo guiado para padronizar termos técnicos.
+- Perfis de tradução para agrupar idioma de destino, glossário e estilo planejado.
 - Proteção de URLs, caminhos, comandos, versões, código inline e identificadores técnicos simples durante a tradução.
 - Nome de saída automático baseado no idioma de destino.
 - Preview traduzido de uma amostra inicial do EPUB.
@@ -124,6 +125,12 @@ uv run ayvu translate livro.epub \
   --cache .cache/traducoes.sqlite
 ```
 
+Traduzir usando um perfil salvo na configuração:
+
+```bash
+uv run ayvu translate livro.epub --profile technical
+```
+
 Se `--source` não for informado, o Ayvu lê o idioma do EPUB nos metadados, exibe o
 plano da tradução (`From`/`To`) antes de começar e usa o idioma detectado como
 origem. Quando o metadado estiver ausente ou inválido, o Ayvu avisa e usa `en`
@@ -184,11 +191,16 @@ livro, gerar preview, abrir biblioteca, gerenciar glossários, acessar configura
 lista EPUBs das pastas `Original` e `Traduzidos`, mostra as versões disponíveis de cada livro e
 permite abrir o original ou uma tradução no leitor configurado ou no leitor padrão detectado no
 sistema. A opção `Settings` permite ver e alterar idioma padrão, pasta base dos livros, nomes das
-pastas das funcionalidades e app leitor de EPUB. Nos fluxos
+pastas das funcionalidades, app leitor de EPUB e perfis de tradução configurados. Nos fluxos
 guiados de tradução e preview, o Ayvu mostra o idioma de destino padrão salvo como primeira
 opção. Ao escolher `Outro idioma`, ele lista os idiomas informados pelo LibreTranslate com nome,
 código e estado, permitindo selecionar pela opção exibida ou digitar um código.
 No modo desenvolvedor, o idioma de destino continua sendo definido por `--target`.
+
+Se perfis estiverem configurados, o fluxo guiado de tradução permite escolher um perfil antes do
+idioma de destino. O perfil pode fornecer um idioma padrão diferente e um glossário associado.
+No modo desenvolvedor, use `--profile nome`. Flags explícitas como `--target` e `--glossary`
+sobrescrevem os valores do perfil.
 
 Antes de iniciar a tradução, o Ayvu verifica internamente o par de idiomas, o glossário, o cache, o EPUB de entrada e, em traduções reais, o tradutor configurado. Se algo impedir a execução, o comando falha cedo com uma mensagem curta e um próximo passo.
 
@@ -382,14 +394,34 @@ Formato inicial:
     "reports": "Relatorios",
     "processing": "Processando"
   },
-  "reader_app": null
+  "reader_app": null,
+  "profiles": {}
 }
 ```
 
-A precedência usada pelos fluxos atuais é:
+Perfis podem ser adicionados manualmente em `profiles`:
+
+```json
+{
+  "profiles": {
+    "technical": {
+      "target_language": "pt",
+      "glossary": "technical.json",
+      "style": "technical"
+    }
+  }
+}
+```
+
+`target_language` define o idioma de destino padrão quando `--target` não for informado.
+`glossary` aceita caminho absoluto ou caminho relativo à pasta local de glossários. `style`
+aceita `neutral`, `technical`, `literary` ou `academic`, mas no backend LibreTranslate atual
+serve apenas como metadado do perfil; ele não muda o prompt nem o comportamento do tradutor.
+
+A precedência para campos cobertos por perfis de tradução é:
 
 ```text
-argumentos da CLI > arquivo de configuração > padrões internos
+argumentos da CLI > perfil selecionado > arquivo de configuração > padrões internos
 ```
 
 Sem caminhos explícitos, a pasta base e os nomes de pastas configurados definem onde o Ayvu salva

--- a/docs/relatorio-tecnico.md
+++ b/docs/relatorio-tecnico.md
@@ -41,7 +41,7 @@ O Ayvu já possui:
 - modo comum guiado e modo desenvolvedor direto;
 - retomada local de traduções interrompidas;
 - comando para listar idiomas do LibreTranslate;
-- formato inicial de configuração local;
+- formato inicial de configuração local com perfis de tradução;
 - biblioteca inicial para listar originais e traduções e abrir EPUBs no leitor configurado ou padrão do sistema;
 - validação do EPUB gerado com barra de progresso e avisos de capítulo vazio, link interno quebrado e imagem ausente;
 - testes automatizados e CI no GitHub Actions.
@@ -243,7 +243,7 @@ regras explícitas `translate`, `preserve` e `forbidden`.
 
 `src/ayvu/cli_progress.py` adapta callbacks de tradução para `rich.Progress` e mantém contadores de textos.
 
-`src/ayvu/config.py` define o formato inicial de configuração JSON, o caminho padrão do arquivo, leitura/gravação e resolução das pastas locais do Ayvu. O menu guiado de `Settings` permite alterar idioma padrão, pasta base, nomes das pastas das funcionalidades e app leitor.
+`src/ayvu/config.py` define o formato inicial de configuração JSON, perfis de tradução, o caminho padrão do arquivo, leitura/gravação e resolução das pastas locais do Ayvu. O menu guiado de `Settings` permite alterar idioma padrão, pasta base, nomes das pastas das funcionalidades e app leitor, além de mostrar os perfis configurados.
 
 `src/ayvu/validation.py` valida o EPUB gerado: confirma abertura e documentos XHTML/HTML e avisa sobre capítulos vazios, links internos quebrados e imagens referenciadas ausentes, com callback de progresso opcional. Qualquer aviso faz a execução falhar com código 1.
 
@@ -275,17 +275,19 @@ Formato versionado atual:
     "reports": "Relatorios",
     "processing": "Processando"
   },
-  "reader_app": null
+  "reader_app": null,
+  "profiles": {}
 }
 ```
 
-A precedência usada pelos fluxos atuais é:
+A precedência para campos cobertos por perfis de tradução é:
 
 ```text
-argumentos da CLI > arquivo de configuração > padrões internos
+argumentos da CLI > perfil selecionado > arquivo de configuração > padrões internos
 ```
 
 Hoje a configuração já alimenta os diretórios padrão de preview, traduções, relatórios Markdown, estados de processamento e biblioteca. O app leitor configurado é usado pela biblioteca ao abrir EPUBs.
+Perfis podem definir `target_language`, `glossary` e `style`; caminhos relativos de glossário são resolvidos a partir da pasta local `glossaries`. Com LibreTranslate, `style` é metadado informativo e não altera a chamada HTTP.
 
 ## 10. Pipeline de EPUB
 

--- a/docs/tutorial-modo-comum-e-dev.md
+++ b/docs/tutorial-modo-comum-e-dev.md
@@ -43,9 +43,11 @@ Abra o menu inicial:
 uv run ayvu
 ```
 
-O menu permite iniciar uma tradução, gerar preview, abrir biblioteca, gerenciar glossários, ver ajuda e acessar configurações. A biblioteca lista EPUBs das pastas configuradas para originais e traduções, mostra as versões disponíveis e permite abrir o arquivo escolhido no leitor configurado ou no leitor padrão detectado no sistema. As configurações permitem alterar idioma padrão, pasta base dos livros, nomes das pastas das funcionalidades e app leitor de EPUB.
+O menu permite iniciar uma tradução, gerar preview, abrir biblioteca, gerenciar glossários, ver ajuda e acessar configurações. A biblioteca lista EPUBs das pastas configuradas para originais e traduções, mostra as versões disponíveis e permite abrir o arquivo escolhido no leitor configurado ou no leitor padrão detectado no sistema. As configurações permitem alterar idioma padrão, pasta base dos livros, nomes das pastas das funcionalidades e app leitor de EPUB, além de mostrar os perfis de tradução configurados.
 
 No primeiro uso, o Ayvu pergunta o idioma padrão de leitura/tradução e a pasta base dos livros. Em seguida, mostra os nomes das pastas das funcionalidades e permite manter os padrões ou alterá-los uma única vez antes de salvar a configuração. Essa pasta é usada para organizar biblioteca, previews, relatórios, traduções e estados de processamento.
+
+Se houver perfis de tradução no arquivo de configuração, a tradução guiada mostra esses perfis antes da escolha do idioma de destino. Um perfil pode fornecer um idioma padrão diferente e um glossário associado.
 
 ### Gerar um preview
 
@@ -172,6 +174,34 @@ O glossário é aplicado depois da tradução e também sobre textos vindos do c
 Use `required: true` em regras `translate` ou `preserve` quando o termo esperado
 deve aparecer na saída. Ao final, o relatório conta termos aplicados e avisa
 termos obrigatórios ausentes ou termos `forbidden` encontrados no texto final.
+
+### Usar perfis de tradução
+
+Perfis ficam no arquivo de configuração local e agrupam opções reutilizáveis:
+
+```json
+{
+  "profiles": {
+    "technical": {
+      "target_language": "pt",
+      "glossary": "technical.json",
+      "style": "technical"
+    }
+  }
+}
+```
+
+Use o perfil no modo desenvolvedor:
+
+```bash
+uv run ayvu translate livro.epub --profile technical
+```
+
+No modo comum, escolha o perfil quando ele aparecer antes da seleção do idioma. Caminhos relativos
+em `glossary` são resolvidos dentro de `$XDG_CONFIG_HOME/ayvu/glossaries` ou
+`~/.config/ayvu/glossaries`. `--target` e `--glossary` continuam tendo precedência sobre o
+perfil. O campo `style` aceita `neutral`, `technical`, `literary` ou `academic`, mas com
+LibreTranslate ele ainda é apenas informativo.
 
 ### Usar cache de forma consistente
 
@@ -348,7 +378,7 @@ Depois da tradução:
 ## Limites atuais
 
 - A biblioteca inicial lista e abre EPUBs, mas ainda não gerencia importação automática, fila ou histórico completo.
-- Configurações ainda cobrem apenas as preferências locais iniciais.
+- Perfis ainda não têm editor guiado completo; edite `profiles` diretamente no arquivo de configuração.
 - A tradução ainda acontece por nós de texto, então frases quebradas por tags podem perder contexto.
 - A qualidade depende do servidor de tradução local.
 - Livros técnicos costumam exigir glossário.

--- a/src/ayvu/cli.py
+++ b/src/ayvu/cli.py
@@ -11,7 +11,15 @@ from rich.table import Table
 
 from .cache import TranslationCache
 from .cli_progress import TranslationProgress, TranslationProgressSnapshot
-from .config import DEFAULT_BOOKS_DIR, AyvuConfig, ConfigError, ConfigStore, FolderNames, default_glossaries_dir
+from .config import (
+    DEFAULT_BOOKS_DIR,
+    AyvuConfig,
+    ConfigError,
+    ConfigStore,
+    FolderNames,
+    TranslationProfile,
+    default_glossaries_dir,
+)
 from .domain import (
     LanguagePair,
     OutputPlan,
@@ -71,6 +79,7 @@ GLOSSARY_PREVIEW_OPTION = "3"
 GLOSSARY_BACK_OPTION = "0"
 GLOSSARY_RULE_TRANSLATE_OPTION = "1"
 GLOSSARY_RULE_PRESERVE_OPTION = "2"
+PROFILE_NO_PROFILE_OPTION = "0"
 EXISTING_OUTPUT_OVERWRITE_OPTION = "1"
 EXISTING_OUTPUT_RENAME_OPTION = "2"
 EXISTING_OUTPUT_CANCEL_OPTION = "0"
@@ -207,11 +216,20 @@ def translate(
         "--source",
         help="Source language. If omitted, Ayvu reads the language metadata from the EPUB.",
     ),
-    target: str = typer.Option(DEFAULT_TARGET_LANGUAGE, "--target", help="Target language."),
+    target: Optional[str] = typer.Option(
+        None,
+        "--target",
+        help="Target language. Defaults to the profile target or pt.",
+    ),
     translator_name: str = typer.Option("libretranslate", "--translator", help="Translator backend."),
     url: str = typer.Option(DEFAULT_TRANSLATOR_URL, "--url", help="Translator base URL."),
     cache_path: Path = typer.Option(Path(".cache/traducoes.sqlite"), "--cache", help="SQLite cache path."),
     glossary_path: Optional[Path] = typer.Option(None, "--glossary", help="Optional JSON glossary."),
+    profile_name: Optional[str] = typer.Option(
+        None,
+        "--profile",
+        help="Translation profile from the Ayvu config.",
+    ),
     dry_run: bool = typer.Option(False, "--dry-run", help="Process without writing translated EPUB."),
     fail_fast: bool = typer.Option(False, "--fail-fast", help="Stop at the first chapter/text error."),
     overwrite: bool = typer.Option(False, "--overwrite", help="Allow replacing an existing output file."),
@@ -241,6 +259,7 @@ def translate(
         url=url,
         cache_path=cache_path,
         glossary_path=glossary_path,
+        profile_name=profile_name,
         dry_run=dry_run,
         fail_fast=fail_fast,
         overwrite=overwrite,
@@ -298,6 +317,8 @@ def _print_translation_plan(
     language_pair: LanguagePair,
     source_inferred: bool,
     mode: UserMode,
+    profile_name: str | None = None,
+    profile_style: str | None = None,
 ) -> None:
     table = Table(title="Translation plan")
     table.add_column("Field")
@@ -307,6 +328,10 @@ def _print_translation_plan(
         source_value = f"{language_pair.source} (inferido do EPUB)"
     table.add_row("From", source_value)
     table.add_row("To", language_pair.target)
+    if profile_name:
+        table.add_row("Profile", profile_name)
+    if profile_style:
+        table.add_row("Profile style", profile_style)
     console.print(table)
     if source_inferred and mode == UserMode.COMMON:
         console.print(f"[dim]Idioma de origem detectado do EPUB: {language_pair.source}[/dim]")
@@ -326,15 +351,66 @@ def _print_translation_route(route: TranslationRoute | None, mode: UserMode) -> 
         console.print("[yellow]Rota intermediária em uso. A qualidade pode ficar comprometida.[/yellow]")
 
 
+def _resolve_requested_profile(
+    config: AyvuConfig,
+    profile_name: str | None,
+    mode: UserMode,
+) -> tuple[str | None, TranslationProfile | None]:
+    if profile_name is None or not profile_name.strip():
+        return None, None
+
+    name = profile_name.strip()
+    profile = config.profiles.get(name)
+    if profile is not None:
+        return name, profile
+
+    available = ", ".join(sorted(config.profiles)) or "nenhum perfil configurado"
+    _print_expected_error(
+        "Perfil de tradução não encontrado.",
+        "Use --profile com um perfil definido em config.json, ou remova --profile para rodar sem perfil.",
+        mode,
+        detail=f"Perfil solicitado: {name}. Perfis disponíveis: {available}.",
+    )
+    raise typer.Exit(code=1)
+
+
+def _resolve_target_language(
+    explicit_target: str | None,
+    profile: TranslationProfile | None,
+    default_target: str = DEFAULT_TARGET_LANGUAGE,
+) -> str:
+    if explicit_target is not None and explicit_target.strip():
+        return explicit_target.strip()
+    if profile is not None and profile.target_language is not None:
+        return profile.target_language
+    return default_target
+
+
+def _resolve_glossary_path(
+    explicit_glossary_path: Path | None,
+    profile: TranslationProfile | None,
+) -> Path | None:
+    if explicit_glossary_path is not None:
+        return explicit_glossary_path
+    if profile is None or profile.glossary is None:
+        return None
+
+    profile_glossary = profile.glossary.expanduser()
+    if profile_glossary.is_absolute():
+        return profile_glossary
+    return default_glossaries_dir() / profile_glossary
+
+
 def _run_translation(
     epub_path: Path,
     output: Path | None,
     source: str | None,
-    target: str,
+    target: str | None,
     translator_name: str,
     url: str,
     cache_path: Path,
     glossary_path: Path | None,
+    profile_name: str | None,
     dry_run: bool,
     fail_fast: bool,
     overwrite: bool,
@@ -347,9 +423,18 @@ def _run_translation(
     translate_alt_text: bool = False,
 ) -> None:
     config = config or _load_existing_config_or_default()
+    resolved_profile_name, profile = _resolve_requested_profile(config, profile_name, mode=mode)
+    resolved_target = _resolve_target_language(target, profile)
+    resolved_glossary_path = _resolve_glossary_path(glossary_path, profile)
     resolved_source, source_inferred = _resolve_source_language(source, epub_path, mode=mode)
-    language_pair = LanguagePair(source=resolved_source, target=target)
-    _print_translation_plan(language_pair, source_inferred=source_inferred, mode=mode)
+    language_pair = LanguagePair(source=resolved_source, target=resolved_target)
+    _print_translation_plan(
+        language_pair,
+        source_inferred=source_inferred,
+        mode=mode,
+        profile_name=resolved_profile_name,
+        profile_style=profile.style if profile else None,
+    )
     translation_options = TranslationOptions(
         language_pair=language_pair,
         dry_run=dry_run,
@@ -373,7 +458,7 @@ def _run_translation(
         preflight = run_translation_preflight(
             epub_path=epub_path,
             cache_path=cache_path,
-            glossary_path=glossary_path,
+            glossary_path=resolved_glossary_path,
             translator_name=translator_name,
             url=url,
             timeout=timeout,
@@ -396,7 +481,7 @@ def _run_translation(
             cache_path=cache_path,
             translator_name=translator_name,
             url=url,
-            glossary_path=glossary_path,
+            glossary_path=resolved_glossary_path,
             options=translation_options,
             overwrite=overwrite,
             timeout=timeout,
@@ -841,8 +926,11 @@ def _handle_guided_main_choice(choice: str, ctx: typer.Context, config: AyvuConf
 
 def _run_guided_translation(config: AyvuConfig) -> None:
     epub_path = Path(typer.prompt("EPUB path")).expanduser()
-    target = _choose_guided_target_language(config.default_target_language)
-    glossary_path = _choose_guided_translation_glossary()
+    profile_name, profile = _choose_guided_translation_profile(config)
+    target = _choose_guided_target_language(
+        _resolve_target_language(None, profile, default_target=config.default_target_language)
+    )
+    glossary_path = _choose_guided_profile_glossary(profile) or _choose_guided_translation_glossary()
     _run_translation(
         epub_path=epub_path,
         output=None,
@@ -852,6 +940,7 @@ def _run_guided_translation(config: AyvuConfig) -> None:
         url=DEFAULT_TRANSLATOR_URL,
         cache_path=Path(".cache/traducoes.sqlite"),
         glossary_path=glossary_path,
+        profile_name=profile_name,
         dry_run=False,
         fail_fast=False,
         overwrite=False,
@@ -867,6 +956,57 @@ def _run_guided_preview(config: AyvuConfig) -> None:
     epub_path = Path(typer.prompt("EPUB path")).expanduser()
     target = _choose_guided_target_language(config.default_target_language)
     _run_preview(epub_path, target=target, mode=UserMode.COMMON, config=config)
+
+
+def _choose_guided_translation_profile(
+    config: AyvuConfig,
+) -> tuple[str | None, TranslationProfile | None]:
+    if not config.profiles:
+        return None, None
+
+    profiles = tuple(sorted(config.profiles.items()))
+    console.print("[yellow]Translation profiles are configured.[/yellow]")
+    _print_translation_profiles(profiles)
+    console.print(f"{PROFILE_NO_PROFILE_OPTION}. Run without profile")
+
+    while True:
+        choice = typer.prompt("Choose profile", default=PROFILE_NO_PROFILE_OPTION).strip()
+        if choice == PROFILE_NO_PROFILE_OPTION:
+            return None, None
+        if choice.isdigit() and 1 <= int(choice) <= len(profiles):
+            name, profile = profiles[int(choice) - 1]
+            console.print(f"[green]Profile selected:[/green] {name}")
+            return name, profile
+        if choice in config.profiles:
+            console.print(f"[green]Profile selected:[/green] {choice}")
+            return choice, config.profiles[choice]
+        console.print(f"[red]Invalid profile.[/red] Choose 1-{len(profiles)} or 0.")
+
+
+def _print_translation_profiles(profiles: tuple[tuple[str, TranslationProfile], ...]) -> None:
+    table = Table(title="Translation profiles")
+    table.add_column("Option")
+    table.add_column("Name")
+    table.add_column("Target")
+    table.add_column("Glossary")
+    table.add_column("Style")
+    for index, (name, profile) in enumerate(profiles, start=1):
+        table.add_row(
+            str(index),
+            name,
+            profile.target_language or "-",
+            str(profile.glossary) if profile.glossary else "-",
+            profile.style or "-",
+        )
+    console.print(table)
+
+
+def _choose_guided_profile_glossary(profile: TranslationProfile | None) -> Path | None:
+    glossary_path = _resolve_glossary_path(None, profile)
+    if glossary_path is None:
+        return None
+    console.print(f"[green]Profile glossary:[/green] {glossary_path}")
+    return glossary_path
 
 
 def _run_guided_glossaries() -> None:
@@ -1267,6 +1407,7 @@ def _print_settings(config: AyvuConfig) -> None:
     table.add_row("Reports folder", config.folders.reports)
     table.add_row("Processing folder", config.folders.processing)
     table.add_row("Reader app", config.reader_app or "-")
+    table.add_row("Translation profiles", _format_profile_names(config))
     console.print(table)
 
 
@@ -1325,6 +1466,12 @@ def _settings_with_reader_app(config: AyvuConfig) -> AyvuConfig:
     if reader_app == config.reader_app:
         return config
     return replace(config, reader_app=reader_app)
+
+
+def _format_profile_names(config: AyvuConfig) -> str:
+    if not config.profiles:
+        return "-"
+    return ", ".join(sorted(config.profiles))
 
 
 def _prompt_path(prompt: str, current: Path) -> Path:
@@ -1463,6 +1610,7 @@ def _resume_translation(state: TranslationResumeState, mode: UserMode) -> None:
             url=state.url,
             cache_path=state.cache_path,
             glossary_path=state.glossary_path,
+            profile_name=None,
             dry_run=False,
             fail_fast=state.fail_fast,
             overwrite=state.overwrite,

--- a/src/ayvu/config.py
+++ b/src/ayvu/config.py
@@ -13,6 +13,16 @@ DEFAULT_BOOKS_DIR = "~/Documentos/Livros"
 DEFAULT_CONFIG_DIR = "ayvu"
 DEFAULT_CONFIG_FILE = "config.json"
 DEFAULT_GLOSSARIES_DIR = "glossaries"
+PROFILE_STYLE_NEUTRAL = "neutral"
+PROFILE_STYLE_TECHNICAL = "technical"
+PROFILE_STYLE_LITERARY = "literary"
+PROFILE_STYLE_ACADEMIC = "academic"
+PROFILE_STYLES = {
+    PROFILE_STYLE_NEUTRAL,
+    PROFILE_STYLE_TECHNICAL,
+    PROFILE_STYLE_LITERARY,
+    PROFILE_STYLE_ACADEMIC,
+}
 
 
 class ConfigError(ValueError):
@@ -47,12 +57,49 @@ class FolderNames:
 
 
 @dataclass(frozen=True)
+class TranslationProfile:
+    target_language: str | None = None
+    glossary: Path | None = None
+    style: str | None = None
+
+    @classmethod
+    def from_dict(cls, data: object, profile_name: str) -> "TranslationProfile":
+        if not isinstance(data, dict):
+            raise ConfigError(f"Config profile {profile_name} must be an object.")
+
+        style = _optional_nullable_text(data, "style")
+        if style is not None and style not in PROFILE_STYLES:
+            allowed = ", ".join(sorted(PROFILE_STYLES))
+            raise ConfigError(
+                f"Config profile {profile_name} field style must be one of: {allowed}."
+            )
+
+        glossary = _optional_nullable_text(data, "glossary")
+        return cls(
+            target_language=_optional_nullable_text(data, "target_language"),
+            glossary=Path(glossary) if glossary is not None else None,
+            style=style,
+        )
+
+    def to_dict(self) -> dict[str, str]:
+        data: dict[str, str] = {}
+        if self.target_language is not None:
+            data["target_language"] = self.target_language
+        if self.glossary is not None:
+            data["glossary"] = str(self.glossary)
+        if self.style is not None:
+            data["style"] = self.style
+        return data
+
+
+@dataclass(frozen=True)
 class AyvuConfig:
     version: int = CONFIG_VERSION
     default_target_language: str = DEFAULT_TARGET_LANGUAGE
     books_dir: Path = Path(DEFAULT_BOOKS_DIR)
     folders: FolderNames = field(default_factory=FolderNames)
     reader_app: str | None = None
+    profiles: dict[str, TranslationProfile] = field(default_factory=dict)
 
     @classmethod
     def default(cls) -> "AyvuConfig":
@@ -77,6 +124,7 @@ class AyvuConfig:
             books_dir=Path(_optional_text(data, "books_dir", DEFAULT_BOOKS_DIR)),
             folders=FolderNames.from_dict(data.get("folders")),
             reader_app=_optional_nullable_text(data, "reader_app"),
+            profiles=_profiles_from_dict(data.get("profiles")),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -86,6 +134,10 @@ class AyvuConfig:
             "books_dir": str(self.books_dir),
             "folders": self.folders.to_dict(),
             "reader_app": self.reader_app,
+            "profiles": {
+                name: profile.to_dict()
+                for name, profile in sorted(self.profiles.items())
+            },
         }
 
     @property
@@ -192,3 +244,20 @@ def _folder_name(data: dict[str, object], key: str, default: str) -> str:
     if path.is_absolute() or path.name != value or "/" in value or "\\" in value:
         raise ConfigError(f"Config folder name {key} must be a folder name, not a path.")
     return value
+
+
+def _profiles_from_dict(data: object) -> dict[str, TranslationProfile]:
+    if data is None:
+        return {}
+    if not isinstance(data, dict):
+        raise ConfigError("Config field profiles must be an object.")
+
+    profiles: dict[str, TranslationProfile] = {}
+    for raw_name, raw_profile in data.items():
+        if not isinstance(raw_name, str) or not raw_name.strip():
+            raise ConfigError("Config profile names must be non-empty strings.")
+        name = raw_name.strip()
+        if name in profiles:
+            raise ConfigError(f"Config profile {name} is defined more than once.")
+        profiles[name] = TranslationProfile.from_dict(raw_profile, profile_name=name)
+    return profiles

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -626,6 +626,62 @@ def test_root_command_selects_saved_glossary_for_guided_translation(isolated_con
     assert calls["glossary"] is not None
 
 
+def test_root_command_selects_profile_for_guided_translation(isolated_config, tmp_path, monkeypatch):
+    epub_path = tmp_path / "book.epub"
+    output_dir = tmp_path / "Traduzidos"
+    processing_dir = tmp_path / "Processando"
+    epub_path.write_bytes(b"fake epub")
+    profile_glossary_path = isolated_config.parent / "glossaries" / "technical.json"
+    isolated_config.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "default_target_language": "pt",
+                "profiles": {
+                    "technical": {
+                        "target_language": "es",
+                        "glossary": "technical.json",
+                        "style": "technical",
+                    }
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    calls: dict[str, object] = {}
+
+    def fake_preflight(**kwargs: object) -> object:
+        calls["preflight"] = kwargs
+        return SimpleNamespace(translator=object(), glossary=object(), route=None)
+
+    def fake_translate(input_path: Path, output_path: Path, **kwargs: object) -> TranslationReport:
+        calls["input_path"] = input_path
+        calls["output_path"] = output_path
+        calls["options"] = kwargs["options"]
+        return TranslationReport(output_path=output_path, input_path=input_path, target_language="es")
+
+    monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: processing_dir)
+    monkeypatch.setattr("ayvu.cli.default_translated_books_dir", lambda: output_dir)
+    monkeypatch.setattr("ayvu.cli.run_translation_preflight", fake_preflight)
+    monkeypatch.setattr("ayvu.cli.TranslationCache", lambda _path: FakeCache())
+    monkeypatch.setattr("ayvu.cli.translate_epub", fake_translate)
+    monkeypatch.setattr("ayvu.cli.validate_output_epub", lambda _path, on_progress=None: ValidationResult(ok=True, document_count=1))
+    monkeypatch.setattr("ayvu.cli._offer_markdown_report", lambda *_args, **_kwargs: None)
+
+    result = runner.invoke(app, [], input=f"1\n{epub_path}\n1\n1\ny\n")
+
+    preflight = calls["preflight"]
+    options = calls["options"]
+    assert result.exit_code == 0
+    assert "Translation profiles are configured." in result.output
+    assert "Profile selected:" in result.output
+    assert "Profile glossary:" in result.output
+    assert preflight["language_pair"].target == "es"
+    assert preflight["glossary_path"] == profile_glossary_path
+    assert options.target == "es"
+
+
 def test_root_command_shows_empty_guided_library(isolated_config, tmp_path):
     books_dir = tmp_path / "Biblioteca"
     isolated_config.write_text(
@@ -1650,6 +1706,121 @@ def test_translate_explicit_source_overrides_epub_metadata(minimal_epub_path, tm
     assert result.exit_code == 0
     assert calls["options"].source == "fr"
     assert "inferido do EPUB" not in result.output
+
+
+def test_translate_command_uses_profile_target_and_glossary(
+    isolated_config,
+    minimal_epub_path,
+    tmp_path,
+    monkeypatch,
+):
+    isolated_config.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "profiles": {
+                    "technical": {
+                        "target_language": "es",
+                        "glossary": "technical.json",
+                        "style": "technical",
+                    }
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("ayvu.cli.default_translated_books_dir", lambda: tmp_path / "Traduzidos")
+    calls: dict[str, object] = {}
+    _mock_translation_pipeline(monkeypatch, calls)
+
+    result = runner.invoke(
+        app,
+        ["--mode", "developer", "translate", str(minimal_epub_path), "--profile", "technical"],
+    )
+
+    preflight = calls["preflight"]
+    options = calls["options"]
+    assert result.exit_code == 0
+    assert "Profile" in result.output
+    assert "technical" in result.output
+    assert preflight["language_pair"].target == "es"
+    assert preflight["glossary_path"] == isolated_config.parent / "glossaries" / "technical.json"
+    assert options.target == "es"
+
+
+def test_translate_command_explicit_target_and_glossary_override_profile(
+    isolated_config,
+    minimal_epub_path,
+    tmp_path,
+    monkeypatch,
+):
+    profile_glossary_path = isolated_config.parent / "glossaries" / "technical.json"
+    explicit_glossary_path = tmp_path / "custom.json"
+    isolated_config.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "profiles": {
+                    "technical": {
+                        "target_language": "es",
+                        "glossary": str(profile_glossary_path),
+                        "style": "technical",
+                    }
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("ayvu.cli.default_translated_books_dir", lambda: tmp_path / "Traduzidos")
+    calls: dict[str, object] = {}
+    _mock_translation_pipeline(monkeypatch, calls)
+
+    result = runner.invoke(
+        app,
+        [
+            "--mode",
+            "developer",
+            "translate",
+            str(minimal_epub_path),
+            "--profile",
+            "technical",
+            "--target",
+            "fr",
+            "--glossary",
+            str(explicit_glossary_path),
+        ],
+    )
+
+    preflight = calls["preflight"]
+    options = calls["options"]
+    assert result.exit_code == 0
+    assert preflight["language_pair"].target == "fr"
+    assert preflight["glossary_path"] == explicit_glossary_path
+    assert options.target == "fr"
+
+
+def test_translate_command_reports_unknown_profile_without_traceback(minimal_epub_path, monkeypatch):
+    called = False
+
+    def fail_preflight(**_kwargs: object) -> object:
+        nonlocal called
+        called = True
+        raise AssertionError("preflight should not run for an unknown profile")
+
+    monkeypatch.setattr("ayvu.cli.run_translation_preflight", fail_preflight)
+
+    result = runner.invoke(
+        app,
+        ["--mode", "developer", "translate", str(minimal_epub_path), "--profile", "missing"],
+    )
+
+    assert result.exit_code == 1
+    assert "Perfil de tradução não encontrado." in result.output
+    assert "Use --profile com um perfil definido" in result.output
+    assert "Traceback" not in result.output
+    assert not called
 
 
 def test_translate_metadata_flag_reaches_translation_options(minimal_epub_path, tmp_path, monkeypatch):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,6 +8,7 @@ from ayvu.config import (
     ConfigError,
     ConfigStore,
     FolderNames,
+    TranslationProfile,
     default_config_path,
     default_glossaries_dir,
 )
@@ -39,6 +40,7 @@ def test_default_config_defines_initial_preferences():
     assert config.books_dir == Path("~/Documentos/Livros")
     assert config.folders == FolderNames()
     assert config.reader_app is None
+    assert config.profiles == {}
 
 
 def test_config_serializes_full_initial_format():
@@ -56,6 +58,7 @@ def test_config_serializes_full_initial_format():
             "processing": "Processando",
         },
         "reader_app": None,
+        "profiles": {},
     }
 
 
@@ -68,6 +71,44 @@ def test_config_loads_partial_file_with_defaults(tmp_path):
     assert config.default_target_language == "es"
     assert config.books_dir == Path("~/Documentos/Livros")
     assert config.folders.translated == "Traduzidos"
+    assert config.profiles == {}
+
+
+def test_config_loads_translation_profiles(tmp_path):
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "profiles": {
+                    "technical": {
+                        "target_language": "pt-BR",
+                        "glossary": "technical.json",
+                        "style": "technical",
+                    }
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    config = ConfigStore(config_path).load()
+
+    assert config.profiles == {
+        "technical": TranslationProfile(
+            target_language="pt-BR",
+            glossary=Path("technical.json"),
+            style="technical",
+        )
+    }
+    assert config.to_dict()["profiles"] == {
+        "technical": {
+            "target_language": "pt-BR",
+            "glossary": "technical.json",
+            "style": "technical",
+        }
+    }
 
 
 def test_config_resolves_feature_directories(tmp_path):
@@ -130,3 +171,22 @@ def test_folder_names_must_not_be_paths():
 def test_blank_default_language_is_rejected():
     with pytest.raises(ConfigError, match="default_target_language"):
         AyvuConfig.from_dict({"version": 1, "default_target_language": " "})
+
+
+def test_translation_profiles_must_be_objects():
+    with pytest.raises(ConfigError, match="profiles must be an object"):
+        AyvuConfig.from_dict({"version": 1, "profiles": []})
+
+
+def test_translation_profile_rejects_unknown_style():
+    with pytest.raises(ConfigError, match="style must be one of"):
+        AyvuConfig.from_dict(
+            {
+                "version": 1,
+                "profiles": {
+                    "custom": {
+                        "style": "cinematic",
+                    }
+                },
+            }
+        )


### PR DESCRIPTION
## Objective

Add reusable translation profiles so users can group target language, glossary, and future style metadata for EPUB translation.

## What changed

- Added `TranslationProfile` support to `config.json` with `target_language`, `glossary`, and `style` fields.
- Added `--profile` to `ayvu translate`, with explicit `--target` and `--glossary` taking precedence over profile values.
- Added guided-mode profile selection when profiles are configured.
- Resolved relative profile glossaries from the local `glossaries/` config folder.
- Updated tests, README, tutorial, technical report, and changelog.

## Out of scope

- No guided editor for creating or editing profiles yet.
- `style` is informational for LibreTranslate and does not change translator behavior.
- Cache keys are unchanged because glossaries are applied after translation and cache reads.

## Validation

- `uv run pytest tests/test_config.py tests/test_cli.py`: 90 tests passing.
- `uv run pytest`: 208 tests passing.
- `git diff --check`: no errors.
- `uv run ayvu translate --help`: confirms `--profile` appears.

## Related issue

Closes #77