### PR TITLE
Add external review CSV export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@ lancadas e secoes versionadas quando uma release for publicada.
 - Opcao `--translate-alt-text` para traduzir o texto alternativo (`alt`) das
   imagens, preservando a imagem e demais atributos e contando os textos no
   relatorio. Leitura de texto dentro da imagem (OCR) fica fora do escopo.
+- Opcao `--review-output` para gerar CSV opcional com textos originais e
+  traduzidos lado a lado, IDs de capitulo/segmento e metadados de rastreio do
+  EPUB para revisao humana externa.
 
 ### Atualizado
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,21 @@ relatório passa a mostrar quantos textos alternativos foram traduzidos. Ler o
 texto que está dentro da imagem (OCR) está fora do escopo e fica para uma feature
 futura.
 
+Gerar um CSV opcional para revisão humana externa:
+
+```bash
+uv run ayvu translate livro.epub \
+  --target pt \
+  --review-output livro-review.csv
+```
+
+O arquivo de revisão só é criado quando `--review-output` é informado. Ele
+registra cada segmento traduzido com identificador de capítulo e segmento,
+caminho interno do documento no EPUB, idiomas, origem do cache e texto original
+e traduzido lado a lado. Se o CSV já existir, use `--overwrite` ou escolha outro
+caminho. A opção não funciona com `--dry-run`, porque o dry-run não gera texto
+traduzido revisável.
+
 Gerar um preview traduzido:
 
 ```bash
@@ -273,7 +288,7 @@ uv run ayvu translate livro.epub \
   --dry-run
 ```
 
-Ao final da tradução, o Ayvu mostra um relatório no terminal com o EPUB original, idiomas, saída calculada, capítulos processados, textos traduzidos, cache, erros e resumo do uso do glossário quando houver glossário configurado. No **Modo Comum**, também pergunta se deve salvar esse relatório em Markdown em `~/Documentos/Livros/Relatorios`.
+Ao final da tradução, o Ayvu mostra um relatório no terminal com o EPUB original, idiomas, saída calculada, arquivo de revisão quando solicitado, capítulos processados, textos traduzidos, cache, erros e resumo do uso do glossário quando houver glossário configurado. No **Modo Comum**, também pergunta se deve salvar esse relatório em Markdown em `~/Documentos/Livros/Relatorios`.
 
 Extrair texto visível para Markdown:
 

--- a/docs/relatorio-tecnico.md
+++ b/docs/relatorio-tecnico.md
@@ -80,6 +80,7 @@ ayvu/
 │       ├── html_translate.py
 │       ├── library.py
 │       ├── preflight.py
+│       ├── review_export.py
 │       ├── resume.py
 │       ├── translator.py
 │       └── validation.py
@@ -95,6 +96,7 @@ ayvu/
 │   ├── test_html_translate.py
 │   ├── test_library.py
 │   ├── test_preflight.py
+│   ├── test_review_export.py
 │   ├── test_resume.py
 │   ├── test_translator.py
 │   └── test_validation.py
@@ -181,6 +183,15 @@ uv run ayvu translate livro.epub \
   --cache .cache/traducoes.sqlite
 ```
 
+Exportar CSV para revisão externa durante a tradução:
+
+```bash
+uv run ayvu translate livro.epub \
+  --source en \
+  --target pt \
+  --review-output livro-review.csv
+```
+
 Gerar preview traduzido:
 
 ```bash
@@ -225,6 +236,8 @@ uv run ayvu --mode common translate livro.epub
 `src/ayvu/epub_io.py` cuida de leitura, inspeção, extração, tradução estrutural e escrita do EPUB final.
 
 `src/ayvu/html_translate.py` traduz HTML/XHTML por bloco (parágrafos, títulos e itens de lista), substituindo tags inline por placeholders neutros e restaurando-as depois, preservando tags e atributos e ignorando conteúdo que não deve ser traduzido.
+
+`src/ayvu/review_export.py` escreve o CSV opcional de revisão externa com segmentos originais/traduzidos, IDs e metadados de rastreio.
 
 `src/ayvu/library.py` varre as pastas de biblioteca configuradas, agrupa EPUB original e traduções por livro e resolve o comando usado para abrir EPUBs no app leitor.
 
@@ -443,6 +456,7 @@ Ao final da tradução, o Ayvu mostra um relatório no terminal com:
 - EPUB original;
 - idiomas;
 - saída gerada;
+- arquivo de revisão, quando `--review-output` for usado;
 - capítulos processados;
 - textos traduzidos;
 - textos reaproveitados do cache;
@@ -453,6 +467,8 @@ Ao final da tradução, o Ayvu mostra um relatório no terminal com:
   ausentes e termos proibidos encontrados.
 
 A validação roda antes do relatório final, então os avisos aparecem na tabela do terminal e, no modo comum, também no relatório Markdown. Qualquer aviso faz a execução terminar com código 1.
