### PR TITLE
Document glossary stacking decision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,9 @@ lancadas e secoes versionadas quando uma release for publicada.
 - README e relatorio tecnico foram atualizados para refletir modos de uso,
   retomada, configuracao, biblioteca, validacao, CI e roadmap.
 - `glossary.example.json` agora demonstra o formato avancado de glossario.
+- Documentada a decisao de manter um glossario ativo por traducao ou perfil,
+  adiando empilhamento generico e preferindo uma futura evolucao por glossarios
+  com regra padrao de arquivo.
 
 ### Corrigido
 

--- a/README.md
+++ b/README.md
@@ -320,6 +320,17 @@ Use `Glossaries` no modo comum para criar glossários guiados ou `glossary.examp
 como base para o modo desenvolvedor. O arquivo `glossary.json` local e os glossários privados
 são ignorados pelo Git para evitar versionar preferências pessoais ou conteúdo privado.
 
+Hoje cada tradução usa no máximo um glossário ativo: o arquivo escolhido em `--glossary`, o
+glossário associado ao perfil, ou nenhum glossário. O Ayvu não aceita vários `--glossary` na
+mesma execução. A decisão atual evita conflitos silenciosos entre arquivos, como um termo
+marcado para tradução em um glossário e para preservação ou proibição em outro.
+
+A direção planejada, se a necessidade crescer, é preferir glossários por regra em vez de
+empilhamento genérico. Nesse modelo futuro, um arquivo poderia declarar no início que todos os
+seus termos são `translate`, `preserve` ou `forbidden`, reduzindo repetição para quem mantém
+glossários grandes. Mesmo nesse caso, a implementação deve definir antes regras claras de
+prioridade, conflito e relatório.
+
 Antes de enviar cada trecho ao tradutor, o Ayvu protege termos especiais como URLs, caminhos de arquivo, comandos de terminal, versões como `v1.2.0`, código inline entre crases, placeholders e identificadores técnicos simples. Esses termos são restaurados antes da aplicação do glossário e antes de salvar a tradução no cache.
 
 ## Cache e Retomada

--- a/docs/relatorio-tecnico.md
+++ b/docs/relatorio-tecnico.md
@@ -373,6 +373,31 @@ EPUB. Ele contabiliza aplicações de `translate` e `preserve`, inclusive em tex
 vindos do cache, e avisa termos obrigatórios ausentes ou termos proibidos
 encontrados na saída.
 
+### Decisão sobre múltiplos glossários
+
+A decisão atual é manter um glossário ativo por tradução ou perfil e não aceitar
+empilhamento genérico de vários arquivos `--glossary` na mesma execução.
+
+Motivos:
+
+- dois arquivos podem definir regras incompatíveis para o mesmo termo;
+- a ordem de prioridade teria de virar contrato de usuário e de cache;
+- o relatório precisaria explicar qual arquivo aplicou, bloqueou ou sobrescreveu
+  cada termo;
+- o modo comum ficaria mais complexo para um caso ainda não validado por uso real.
+
+Quando o usuário precisar combinar termos gerais, técnicos e específicos de um
+livro, a solução atual é compor um único glossário avançado e associá-lo ao livro
+ou ao perfil de tradução.
+
+A alternativa futura preferida não é empilhamento arbitrário, mas glossários por
+papel. Um arquivo poderia declarar uma regra padrão no início, como `translate`,
+`preserve` ou `forbidden`, e todos os termos internos herdariam essa regra. Isso
+reduz repetição para glossários grandes e mantém uma separação natural entre
+traduções preferidas, termos preservados e termos proibidos. Antes de implementar,
+o Ayvu ainda precisa definir formato, precedência, detecção de conflito e impacto
+no relatório.
+
 Antes de enviar texto ao tradutor, `src/ayvu/html_translate.py` protege termos especiais com placeholders internos e os restaura depois da chamada HTTP. O escopo protegido inclui URLs, caminhos de arquivo, comandos de terminal, versões como `v1.2.0`, placeholders, código inline e identificadores técnicos simples. A tradução restaurada é gravada no cache antes da aplicação do glossário.
 
 Textos longos são divididos antes de serem enviados ao tradutor. A regra atual tenta dividir por:
@@ -511,7 +536,8 @@ uv run pytest
 
 Prioridades que ainda fazem sentido:
 
-1. Evoluir o glossário para regras explícitas de preservar, traduzir e proibir termos.
+1. Avaliar glossários por regra, com regra padrão no arquivo para `translate`,
+   `preserve` ou `forbidden`, sem empilhamento genérico.
 2. Melhorar validação pós-tradução, incluindo links, capítulos vazios, imagens ausentes e texto não traduzido.
 3. Criar configuração persistente para idioma padrão, pastas e preferências.
 4. Melhorar cache com inspeção, limpeza, exportação e escopo por backend/modelo/glossário.

--- a/docs/tutorial-modo-comum-e-dev.md
+++ b/docs/tutorial-modo-comum-e-dev.md
@@ -175,6 +175,16 @@ Use `required: true` em regras `translate` ou `preserve` quando o termo esperado
 deve aparecer na saída. Ao final, o relatório conta termos aplicados e avisa
 termos obrigatórios ausentes ou termos `forbidden` encontrados no texto final.
 
+Use um glossário ativo por tradução ou perfil. O Ayvu não empilha vários arquivos de
+glossário na mesma execução, porque isso exigiria resolver conflitos entre regras diferentes
+para o mesmo termo. Quando um livro precisar de termos gerais, técnicos e específicos, componha
+esses termos em um único glossário por enquanto.
+
+Uma evolução futura pode separar glossários por papel, por exemplo um arquivo todo de
+traduções preferidas, outro de termos preservados e outro de termos proibidos. Para isso, o
+arquivo precisaria declarar sua regra padrão no início, em vez de repetir `rule` em cada termo.
+Esse formato ainda não está implementado.
+
 ### Usar perfis de tradução
 
 Perfis ficam no arquivo de configuração local e agrupam opções reutilizáveis:


### PR DESCRIPTION
## Objective

Record the product and technical decision for issue #78 about whether Ayvu should support multiple stacked glossaries.

## What changed

- Documented that current translations use at most one active glossary per run or profile.
- Explained why generic stacked `--glossary` inputs are deferred: conflicts, precedence, reporting, and common-mode complexity.
- Captured the preferred future direction: role-based glossaries with a file-level default rule such as `translate`, `preserve`, or `forbidden`.
- Updated README, guided/developer tutorial, technical report, and changelog.

## Out of scope

- No CLI or config behavior changes.
- No support for repeated `--glossary` inputs.
- No implementation of role-based glossary files yet.

## Validation

- `git diff --check`: no errors.

## Related issue

Closes #78