+
+Quando `--review-output` é informado, a CLI coleta os segmentos emitidos pelo fluxo normal de tradução e grava um CSV lado a lado. Cada linha inclui `segment_id`, caminho interno do documento no EPUB, índice de capítulo, idiomas, indicação de cache, texto original e texto traduzido. O CSV não é gerado em `--dry-run` e não sobrescreve arquivo existente sem `--overwrite`.
 
 No modo comum, o Ayvu também oferece salvar esse relatório em Markdown em `~/Documentos/Livros/Relatorios`, sem sobrescrever relatórios anteriores. O relatório Markdown repete o resumo de glossário e inclui seções com termos aplicados e avisos quando existirem.
 

--- a/docs/tutorial-modo-comum-e-dev.md
+++ b/docs/tutorial-modo-comum-e-dev.md
@@ -90,6 +90,10 @@ Ao final, o Ayvu mostra um relatório no terminal com capítulos processados, te
 ~/Documentos/Livros/Relatorios
 ```
 
+Quando precisar revisar a tradução fora do EPUB, use o modo desenvolvedor com
+`--review-output` para salvar um CSV lado a lado. O modo comum não pede esse
+arquivo automaticamente.
+
 ### Retomar uma tradução interrompida
 
 Durante traduções reais, o Ayvu registra um estado local em:
@@ -323,6 +327,21 @@ opção ativa, traduz apenas o `alt` das tags `<img>`, mantendo a imagem, o `src
 os demais atributos; imagens decorativas (`alt=""`) são ignoradas. O relatório
 mostra a quantidade de textos alternativos traduzidos. Ler o texto que está
 dentro da imagem (OCR) continua fora do escopo.
+
+### Exportar CSV para revisão externa
+
+```bash
+uv run ayvu translate livro.epub \
+  --source en \
+  --target pt \
+  --review-output livro-review.csv
+```
+
+O CSV contém uma linha por segmento traduzido, com `segment_id`, índice e nome
+do capítulo, caminho interno do documento, idiomas, indicação de cache e textos
+original/traduzido lado a lado. O arquivo só é criado quando a opção é usada. Se
+o caminho já existir, passe `--overwrite` ou escolha outro arquivo. `--dry-run`
+não gera CSV de revisão porque não produz tradução revisável.
 
 ### Sobrescrever saída existente
 

--- a/src/ayvu/cli.py
+++ b/src/ayvu/cli.py
@@ -48,6 +48,7 @@ from .resume import (
     TranslationResumeState,
     default_processing_dir,
 )
+from .review_export import ReviewSegment, write_review_csv
 from .translator import LibreTranslateTranslator, TranslationRoute, TranslatorError, TranslatorLanguage
 from .validation import validate_output_epub
 
@@ -211,6 +212,11 @@ def translate(
         "-o",
         help="Output EPUB path. Defaults to <input-stem>-<target>.epub.",
     ),
+    review_output: Optional[Path] = typer.Option(
+        None,
+        "--review-output",
+        help="Optional CSV path with original and translated segments for external review.",
+    ),
     source: Optional[str] = typer.Option(
         None,
         "--source",
@@ -253,6 +259,7 @@ def translate(
     _run_translation(
         epub_path=epub_path,
         output=output,
+        review_output=review_output,
         source=source,
         target=target,
         translator_name=translator_name,
@@ -404,6 +411,7 @@ def _resolve_glossary_path(
 def _run_translation(
     epub_path: Path,
     output: Path | None,
+    review_output: Path | None,
     source: str | None,
     target: str | None,
     translator_name: str,
@@ -453,6 +461,12 @@ def _run_translation(
     output_plan = _confirm_default_output_location(output_plan, epub_path, mode=mode)
     output_plan = _resolve_existing_output_conflict(output_plan, overwrite=overwrite, mode=mode)
     output_path = output_plan.path
+    review_output_path = _resolve_review_output_path(
+        review_output,
+        dry_run=dry_run,
+        overwrite=overwrite,
+        mode=mode,
+    )
 
     try:
         preflight = run_translation_preflight(
@@ -490,6 +504,7 @@ def _run_translation(
         )
 
     progress_view: TranslationProgress | None = None
+    review_segments: list[ReviewSegment] | None = [] if review_output_path is not None else None
     try:
         with Progress(
             SpinnerColumn(),
@@ -512,6 +527,7 @@ def _run_translation(
                     on_chapter_start=progress_view.chapter_started,
                     on_chapter_done=progress_view.chapter_done,
                     on_text_processed=progress_view.text_processed,
+                    review_segments=review_segments,
                 )
     except KeyboardInterrupt as exc:
         _print_interrupted_translation(
@@ -521,6 +537,10 @@ def _run_translation(
             dry_run=dry_run,
         )
         raise typer.Exit(code=1) from exc
+
+    if review_output_path is not None and review_segments is not None:
+        _write_review_output(review_output_path, review_segments, overwrite=overwrite, mode=mode)
+        report.review_output_path = review_output_path
 
     validation = None if dry_run else _validate_with_progress(output_path)
     validation_warnings = validation.warnings if validation else []
@@ -690,6 +710,8 @@ def _print_report(
     table.add_row("Detected language", report.detected_language or "-")
     table.add_row("Translated language", report.target_language or "-")
     table.add_row("Output", _report_output_value(report, dry_run))
+    if report.review_output_path is not None:
+        table.add_row("Review file", str(report.review_output_path))
     table.add_row("Chapters processed", str(report.chapters_processed))
     table.add_row("Texts translated", str(report.texts_translated))
     table.add_row("Texts from cache", str(report.texts_from_cache))
@@ -733,6 +755,56 @@ def _print_glossary_warnings(report: TranslationReport) -> None:
         console.print(f"  - Required terms missing: {_format_terms(usage.required_terms_missing)}")
     if usage.forbidden_terms_found:
         console.print(f"  - Forbidden terms found: {_format_counted_terms(usage.forbidden_terms_found)}")
+
+
+def _resolve_review_output_path(
+    review_output: Path | None,
+    dry_run: bool,
+    overwrite: bool,
+    mode: UserMode,
+) -> Path | None:
+    if review_output is None:
+        return None
+
+    if dry_run:
+        _print_expected_error(
+            "Não é possível gerar arquivo de revisão em dry-run.",
+            "Remova --dry-run para gerar traduções revisáveis, ou remova --review-output.",
+            mode,
+        )
+        raise typer.Exit(code=1)
+
+    path = review_output.expanduser()
+    if path.exists() and not overwrite:
+        _print_expected_error(
+            "Arquivo de revisão já existe.",
+            "Use --overwrite para substituí-lo ou escolha outro caminho em --review-output.",
+            mode,
+            detail=f"Review output: {path}",
+        )
+        raise typer.Exit(code=1)
+
+    return path
+
+
+def _write_review_output(
+    path: Path,
+    segments: list[ReviewSegment],
+    overwrite: bool,
+    mode: UserMode,
+) -> None:
+    try:
+        write_review_csv(path, segments, overwrite=overwrite)
+    except OSError as exc:
+        _print_expected_error(
+            "Não foi possível salvar o arquivo de revisão.",
+            "Escolha um caminho gravável para --review-output e tente novamente.",
+            mode,
+            detail=str(exc),
+        )
+        raise typer.Exit(code=1) from exc
+
+    console.print(f"[green]Review file saved to:[/green] {path}")
 
 
 def _print_interrupted_translation(
@@ -934,6 +1006,7 @@ def _run_guided_translation(config: AyvuConfig) -> None:
     _run_translation(
         epub_path=epub_path,
         output=None,
+        review_output=None,
         source=None,
         target=target,
         translator_name="libretranslate",
@@ -1604,6 +1677,7 @@ def _resume_translation(state: TranslationResumeState, mode: UserMode) -> None:
         _run_translation(
             epub_path=state.input_path,
             output=state.output_path,
+            review_output=None,
             source=state.source,
             target=state.target,
             translator_name=state.translator_name,
@@ -1746,6 +1820,8 @@ def _render_markdown_report(
         f"- Texts translated: {report.texts_translated}",
         f"- Texts from cache: {report.texts_from_cache}",
     ]
+    if report.review_output_path is not None:
+        lines.insert(6, f"- Review file: {report.review_output_path}")
     if report.alt_texts_translated:
         lines.append(f"- Alt texts translated: {report.alt_texts_translated}")
     lines.extend([

--- a/src/ayvu/epub_io.py
+++ b/src/ayvu/epub_io.py
@@ -14,18 +14,21 @@ from .cache import TranslationCache
 from .domain import TranslationOptions
 from .glossary import Glossary, GlossaryUsage
 from .html_translate import (
+    HtmlTranslatedSegment,
     HtmlTranslationStats,
     TextTranslationResult,
     extract_visible_text,
     translate_html,
     translate_text,
 )
+from .review_export import ReviewSegment
 from .translator import Translator
 
 
 ChapterStartCallback = Callable[[int, int, str], None]
 ChapterDoneCallback = Callable[[int, int, str, HtmlTranslationStats], None]
 TextProgressCallback = Callable[[str], None]
+MetadataReviewCallback = Callable[[str, TextTranslationResult], None]
 OPF_NAMESPACE = "http://www.idpf.org/2007/opf"
 DC_NAMESPACE = "http://purl.org/dc/elements/1.1/"
 
@@ -80,6 +83,7 @@ class TranslationReport:
     glossary_terms_configured: int = 0
     glossary_usage: GlossaryUsage = field(default_factory=GlossaryUsage)
     output_path: Path | None = None
+    review_output_path: Path | None = None
     input_path: Path | None = None
     detected_language: str | None = None
     target_language: str | None = None
@@ -163,6 +167,7 @@ def translate_epub(
     on_chapter_start: ChapterStartCallback | None = None,
     on_chapter_done: ChapterDoneCallback | None = None,
     on_text_processed: TextProgressCallback | None = None,
+    review_segments: list[ReviewSegment] | None = None,
 ) -> TranslationReport:
     source_path = Path(input_path)
     destination_path = Path(output_path)
@@ -201,6 +206,13 @@ def translate_epub(
                     glossary=glossary,
                     report=report,
                     on_text_processed=on_text_processed,
+                    on_review_text=_metadata_review_callback(
+                        review_segments,
+                        source_path=source_path,
+                        destination_path=destination_path,
+                        opf_archive_path=opf_archive_path,
+                        options=options,
+                    ),
                 )
                 if translated_opf is not None and not options.dry_run:
                     replacements.add(opf_archive_path, translated_opf)
@@ -221,6 +233,25 @@ def translate_epub(
                 on_chapter_start(index, total_documents, document.name)
 
             try:
+                document_segment_index = 0
+
+                def on_segment_translated(segment: HtmlTranslatedSegment) -> None:
+                    nonlocal document_segment_index
+                    if review_segments is None:
+                        return
+                    document_segment_index += 1
+                    review_segments.append(
+                        _review_segment_for_document(
+                            segment,
+                            source_path=source_path,
+                            destination_path=destination_path,
+                            document=document,
+                            chapter_index=index,
+                            segment_index=document_segment_index,
+                            options=options,
+                        )
+                    )
+
                 translated_content, stats = translate_html(
                     source_epub.read(document.archive_path),
                     translator=translator,
@@ -232,6 +263,7 @@ def translate_epub(
                     fail_fast=options.fail_fast,
                     chunk_limit=options.chunk_limit,
                     on_text_processed=on_text_processed,
+                    on_segment_translated=on_segment_translated if review_segments is not None else None,
                     translate_alt_text=options.translate_alt_text,
                 )
                 if not options.dry_run:
@@ -378,6 +410,68 @@ def _manifest_href_path(href: str) -> str:
     return PurePosixPath(unquote(clean)).as_posix()
 
 
+def _metadata_review_callback(
+    review_segments: list[ReviewSegment] | None,
+    source_path: Path,
+    destination_path: Path,
+    opf_archive_path: str,
+    options: TranslationOptions,
+) -> MetadataReviewCallback | None:
+    if review_segments is None:
+        return None
+
+    def append_metadata_segment(original: str, result: TextTranslationResult) -> None:
+        review_segments.append(
+            ReviewSegment(
+                segment_id="metadata-title",
+                source_epub=str(source_path),
+                output_epub=str(destination_path),
+                chapter_index=0,
+                chapter_name="metadata",
+                document_name=opf_archive_path,
+                document_path=opf_archive_path,
+                segment_kind="metadata_title",
+                source_language=options.source,
+                target_language=options.target,
+                original=original,
+                translated=result.text,
+                from_cache=result.from_cache,
+            )
+        )
+
+    return append_metadata_segment
+
+
+def _review_segment_for_document(
+    segment: HtmlTranslatedSegment,
+    source_path: Path,
+    destination_path: Path,
+    document: EpubDocument,
+    chapter_index: int,
+    segment_index: int,
+    options: TranslationOptions,
+) -> ReviewSegment:
+    return ReviewSegment(
+        segment_id=_review_segment_id(chapter_index, segment_index),
+        source_epub=str(source_path),
+        output_epub=str(destination_path),
+        chapter_index=chapter_index,
+        chapter_name=document.name,
+        document_name=document.name,
+        document_path=document.archive_path,
+        segment_kind=segment.kind,
+        source_language=options.source,
+        target_language=options.target,
+        original=segment.original,
+        translated=segment.translated,
+        from_cache=segment.from_cache,
+    )
+
+
+def _review_segment_id(chapter_index: int, segment_index: int) -> str:
+    return f"c{chapter_index:04d}-s{segment_index:04d}"
+
+
 def _translate_opf_title(
     opf_content: bytes,
     translator: Translator,
@@ -386,6 +480,7 @@ def _translate_opf_title(
     glossary: Glossary | None,
     report: TranslationReport,
     on_text_processed: TextProgressCallback | None,
+    on_review_text: MetadataReviewCallback | None = None,
 ) -> bytes | None:
     root = ET.fromstring(opf_content)
     title = _first_metadata_title(root)
@@ -402,6 +497,8 @@ def _translate_opf_title(
         dry_run=options.dry_run,
         chunk_limit=options.chunk_limit,
     )
+    if on_review_text:
+        on_review_text(title.text, result)
     title.text = result.text
     report.record_text(result)
     _notify_text_processed(on_text_processed, _text_progress_status(result, options.dry_run))

--- a/src/ayvu/html_translate.py
+++ b/src/ayvu/html_translate.py
@@ -113,6 +113,17 @@ class TextTranslationResult:
     glossary_usage: GlossaryUsage = field(default_factory=GlossaryUsage)
 
 
+@dataclass(frozen=True)
+class HtmlTranslatedSegment:
+    original: str
+    translated: str
+    kind: str
+    from_cache: bool = False
+
+
+SegmentReviewCallback = Callable[[HtmlTranslatedSegment], None]
+
+
 def extract_visible_text(html: str | bytes) -> list[str]:
     soup = BeautifulSoup(html, "lxml-xml")
     return [str(text_node) for text_node in _visible_text_nodes(soup) if str(text_node).strip()]
@@ -130,6 +141,7 @@ def translate_html(
     chunk_limit: int = 3000,
     on_error: Callable[[Exception], None] | None = None,
     on_text_processed: TextProgressCallback | None = None,
+    on_segment_translated: SegmentReviewCallback | None = None,
     translate_alt_text: bool = False,
 ) -> tuple[bytes, HtmlTranslationStats]:
     soup = BeautifulSoup(html, "lxml-xml")
@@ -155,6 +167,14 @@ def translate_html(
             if not dry_run:
                 fragment = _expand_tag_tokens(escape(result.text), tag_markup)
                 _replace_run(run, _parse_fragment_nodes(fragment))
+            _notify_segment_translated(
+                on_segment_translated,
+                original_template=template,
+                translated_template=result.text,
+                tag_markup=tag_markup,
+                kind="text",
+                from_cache=result.from_cache,
+            )
             stats.glossary_usage.merge(result.glossary_usage)
             _record_success(stats, result.from_cache, dry_run, on_text_processed)
         except Exception as exc:
@@ -179,6 +199,7 @@ def translate_html(
             stats=stats,
             on_error=on_error,
             on_text_processed=on_text_processed,
+            on_segment_translated=on_segment_translated,
         )
 
     return soup.encode(formatter="minimal"), stats
@@ -236,6 +257,7 @@ def _translate_image_alt_text(
     stats: HtmlTranslationStats,
     on_error: Callable[[Exception], None] | None,
     on_text_processed: TextProgressCallback | None,
+    on_segment_translated: SegmentReviewCallback | None,
 ) -> None:
     """Translate the ``alt`` text of ``img`` elements as plain text.
 
@@ -260,6 +282,14 @@ def _translate_image_alt_text(
             )
             if not dry_run:
                 image["alt"] = result.text
+            _notify_segment_translated(
+                on_segment_translated,
+                original_template=alt,
+                translated_template=result.text,
+                tag_markup=[],
+                kind="alt",
+                from_cache=result.from_cache,
+            )
             stats.glossary_usage.merge(result.glossary_usage)
             stats.alt_translated += 1
             _record_success(stats, result.from_cache, dry_run, on_text_processed)
@@ -488,6 +518,55 @@ def _protected_placeholder(index: int) -> str:
 def _notify_text_processed(callback: TextProgressCallback | None, status: str) -> None:
     if callback:
         callback(status)
+
+
+def _notify_segment_translated(
+    callback: SegmentReviewCallback | None,
+    original_template: str,
+    translated_template: str,
+    tag_markup: list[str],
+    kind: str,
+    from_cache: bool,
+) -> None:
+    if callback is None:
+        return
+
+    callback(
+        HtmlTranslatedSegment(
+            original=_review_text_from_template(original_template, tag_markup),
+            translated=_review_text_from_template(translated_template, tag_markup),
+            kind=kind,
+            from_cache=from_cache,
+        )
+    )
+
+
+def _review_text_from_template(template: str, tag_markup: list[str]) -> str:
+    fragment = _expand_tag_tokens(escape(template), tag_markup)
+    soup = BeautifulSoup(f"<{FRAGMENT_ROOT_TAG}>{fragment}</{FRAGMENT_ROOT_TAG}>", "lxml-xml")
+    root = soup.find(FRAGMENT_ROOT_TAG)
+    if root is None:
+        return TAG_TOKEN_PATTERN.sub("", template).strip()
+    return "".join(_review_visible_text_parts(root)).strip()
+
+
+def _review_visible_text_parts(node) -> list[str]:
+    parts: list[str] = []
+    for child in list(getattr(node, "children", [])):
+        if _is_special_string(child):
+            continue
+        if isinstance(child, NavigableString):
+            parts.append(str(child))
+            continue
+
+        name = _tag_name(child)
+        if name in {"script", "style", "svg", "math"}:
+            continue
+        if name == "br":
+            parts.append("\n")
+            continue
+        parts.extend(_review_visible_text_parts(child))
+    return parts
 
 
 def _record_success(

--- a/src/ayvu/review_export.py
+++ b/src/ayvu/review_export.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import csv
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+
+REVIEW_CSV_COLUMNS = (
+    "segment_id",
+    "source_epub",
+    "output_epub",
+    "chapter_index",
+    "chapter_name",
+    "document_name",
+    "document_path",
+    "segment_kind",
+    "source_language",
+    "target_language",
+    "from_cache",
+    "original",
+    "translated",
+)
+
+
+@dataclass(frozen=True)
+class ReviewSegment:
+    segment_id: str
+    source_epub: str
+    output_epub: str
+    chapter_index: int
+    chapter_name: str
+    document_name: str
+    document_path: str
+    segment_kind: str
+    source_language: str
+    target_language: str
+    original: str
+    translated: str
+    from_cache: bool = False
+
+
+def write_review_csv(
+    path: str | Path,
+    segments: Iterable[ReviewSegment],
+    overwrite: bool = False,
+) -> Path:
+    destination = Path(path)
+    if destination.exists() and not overwrite:
+        raise FileExistsError(destination)
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with destination.open("w", encoding="utf-8", newline="") as output_file:
+        writer = csv.DictWriter(output_file, fieldnames=REVIEW_CSV_COLUMNS)
+        writer.writeheader()
+        for segment in segments:
+            writer.writerow(_segment_row(segment))
+
+    return destination
+
+
+def _segment_row(segment: ReviewSegment) -> dict[str, object]:
+    return {
+        "segment_id": segment.segment_id,
+        "source_epub": segment.source_epub,
+        "output_epub": segment.output_epub,
+        "chapter_index": segment.chapter_index,
+        "chapter_name": segment.chapter_name,
+        "document_name": segment.document_name,
+        "document_path": segment.document_path,
+        "segment_kind": segment.segment_kind,
+        "source_language": segment.source_language,
+        "target_language": segment.target_language,
+        "from_cache": "true" if segment.from_cache else "false",
+        "original": segment.original,
+        "translated": segment.translated,
+    }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import csv
 import json
 from pathlib import Path
 from types import SimpleNamespace
@@ -19,6 +20,7 @@ from ayvu.glossary import GlossaryUsage
 from ayvu.library import LibraryOpenError
 from ayvu.preflight import PreflightError
 from ayvu.resume import COMPLETED_STATUS, ResumeStateStore, TranslationResumeState
+from ayvu.review_export import ReviewSegment
 from ayvu.translator import TranslatorError, TranslatorLanguage
 from ayvu.validation import ValidationResult
 
@@ -1352,6 +1354,131 @@ def test_translate_command_continues_when_existing_output_is_confirmed(tmp_path)
     assert "Detalhe técnico:" not in result.output
     assert "Unsupported translator:" not in result.output
     assert output_path.read_text(encoding="utf-8") == "already here"
+    assert "Traceback" not in result.output
+
+
+def test_translate_command_writes_review_output_when_requested(tmp_path, monkeypatch):
+    epub_path = tmp_path / "book.epub"
+    output_path = tmp_path / "book-pt.epub"
+    review_path = tmp_path / "book-review.csv"
+    processing_dir = tmp_path / "processing"
+    epub_path.write_bytes(b"fake epub")
+
+    def fake_translate(input_path: Path, output_path: Path, **kwargs: object) -> TranslationReport:
+        review_segments = kwargs["review_segments"]
+        assert isinstance(review_segments, list)
+        review_segments.append(
+            ReviewSegment(
+                segment_id="c0001-s0001",
+                source_epub=str(input_path),
+                output_epub=str(output_path),
+                chapter_index=1,
+                chapter_name="text/chapter.xhtml",
+                document_name="text/chapter.xhtml",
+                document_path="OEBPS/text/chapter.xhtml",
+                segment_kind="text",
+                source_language=kwargs["options"].source,
+                target_language=kwargs["options"].target,
+                original="Hello reader.",
+                translated="Ola leitor.",
+            )
+        )
+        return TranslationReport(
+            output_path=output_path,
+            input_path=input_path,
+            detected_language=kwargs["options"].source,
+            target_language=kwargs["options"].target,
+        )
+
+    monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: processing_dir)
+    monkeypatch.setattr(
+        "ayvu.cli.run_translation_preflight",
+        lambda **_kwargs: SimpleNamespace(translator=object(), glossary=None, route=None),
+    )
+    monkeypatch.setattr("ayvu.cli.TranslationCache", lambda _path: FakeCache())
+    monkeypatch.setattr("ayvu.cli.translate_epub", fake_translate)
+    monkeypatch.setattr("ayvu.cli.validate_output_epub", lambda _path, on_progress=None: ValidationResult(ok=True, document_count=1))
+    monkeypatch.setattr("ayvu.cli._offer_markdown_report", lambda *_args, **_kwargs: None)
+
+    result = runner.invoke(
+        app,
+        [
+            "translate",
+            str(epub_path),
+            "--output",
+            str(output_path),
+            "--review-output",
+            str(review_path),
+        ],
+    )
+
+    with review_path.open(encoding="utf-8", newline="") as input_file:
+        rows = list(csv.DictReader(input_file))
+
+    assert result.exit_code == 0
+    assert "Review file saved to:" in result.output
+    assert "Review file" in result.output
+    assert rows[0]["segment_id"] == "c0001-s0001"
+    assert rows[0]["document_path"] == "OEBPS/text/chapter.xhtml"
+    assert rows[0]["original"] == "Hello reader."
+    assert rows[0]["translated"] == "Ola leitor."
+
+
+def test_translate_command_rejects_existing_review_output_without_overwrite(tmp_path, monkeypatch):
+    epub_path = tmp_path / "book.epub"
+    output_path = tmp_path / "book-pt.epub"
+    review_path = tmp_path / "book-review.csv"
+    epub_path.write_bytes(b"fake epub")
+    review_path.write_text("already here", encoding="utf-8")
+
+    def fail_preflight(**_kwargs: object) -> object:
+        raise AssertionError("preflight should not run when review output already exists")
+
+    monkeypatch.setattr("ayvu.cli.run_translation_preflight", fail_preflight)
+
+    result = runner.invoke(
+        app,
+        [
+            "translate",
+            str(epub_path),
+            "--output",
+            str(output_path),
+            "--review-output",
+            str(review_path),
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Arquivo de revisão já existe." in result.output
+    assert "Use --overwrite" in result.output
+    assert review_path.read_text(encoding="utf-8") == "already here"
+    assert "Traceback" not in result.output
+
+
+def test_translate_command_rejects_review_output_with_dry_run(tmp_path, monkeypatch):
+    epub_path = tmp_path / "book.epub"
+    review_path = tmp_path / "book-review.csv"
+    epub_path.write_bytes(b"fake epub")
+
+    def fail_preflight(**_kwargs: object) -> object:
+        raise AssertionError("preflight should not run for dry-run review output")
+
+    monkeypatch.setattr("ayvu.cli.run_translation_preflight", fail_preflight)
+
+    result = runner.invoke(
+        app,
+        [
+            "translate",
+            str(epub_path),
+            "--dry-run",
+            "--review-output",
+            str(review_path),
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Não é possível gerar arquivo de revisão em dry-run." in result.output
+    assert not review_path.exists()
     assert "Traceback" not in result.output
 
 

--- a/tests/test_epub_io.py
+++ b/tests/test_epub_io.py
@@ -187,6 +187,42 @@ def test_translate_epub_translates_minimal_generated_epub_without_mutating_input
     assert "../images/pixel.png" in chapter
 
 
+def test_translate_epub_collects_review_segments_with_document_metadata(
+    minimal_epub_path: Path,
+    tmp_path: Path,
+):
+    output_path = tmp_path / "minimal-pt.epub"
+    translator = PrefixTranslator()
+    options = TranslationOptions(language_pair=LanguagePair(source="en", target="pt"))
+    review_segments = []
+
+    with TranslationCache(tmp_path / "cache.sqlite") as cache:
+        translate_epub(
+            minimal_epub_path,
+            output_path,
+            translator=translator,
+            cache=cache,
+            options=options,
+            review_segments=review_segments,
+        )
+
+    assert review_segments
+    assert review_segments[0].segment_id == "c0001-s0001"
+    assert review_segments[0].source_epub == str(minimal_epub_path)
+    assert review_segments[0].output_epub == str(output_path)
+    assert review_segments[0].chapter_index == 1
+    assert review_segments[0].document_path.endswith("text/chapter1.xhtml")
+    assert review_segments[0].source_language == "en"
+    assert review_segments[0].target_language == "pt"
+
+    paragraph = next(segment for segment in review_segments if "Hello reader" in segment.original)
+    assert paragraph.segment_id == "c0001-s0003"
+    assert paragraph.segment_kind == "text"
+    assert paragraph.original == "Hello reader. Visit chapter two."
+    assert paragraph.translated == "PT:Hello reader. Visit chapter two."
+    assert not paragraph.from_cache
+
+
 def test_translate_epub_preserves_metadata_and_navigation_by_default(
     minimal_epub_path: Path,
     tmp_path: Path,
@@ -235,6 +271,36 @@ def test_translate_epub_translates_metadata_and_navigation_when_enabled(
     assert ("Minimal Test Book", "en", "pt") in translator.calls
     navigation = _read_navigation_document(output_path)
     assert 'PT:<a href="text/chapter1.xhtml">Chapter One</a>' in navigation
+
+
+def test_translate_epub_collects_metadata_review_segment_when_enabled(
+    minimal_epub_path: Path,
+    tmp_path: Path,
+):
+    output_path = tmp_path / "minimal-pt.epub"
+    translator = PrefixTranslator()
+    options = TranslationOptions(
+        language_pair=LanguagePair(source="en", target="pt"),
+        translate_metadata=True,
+    )
+    review_segments = []
+
+    with TranslationCache(tmp_path / "cache.sqlite") as cache:
+        translate_epub(
+            minimal_epub_path,
+            output_path,
+            translator=translator,
+            cache=cache,
+            options=options,
+            review_segments=review_segments,
+        )
+
+    metadata = next(segment for segment in review_segments if segment.segment_id == "metadata-title")
+    assert metadata.chapter_index == 0
+    assert metadata.chapter_name == "metadata"
+    assert metadata.segment_kind == "metadata_title"
+    assert metadata.original == "Minimal Test Book"
+    assert metadata.translated == "PT:Minimal Test Book"
 
 
 def _read_chapter_one(epub_path: Path) -> str:

--- a/tests/test_html_translate.py
+++ b/tests/test_html_translate.py
@@ -81,6 +81,53 @@ def test_translate_html_uses_cache(tmp_path):
     assert translator.calls == ["Keep me"]
 
 
+def test_translate_html_reports_review_segments_as_visible_text(tmp_path):
+    html = '<html><body><p>Hello <a href="chapter.xhtml">reader</a>.</p></body></html>'
+    segments = []
+    translator = FakeTranslator()
+
+    with TranslationCache(tmp_path / "cache.sqlite") as cache:
+        translate_html(
+            html,
+            translator,
+            cache,
+            "en",
+            "pt",
+            on_segment_translated=segments.append,
+        )
+
+    assert len(segments) == 1
+    assert segments[0].kind == "text"
+    assert segments[0].original == "Hello reader."
+    assert segments[0].translated == "PT:Hello reader."
+    assert not segments[0].from_cache
+
+
+def test_translate_html_reports_review_segments_from_cache(tmp_path):
+    segments = []
+    translator = FakeTranslator()
+
+    with TranslationCache(tmp_path / "cache.sqlite") as cache:
+        cache.set(
+            CacheKey(text="Keep me", language_pair=LanguagePair(source="en", target="pt")),
+            "Mantenha-me",
+        )
+        translate_html(
+            "<html><body><p>Keep me</p></body></html>",
+            translator,
+            cache,
+            "en",
+            "pt",
+            on_segment_translated=segments.append,
+        )
+
+    assert len(segments) == 1
+    assert segments[0].original == "Keep me"
+    assert segments[0].translated == "Mantenha-me"
+    assert segments[0].from_cache
+    assert translator.calls == []
+
+
 def test_translate_text_result_reports_cache_hit(tmp_path):
     translator = FakeTranslator()
     with TranslationCache(tmp_path / "cache.sqlite") as cache:
@@ -381,6 +428,28 @@ def test_translate_html_translates_image_alt_when_enabled(tmp_path):
     assert "A red house" in translator.calls
     assert stats.alt_translated == 1
     assert stats.translated == 1
+
+
+def test_translate_html_reports_review_segments_for_image_alt(tmp_path):
+    html = '<html><body><p><img src="cover.png" alt="A red house" /></p></body></html>'
+    segments = []
+    translator = FakeTranslator()
+
+    with TranslationCache(tmp_path / "cache.sqlite") as cache:
+        translate_html(
+            html,
+            translator,
+            cache,
+            "en",
+            "pt",
+            translate_alt_text=True,
+            on_segment_translated=segments.append,
+        )
+
+    assert len(segments) == 1
+    assert segments[0].kind == "alt"
+    assert segments[0].original == "A red house"
+    assert segments[0].translated == "PT:A red house"
 
 
 def test_translate_html_skips_empty_or_missing_image_alt(tmp_path):

--- a/tests/test_review_export.py
+++ b/tests/test_review_export.py
@@ -1,0 +1,60 @@
+import csv
+from pathlib import Path
+
+import pytest
+
+from ayvu.review_export import REVIEW_CSV_COLUMNS, ReviewSegment, write_review_csv
+
+
+def test_write_review_csv_writes_segments_with_stable_columns(tmp_path: Path):
+    output = tmp_path / "review.csv"
+    segment = ReviewSegment(
+        segment_id="c0001-s0002",
+        source_epub="book.epub",
+        output_epub="book-pt.epub",
+        chapter_index=1,
+        chapter_name="text/chapter1.xhtml",
+        document_name="text/chapter1.xhtml",
+        document_path="OEBPS/text/chapter1.xhtml",
+        segment_kind="text",
+        source_language="en",
+        target_language="pt",
+        original="Hello, reader.",
+        translated="Ola, leitor.\nTudo bem?",
+        from_cache=True,
+    )
+
+    written = write_review_csv(output, [segment])
+
+    with written.open(encoding="utf-8", newline="") as input_file:
+        rows = list(csv.DictReader(input_file))
+
+    assert written == output
+    assert list(rows[0]) == list(REVIEW_CSV_COLUMNS)
+    assert rows == [
+        {
+            "segment_id": "c0001-s0002",
+            "source_epub": "book.epub",
+            "output_epub": "book-pt.epub",
+            "chapter_index": "1",
+            "chapter_name": "text/chapter1.xhtml",
+            "document_name": "text/chapter1.xhtml",
+            "document_path": "OEBPS/text/chapter1.xhtml",
+            "segment_kind": "text",
+            "source_language": "en",
+            "target_language": "pt",
+            "from_cache": "true",
+            "original": "Hello, reader.",
+            "translated": "Ola, leitor.\nTudo bem?",
+        }
+    ]
+
+
+def test_write_review_csv_does_not_overwrite_by_default(tmp_path: Path):
+    output = tmp_path / "review.csv"
+    output.write_text("already here", encoding="utf-8")
+
+    with pytest.raises(FileExistsError):
+        write_review_csv(output, [])
+
+    assert output.read_text(encoding="utf-8") == "already here"


### PR DESCRIPTION
## Objective

Add an explicit review export option so users can inspect original and translated content outside the EPUB.

## What changed

- Added `--review-output` to `ayvu translate` to write an optional CSV review file.
- Captured translated HTML, metadata title, and optional image alt segments through the existing translation and cache flow.
- Added stable segment metadata including chapter index, segment id, EPUB document path, source/target languages, cache usage, original text, and translated text.
- Added overwrite and dry-run validation for review export paths.
- Updated README, tutorial, technical report, changelog, and tests.

## Out of scope

- Importing reviewed CSV changes back into EPUB output is not implemented here.
- OCR or image text extraction remains out of scope.

## Validation

- `uv run pytest tests/test_html_translate.py tests/test_epub_io.py tests/test_review_export.py tests/test_cli.py`: 127 tests passing.
- `uv run pytest`: 218 tests passing.
- `git diff --check`: no errors.
- `uv run ayvu translate --help`: confirmed `--review-output` is listed.

## Related issue

Closes #91