### PR TITLE
Import reviewed translations into EPUB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ lancadas e secoes versionadas quando uma release for publicada.
 - Opcao `--review-output` para gerar CSV opcional com textos originais e
   traduzidos lado a lado, IDs de capitulo/segmento e metadados de rastreio do
   EPUB para revisao humana externa.
+- Comando `apply-review` para reconstruir um EPUB a partir de um CSV revisado,
+  validando que cada segmento ainda corresponde ao EPUB original, aplicando as
+  traducoes revisadas sem alterar o original e relatando trechos sem revisao,
+  ausentes, inconsistentes, duplicados ou de documentos desconhecidos.
 
 ### Atualizado
 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,28 @@ e traduzido lado a lado. Se o CSV já existir, use `--overwrite` ou escolha outr
 caminho. A opção não funciona com `--dry-run`, porque o dry-run não gera texto
 traduzido revisável.
 
+Depois de revisar o CSV (editando a coluna `translated`), reconstrua um EPUB
+final a partir do EPUB original com o texto revisado:
+
+```bash
+uv run ayvu apply-review livro.epub livro-review.csv \
+  --output livro-revisado.epub
+```
+
+O comando `apply-review` lê o EPUB original e o CSV revisado, confere que cada
+segmento ainda corresponde ao livro (comparando o texto original) e aplica as
+traduções revisadas em um novo EPUB, sem alterar o original. Se `--output` for
+omitido, o padrão é `<nome>-<idioma>-reviewed.epub`; use `--overwrite` para
+substituir um arquivo existente. O relatório informa quantos segmentos foram
+aplicados e lista trechos sem revisão, ausentes no EPUB, inconsistentes (texto
+original divergente), com identificadores duplicados ou documentos
+desconhecidos.
+
+Limitação: o CSV de revisão guarda apenas o texto visível de cada segmento.
+Por isso, formatação inline dentro de um parágrafo traduzido (negrito, itálico,
+links) é convertida em texto plano ao aplicar a revisão. A estrutura de blocos
+do EPUB (capítulos, parágrafos, imagens, sumário) é preservada.
+
 Gerar um preview traduzido:
 
 ```bash

--- a/docs/relatorio-tecnico.md
+++ b/docs/relatorio-tecnico.md
@@ -81,6 +81,7 @@ ayvu/
 │       ├── library.py
 │       ├── preflight.py
 │       ├── review_export.py
+│       ├── review_import.py
 │       ├── resume.py
 │       ├── translator.py
 │       └── validation.py
@@ -97,6 +98,7 @@ ayvu/
 │   ├── test_library.py
 │   ├── test_preflight.py
 │   ├── test_review_export.py
+│   ├── test_review_import.py
 │   ├── test_resume.py
 │   ├── test_translator.py
 │   └── test_validation.py
@@ -192,6 +194,13 @@ uv run ayvu translate livro.epub \
   --review-output livro-review.csv
 ```
 
+Importar o CSV revisado e reconstruir o EPUB sem alterar o original:
+
+```bash
+uv run ayvu apply-review livro.epub livro-review.csv \
+  --output livro-revisado.epub
+```
+
 Gerar preview traduzido:
 
 ```bash
@@ -237,7 +246,9 @@ uv run ayvu --mode common translate livro.epub
 
 `src/ayvu/html_translate.py` traduz HTML/XHTML por bloco (parágrafos, títulos e itens de lista), substituindo tags inline por placeholders neutros e restaurando-as depois, preservando tags e atributos e ignorando conteúdo que não deve ser traduzido.
 
-`src/ayvu/review_export.py` escreve o CSV opcional de revisão externa com segmentos originais/traduzidos, IDs e metadados de rastreio.
+`src/ayvu/review_export.py` escreve o CSV opcional de revisão externa com segmentos originais/traduzidos, IDs e metadados de rastreio, e centraliza o contrato de `segment_id` (`format_segment_id`/`parse_segment_id`).
+
+`src/ayvu/review_import.py` lê o CSV de revisão, valida o cabeçalho, expõe as linhas e detecta `segment_id` duplicados. O comando `apply-review` usa `epub_io.apply_reviewed_epub` para reconstruir um novo EPUB a partir do original, casando cada segmento por documento e índice, validando o texto original e relatando ausentes, inconsistentes, duplicados e documentos desconhecidos.
 
 `src/ayvu/library.py` varre as pastas de biblioteca configuradas, agrupa EPUB original e traduções por livro e resolve o comando usado para abrir EPUBs no app leitor.
 
@@ -469,6 +480,8 @@ Ao final da tradução, o Ayvu mostra um relatório no terminal com:
 A validação roda antes do relatório final, então os avisos aparecem na tabela do terminal e, no modo comum, também no relatório Markdown. Qualquer aviso faz a execução terminar com código 1.
 
 Quando `--review-output` é informado, a CLI coleta os segmentos emitidos pelo fluxo normal de tradução e grava um CSV lado a lado. Cada linha inclui `segment_id`, caminho interno do documento no EPUB, índice de capítulo, idiomas, indicação de cache, texto original e texto traduzido. O CSV não é gerado em `--dry-run` e não sobrescreve arquivo existente sem `--overwrite`.
+
+O comando `apply-review` fecha o ciclo: percorre o EPUB original com a mesma lógica de runs da tradução, casa cada segmento ao CSV por `document_path` e índice por documento, valida que o texto original ainda corresponde e aplica as traduções revisadas em um novo EPUB, preservando o original. Segmentos sem revisão ficam no idioma de origem; ausentes, inconsistentes, duplicados e documentos desconhecidos entram no relatório. Como o CSV guarda só o texto visível, formatação inline dentro de um parágrafo revisado vira texto plano, mantendo a estrutura de blocos do EPUB.
 
 No modo comum, o Ayvu também oferece salvar esse relatório em Markdown em `~/Documentos/Livros/Relatorios`, sem sobrescrever relatórios anteriores. O relatório Markdown repete o resumo de glossário e inclui seções com termos aplicados e avisos quando existirem.
 

--- a/docs/tutorial-modo-comum-e-dev.md
+++ b/docs/tutorial-modo-comum-e-dev.md
@@ -343,6 +343,25 @@ original/traduzido lado a lado. O arquivo só é criado quando a opção é usad
 o caminho já existir, passe `--overwrite` ou escolha outro arquivo. `--dry-run`
 não gera CSV de revisão porque não produz tradução revisável.
 
+### Importar revisão e reconstruir o EPUB
+
+```bash
+uv run ayvu apply-review livro.epub livro-review.csv \
+  --output livro-revisado.epub
+```
+
+Depois de editar a coluna `translated` do CSV, `apply-review` lê o EPUB original
+e o CSV revisado, confere que cada segmento ainda corresponde ao livro (comparando
+o texto original) e aplica as traduções revisadas em um novo EPUB, sem tocar no
+original. Sem `--output`, o padrão é `<nome>-<idioma>-reviewed.epub`; use
+`--overwrite` para substituir. O relatório informa segmentos aplicados e lista
+trechos sem revisão, ausentes no EPUB, inconsistentes, com `segment_id`
+duplicado ou documentos desconhecidos.
+
+Como o CSV guarda só o texto visível, formatação inline dentro de um parágrafo
+revisado (negrito, itálico, links) vira texto plano ao aplicar; a estrutura de
+blocos do EPUB é preservada.
+
 ### Sobrescrever saída existente
 
 ```bash

--- a/src/ayvu/cli.py
+++ b/src/ayvu/cli.py
@@ -28,7 +28,15 @@ from .domain import (
     default_preview_books_dir,
     default_translated_books_dir,
 )
-from .epub_io import TranslationReport, detect_epub_language, extract_markdown, inspect_epub, translate_epub
+from .epub_io import (
+    ReviewApplyReport,
+    TranslationReport,
+    apply_reviewed_epub,
+    detect_epub_language,
+    extract_markdown,
+    inspect_epub,
+    translate_epub,
+)
 from .glossary import (
     GLOSSARY_RULE_PRESERVE,
     GLOSSARY_RULE_TRANSLATE,
@@ -49,6 +57,7 @@ from .resume import (
     default_processing_dir,
 )
 from .review_export import ReviewSegment, write_review_csv
+from .review_import import ReviewImportError, read_review_csv
 from .translator import LibreTranslateTranslator, TranslationRoute, TranslatorError, TranslatorLanguage
 from .validation import validate_output_epub
 
@@ -667,6 +676,124 @@ def extract(
         _print_epub_read_error(str(exc), mode)
         raise typer.Exit(code=1) from exc
     console.print(f"[green]Extracted {len(written)} Markdown files to[/green] {output}")
+
+
+@app.command("apply-review")
+def apply_review(
+    ctx: typer.Context,
+    epub_path: Path = typer.Argument(
+        ...,
+        exists=True,
+        dir_okay=False,
+        readable=True,
+        help="Original EPUB to rebuild from.",
+    ),
+    review_csv: Path = typer.Argument(
+        ...,
+        exists=True,
+        dir_okay=False,
+        readable=True,
+        help="Reviewed CSV exported by Ayvu.",
+    ),
+    output: Optional[Path] = typer.Option(
+        None,
+        "--output",
+        "-o",
+        help="Output EPUB path. Defaults to <input-stem>-<target>-reviewed.epub.",
+    ),
+    overwrite: bool = typer.Option(False, "--overwrite", help="Allow replacing an existing output file."),
+) -> None:
+    """Rebuild a translated EPUB from a reviewed CSV, preserving the original file."""
+    mode = ctx.obj.get("mode", UserMode.DEVELOPER)
+    try:
+        review = read_review_csv(review_csv)
+    except ReviewImportError as exc:
+        _print_expected_error(
+            "Não foi possível ler o arquivo de revisão.",
+            "Confirme que é um CSV de revisão gerado pelo Ayvu e tente novamente.",
+            mode,
+            detail=str(exc),
+        )
+        raise typer.Exit(code=1) from exc
+
+    if not review.rows:
+        _print_expected_error(
+            "O arquivo de revisão não tem segmentos.",
+            "Gere o CSV com `ayvu translate --review-output` e revise antes de importar.",
+            mode,
+        )
+        raise typer.Exit(code=1)
+
+    output_path = _resolve_apply_review_output(epub_path, output, review.target_language)
+    if output_path.exists() and not overwrite:
+        _print_expected_error(
+            "Arquivo de saída já existe.",
+            "Use --overwrite para substituí-lo ou escolha outro caminho em --output.",
+            mode,
+            detail=f"Output: {output_path}",
+        )
+        raise typer.Exit(code=1)
+
+    try:
+        report = apply_reviewed_epub(epub_path, output_path, review)
+    except Exception as exc:
+        _print_epub_read_error(str(exc), mode)
+        raise typer.Exit(code=1) from exc
+
+    validation = _validate_with_progress(output_path)
+    _print_apply_review_report(report, validation.warnings)
+
+
+def _resolve_apply_review_output(epub_path: Path, output: Path | None, target_language: str) -> Path:
+    if output is not None:
+        return output.expanduser()
+    suffix = f"-{target_language}" if target_language else ""
+    return epub_path.with_name(f"{epub_path.stem}{suffix}-reviewed.epub")
+
+
+def _print_apply_review_report(report: ReviewApplyReport, validation_warnings: list[str]) -> None:
+    table = Table(title="Importação de revisão", show_header=False)
+    table.add_column("Campo", style="bold")
+    table.add_column("Valor")
+    table.add_row("Input", str(report.input_path) if report.input_path else "-")
+    table.add_row("Output", str(report.output_path) if report.output_path else "-")
+    table.add_row("Languages", f"{report.source_language or '-'} → {report.target_language or '-'}")
+    table.add_row("Segments applied", str(report.applied))
+    table.add_row("Without review", str(report.untranslated))
+    table.add_row("Missing in EPUB", str(len(report.missing_in_epub)))
+    table.add_row("Inconsistent", str(len(report.inconsistent)))
+    table.add_row("Duplicated ids", str(len(report.duplicated)))
+    table.add_row("Unknown documents", str(len(report.unknown_documents)))
+    table.add_row("Invalid ids", str(len(report.invalid_ids)))
+    console.print(table)
+
+    _print_apply_review_warnings(report)
+    if validation_warnings:
+        _print_validation_warnings(validation_warnings)
+    console.print(f"[green]Reviewed EPUB saved to:[/green] {report.output_path}")
+
+
+def _print_apply_review_warnings(report: ReviewApplyReport) -> None:
+    sections = (
+        ("Segments missing in the EPUB", report.missing_in_epub),
+        ("Inconsistent segments (original changed)", report.inconsistent),
+        ("Duplicated segment ids", report.duplicated),
+        ("Unknown documents", report.unknown_documents),
+        ("Invalid segment ids", report.invalid_ids),
+    )
+    for title, items in sections:
+        if not items:
+            continue
+        console.print(f"[yellow]{title}:[/yellow]")
+        for item in items[:10]:
+            console.print(f"  - {item}")
+        if len(items) > 10:
+            console.print(f"  - ... (+{len(items) - 10})")
+    if report.untranslated:
+        console.print(
+            f"[yellow]{report.untranslated} segment(s) had no reviewed translation "
+            "and stayed in the source language.[/yellow]"
+        )
 
 
 def _validate_with_progress(output_path: Path) -> ValidationResult:

--- a/src/ayvu/epub_io.py
+++ b/src/ayvu/epub_io.py
@@ -17,11 +17,20 @@ from .html_translate import (
     HtmlTranslatedSegment,
     HtmlTranslationStats,
     TextTranslationResult,
+    apply_reviewed_html,
     extract_visible_text,
     translate_html,
     translate_text,
 )
-from .review_export import ReviewSegment
+from .review_export import (
+    METADATA_CHAPTER_NAME,
+    METADATA_SEGMENT_ID,
+    METADATA_SEGMENT_KIND,
+    ReviewSegment,
+    format_segment_id,
+    parse_segment_id,
+)
+from .review_import import ReviewImportData, ReviewRow
 from .translator import Translator
 
 
@@ -301,6 +310,171 @@ def extract_markdown(input_path: str | Path, output_dir: str | Path) -> list[Pat
     return written
 
 
+@dataclass
+class ReviewApplyReport:
+    input_path: Path | None = None
+    output_path: Path | None = None
+    source_language: str = ""
+    target_language: str = ""
+    applied: int = 0
+    untranslated: int = 0
+    inconsistent: list[str] = field(default_factory=list)
+    missing_in_epub: list[str] = field(default_factory=list)
+    duplicated: list[str] = field(default_factory=list)
+    unknown_documents: list[str] = field(default_factory=list)
+    invalid_ids: list[str] = field(default_factory=list)
+
+    @property
+    def has_warnings(self) -> bool:
+        return bool(
+            self.untranslated
+            or self.inconsistent
+            or self.missing_in_epub
+            or self.duplicated
+            or self.unknown_documents
+            or self.invalid_ids
+        )
+
+
+def apply_reviewed_epub(
+    input_path: str | Path,
+    output_path: str | Path,
+    review: ReviewImportData,
+) -> ReviewApplyReport:
+    """Rebuild a translated EPUB from a reviewed CSV without touching the input.
+
+    Walks the original EPUB with the same run logic as translation so segment
+    indices line up with the review export, validates each segment's original
+    text against the CSV, and applies the reviewed translations. Missing,
+    duplicated, inconsistent and unknown segments are reported instead of
+    aborting; segments without a reviewed translation stay in the source
+    language.
+    """
+    source_path = Path(input_path)
+    destination_path = Path(output_path)
+    report = ReviewApplyReport(
+        input_path=source_path,
+        output_path=destination_path,
+        source_language=review.source_language,
+        target_language=review.target_language,
+        duplicated=list(review.duplicate_ids),
+    )
+
+    opf_archive_path = _get_opf_archive_path(source_path)
+    metadata_rows, document_groups = _group_review_rows(review.rows, report)
+    replacements = EpubReplacements()
+
+    with ZipFile(source_path, "r") as source_epub:
+        archive_names = set(source_epub.namelist())
+
+        if metadata_rows:
+            _apply_metadata_review(
+                metadata_rows[0],
+                source_epub=source_epub,
+                opf_archive_path=opf_archive_path,
+                archive_names=archive_names,
+                replacements=replacements,
+                report=report,
+            )
+
+        for document_path, rows_by_index in document_groups.items():
+            if document_path not in archive_names:
+                report.unknown_documents.append(document_path)
+                continue
+            replacements.add(
+                document_path,
+                _apply_document_review(
+                    source_epub.read(document_path),
+                    rows_by_index=rows_by_index,
+                    report=report,
+                ),
+            )
+
+    destination_path.parent.mkdir(parents=True, exist_ok=True)
+    _copy_epub_with_replacements(source_path, destination_path, replacements)
+    return report
+
+
+def _group_review_rows(
+    rows: tuple[ReviewRow, ...],
+    report: ReviewApplyReport,
+) -> tuple[list[ReviewRow], dict[str, dict[int, ReviewRow]]]:
+    metadata_rows: list[ReviewRow] = []
+    groups: dict[str, dict[int, ReviewRow]] = {}
+    for row in rows:
+        location = parse_segment_id(row.segment_id) if row.segment_id else None
+        if location is None:
+            report.invalid_ids.append(row.segment_id or "(empty)")
+            continue
+        if location.is_metadata:
+            metadata_rows.append(row)
+            continue
+        if not row.document_path or location.segment_index is None:
+            report.invalid_ids.append(row.segment_id)
+            continue
+        groups.setdefault(row.document_path, {})[location.segment_index] = row
+    return metadata_rows, groups
+
+
+def _apply_document_review(
+    content: bytes,
+    rows_by_index: dict[int, ReviewRow],
+    report: ReviewApplyReport,
+) -> bytes:
+    consumed: set[int] = set()
+
+    def resolve(index: int, _kind: str, original: str) -> str | None:
+        row = rows_by_index.get(index)
+        if row is None:
+            report.untranslated += 1
+            return None
+        consumed.add(index)
+        if row.original.strip() != original.strip():
+            report.inconsistent.append(row.segment_id)
+            return None
+        report.applied += 1
+        return row.translated
+
+    new_content, _stats = apply_reviewed_html(content, resolve)
+
+    for index, row in rows_by_index.items():
+        if index not in consumed:
+            report.missing_in_epub.append(row.segment_id)
+
+    return new_content
+
+
+def _apply_metadata_review(
+    row: ReviewRow,
+    source_epub: ZipFile,
+    opf_archive_path: str | None,
+    archive_names: set[str],
+    replacements: EpubReplacements,
+    report: ReviewApplyReport,
+) -> None:
+    if opf_archive_path is None or opf_archive_path not in archive_names:
+        report.missing_in_epub.append(row.segment_id)
+        return
+
+    opf_content = source_epub.read(opf_archive_path)
+    root = ET.fromstring(opf_content)
+    title = _first_metadata_title(root)
+    if title is None or title.text is None or not title.text.strip():
+        report.missing_in_epub.append(row.segment_id)
+        return
+
+    if row.original.strip() != title.text.strip():
+        report.inconsistent.append(row.segment_id)
+        return
+
+    title.text = row.translated
+    report.applied += 1
+    replacements.add(
+        opf_archive_path,
+        ET.tostring(root, encoding="utf-8", xml_declaration=_has_xml_declaration(opf_content)),
+    )
+
+
 def _clean_extracted_text(text: str) -> str:
     lines = [line.strip() for line in text.splitlines()]
     clean_lines = [line for line in lines if line]
@@ -423,14 +597,14 @@ def _metadata_review_callback(
     def append_metadata_segment(original: str, result: TextTranslationResult) -> None:
         review_segments.append(
             ReviewSegment(
-                segment_id="metadata-title",
+                segment_id=METADATA_SEGMENT_ID,
                 source_epub=str(source_path),
                 output_epub=str(destination_path),
                 chapter_index=0,
-                chapter_name="metadata",
+                chapter_name=METADATA_CHAPTER_NAME,
                 document_name=opf_archive_path,
                 document_path=opf_archive_path,
-                segment_kind="metadata_title",
+                segment_kind=METADATA_SEGMENT_KIND,
                 source_language=options.source,
                 target_language=options.target,
                 original=original,
@@ -452,7 +626,7 @@ def _review_segment_for_document(
     options: TranslationOptions,
 ) -> ReviewSegment:
     return ReviewSegment(
-        segment_id=_review_segment_id(chapter_index, segment_index),
+        segment_id=format_segment_id(chapter_index, segment_index),
         source_epub=str(source_path),
         output_epub=str(destination_path),
         chapter_index=chapter_index,
@@ -466,10 +640,6 @@ def _review_segment_for_document(
         translated=segment.translated,
         from_cache=segment.from_cache,
     )
-
-
-def _review_segment_id(chapter_index: int, segment_index: int) -> str:
-    return f"c{chapter_index:04d}-s{segment_index:04d}"
 
 
 def _translate_opf_title(

--- a/src/ayvu/html_translate.py
+++ b/src/ayvu/html_translate.py
@@ -123,6 +123,18 @@ class HtmlTranslatedSegment:
 
 SegmentReviewCallback = Callable[[HtmlTranslatedSegment], None]
 
+# Resolves a reviewed translation for one segment. Receives the per-document
+# segment index (1-based, in emission order), the segment kind ("text"/"alt")
+# and the visible original text re-derived from the source EPUB. Returns the
+# replacement text to apply, or ``None`` to leave the segment untouched.
+ApplyResolver = Callable[[int, str, str], "str | None"]
+
+
+@dataclass
+class ApplyHtmlStats:
+    applied: int = 0
+    skipped: int = 0
+
 
 def extract_visible_text(html: str | bytes) -> list[str]:
     soup = BeautifulSoup(html, "lxml-xml")
@@ -242,6 +254,49 @@ def translate_text(
     cache.set(cache_key, translated)
     application = apply_glossary_with_usage(translated, glossary)
     return TextTranslationResult(text=parts.restore(application.text), glossary_usage=application.usage)
+
+
+def apply_reviewed_html(
+    html: str | bytes,
+    resolve: ApplyResolver,
+) -> tuple[bytes, ApplyHtmlStats]:
+    """Apply reviewed translations to an HTML/XHTML document.
+
+    Walks the same translation runs as :func:`translate_html` so per-document
+    segment indices line up with the review export. The translator is never
+    called: each translatable run (and image ``alt`` text) is offered to
+    ``resolve``; when it returns a string the run's visible text is replaced by
+    that plain text. Inline tags inside a replaced run are not restored because
+    the review file stores plain visible text only.
+    """
+    soup = BeautifulSoup(html, "lxml-xml")
+    stats = ApplyHtmlStats()
+    index = 0
+
+    for run in _collect_translation_runs(soup):
+        template, tag_markup = _build_block_template(run)
+        if not _has_translatable_text(template):
+            stats.skipped += 1
+            continue
+        index += 1
+        original = _review_text_from_template(template, tag_markup)
+        replacement = resolve(index, "text", original)
+        if replacement is not None:
+            _replace_run(run, _parse_fragment_nodes(escape(replacement)))
+            stats.applied += 1
+
+    for image in _image_elements(soup):
+        alt = image.get("alt")
+        if not isinstance(alt, str) or not alt.strip():
+            continue
+        index += 1
+        original = _review_text_from_template(alt, [])
+        replacement = resolve(index, "alt", original)
+        if replacement is not None:
+            image["alt"] = replacement
+            stats.applied += 1
+
+    return soup.encode(formatter="minimal"), stats
 
 
 def _translate_image_alt_text(

--- a/src/ayvu/review_export.py
+++ b/src/ayvu/review_export.py
@@ -1,9 +1,41 @@
 from __future__ import annotations
 
 import csv
+import re
 from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
+
+
+METADATA_SEGMENT_ID = "metadata-title"
+METADATA_SEGMENT_KIND = "metadata_title"
+METADATA_CHAPTER_NAME = "metadata"
+_SEGMENT_ID_PATTERN = re.compile(r"^c(\d+)-s(\d+)$")
+
+
+@dataclass(frozen=True)
+class SegmentLocation:
+    is_metadata: bool
+    chapter_index: int | None = None
+    segment_index: int | None = None
+
+
+def format_segment_id(chapter_index: int, segment_index: int) -> str:
+    return f"c{chapter_index:04d}-s{segment_index:04d}"
+
+
+def parse_segment_id(segment_id: str) -> SegmentLocation | None:
+    value = segment_id.strip()
+    if value == METADATA_SEGMENT_ID:
+        return SegmentLocation(is_metadata=True)
+    match = _SEGMENT_ID_PATTERN.match(value)
+    if match is None:
+        return None
+    return SegmentLocation(
+        is_metadata=False,
+        chapter_index=int(match.group(1)),
+        segment_index=int(match.group(2)),
+    )
 
 
 REVIEW_CSV_COLUMNS = (

--- a/src/ayvu/review_import.py
+++ b/src/ayvu/review_import.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import csv
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+
+
+class ReviewImportError(Exception):
+    """Raised when a review CSV cannot be read or is malformed."""
+
+
+# Columns the import needs to locate and apply a reviewed segment. Other export
+# columns (chapter index/name, languages, from_cache) are optional here so that
+# hand-edited review files stay usable as long as these are present.
+REQUIRED_REVIEW_COLUMNS = ("segment_id", "document_path", "original", "translated")
+
+
+@dataclass(frozen=True)
+class ReviewRow:
+    segment_id: str
+    document_path: str
+    original: str
+    translated: str
+    segment_kind: str = ""
+    source_language: str = ""
+    target_language: str = ""
+
+
+@dataclass(frozen=True)
+class ReviewImportData:
+    rows: tuple[ReviewRow, ...]
+    duplicate_ids: tuple[str, ...]
+
+    @property
+    def source_language(self) -> str:
+        return next((row.source_language for row in self.rows if row.source_language), "")
+
+    @property
+    def target_language(self) -> str:
+        return next((row.target_language for row in self.rows if row.target_language), "")
+
+
+def read_review_csv(path: str | Path) -> ReviewImportData:
+    source = Path(path)
+    try:
+        with source.open(encoding="utf-8", newline="") as input_file:
+            reader = csv.DictReader(input_file)
+            _check_columns(reader.fieldnames)
+            rows = tuple(_row_from_record(record) for record in reader)
+    except FileNotFoundError as exc:
+        raise ReviewImportError(f"Review file not found: {source}") from exc
+    except UnicodeDecodeError as exc:
+        raise ReviewImportError(f"Review file is not valid UTF-8: {source}") from exc
+    except OSError as exc:
+        raise ReviewImportError(f"Could not read review file: {source}") from exc
+
+    return ReviewImportData(rows=rows, duplicate_ids=_duplicate_ids(rows))
+
+
+def _check_columns(fieldnames: list[str] | None) -> None:
+    if not fieldnames:
+        raise ReviewImportError("Review file has no header row.")
+    missing = [column for column in REQUIRED_REVIEW_COLUMNS if column not in fieldnames]
+    if missing:
+        raise ReviewImportError("Review file is missing required columns: " + ", ".join(missing))
+
+
+def _row_from_record(record: dict[str, str]) -> ReviewRow:
+    return ReviewRow(
+        segment_id=(record.get("segment_id") or "").strip(),
+        document_path=(record.get("document_path") or "").strip(),
+        original=record.get("original") or "",
+        translated=record.get("translated") or "",
+        segment_kind=(record.get("segment_kind") or "").strip(),
+        source_language=(record.get("source_language") or "").strip(),
+        target_language=(record.get("target_language") or "").strip(),
+    )
+
+
+def _duplicate_ids(rows: tuple[ReviewRow, ...]) -> tuple[str, ...]:
+    counts = Counter(row.segment_id for row in rows if row.segment_id)
+    return tuple(sorted(segment_id for segment_id, count in counts.items() if count > 1))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,12 +15,12 @@ from ayvu.cli import (
     app,
 )
 from ayvu.domain import LanguagePair, OutputPlan, TranslationOptions, UserMode
-from ayvu.epub_io import TranslationReport
+from ayvu.epub_io import ReviewApplyReport, TranslationReport
 from ayvu.glossary import GlossaryUsage
 from ayvu.library import LibraryOpenError
 from ayvu.preflight import PreflightError
 from ayvu.resume import COMPLETED_STATUS, ResumeStateStore, TranslationResumeState
-from ayvu.review_export import ReviewSegment
+from ayvu.review_export import ReviewSegment, write_review_csv
 from ayvu.translator import TranslatorError, TranslatorLanguage
 from ayvu.validation import ValidationResult
 
@@ -2096,3 +2096,101 @@ def test_translate_common_mode_warns_about_intermediate_route(
     assert "A tradução passará por 2 etapas" in result.output
     assert "fr -> en -> pt" in result.output
     assert "qualidade pode ficar comprometida" in result.output
+
+
+def _write_review_csv_file(path: Path, target: str = "pt") -> Path:
+    segment = ReviewSegment(
+        segment_id="c0001-s0001",
+        source_epub="book.epub",
+        output_epub="book-pt.epub",
+        chapter_index=1,
+        chapter_name="text/chapter.xhtml",
+        document_name="text/chapter.xhtml",
+        document_path="OEBPS/text/chapter.xhtml",
+        segment_kind="text",
+        source_language="en",
+        target_language=target,
+        original="Hello reader.",
+        translated="Ola leitor.",
+    )
+    return write_review_csv(path, [segment])
+
+
+def test_apply_review_command_reports_and_saves_epub(tmp_path, monkeypatch):
+    epub_path = tmp_path / "book.epub"
+    epub_path.write_bytes(b"fake epub")
+    review_path = _write_review_csv_file(tmp_path / "review.csv")
+
+    captured: dict[str, object] = {}
+
+    def fake_apply(input_path: Path, output_path: Path, review: object) -> ReviewApplyReport:
+        captured["output"] = output_path
+        return ReviewApplyReport(
+            input_path=input_path,
+            output_path=output_path,
+            source_language="en",
+            target_language="pt",
+            applied=2,
+            untranslated=1,
+            inconsistent=["c0001-s0005"],
+            missing_in_epub=["c0002-s0009"],
+            duplicated=["c0001-s0003"],
+            unknown_documents=["OEBPS/ghost.xhtml"],
+        )
+
+    monkeypatch.setattr("ayvu.cli.apply_reviewed_epub", fake_apply)
+    monkeypatch.setattr(
+        "ayvu.cli.validate_output_epub",
+        lambda _path, on_progress=None: ValidationResult(ok=True, document_count=1),
+    )
+
+    result = runner.invoke(app, ["apply-review", str(epub_path), str(review_path)])
+
+    assert result.exit_code == 0
+    assert "Segments applied" in result.output
+    assert "Inconsistent segments (original changed):" in result.output
+    assert "c0001-s0005" in result.output
+    assert "had no reviewed translation" in result.output
+    assert "Reviewed EPUB saved to:" in result.output
+    # Default output is derived from the input stem and the CSV target language.
+    assert captured["output"] == tmp_path / "book-pt-reviewed.epub"
+    assert "Traceback" not in result.output
+
+
+def test_apply_review_command_rejects_existing_output_without_overwrite(tmp_path, monkeypatch):
+    epub_path = tmp_path / "book.epub"
+    epub_path.write_bytes(b"fake epub")
+    review_path = _write_review_csv_file(tmp_path / "review.csv")
+    output_path = tmp_path / "book-pt-reviewed.epub"
+    output_path.write_bytes(b"already here")
+
+    def fail_apply(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("apply should not run when output already exists")
+
+    monkeypatch.setattr("ayvu.cli.apply_reviewed_epub", fail_apply)
+
+    result = runner.invoke(app, ["apply-review", str(epub_path), str(review_path)])
+
+    assert result.exit_code == 1
+    assert "Arquivo de saída já existe." in result.output
+    assert "Use --overwrite" in result.output
+    assert output_path.read_bytes() == b"already here"
+    assert "Traceback" not in result.output
+
+
+def test_apply_review_command_reports_unreadable_review_file(tmp_path, monkeypatch):
+    epub_path = tmp_path / "book.epub"
+    epub_path.write_bytes(b"fake epub")
+    broken_csv = tmp_path / "broken.csv"
+    broken_csv.write_text("segment_id,translated\nc0001-s0001,x\n", encoding="utf-8")
+
+    def fail_apply(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("apply should not run when CSV is malformed")
+
+    monkeypatch.setattr("ayvu.cli.apply_reviewed_epub", fail_apply)
+
+    result = runner.invoke(app, ["apply-review", str(epub_path), str(broken_csv)])
+
+    assert result.exit_code == 1
+    assert "Não foi possível ler o arquivo de revisão." in result.output
+    assert "Traceback" not in result.output

--- a/tests/test_epub_io.py
+++ b/tests/test_epub_io.py
@@ -1,3 +1,4 @@
+import csv
 from pathlib import Path, PurePosixPath
 from zipfile import ZipFile
 
@@ -15,6 +16,7 @@ from ayvu.epub_io import (
     _get_opf_archive_path,
     _navigation_document_entries,
     _opf_base_path,
+    apply_reviewed_epub,
     detect_epub_language,
     extract_markdown,
     inspect_epub,
@@ -22,6 +24,8 @@ from ayvu.epub_io import (
     translate_epub,
 )
 from ayvu.glossary import GLOSSARY_RULE_FORBIDDEN, GLOSSARY_RULE_PRESERVE, Glossary, GlossaryEntry
+from ayvu.review_export import REVIEW_CSV_COLUMNS, write_review_csv
+from ayvu.review_import import ReviewImportData, ReviewRow, read_review_csv
 
 
 class FakeBook:
@@ -440,3 +444,117 @@ def test_translate_epub_reports_glossary_usage(minimal_epub_path: Path, tmp_path
     assert report.glossary_usage.required_terms_present["PT:Hello reader"] == 1
     assert report.glossary_usage.required_terms_missing == ["Missing Term"]
     assert report.glossary_usage.forbidden_terms_found["PT:Chapter Two"] >= 1
+
+
+def _export_review_csv(minimal_epub_path: Path, tmp_path: Path) -> Path:
+    output_path = tmp_path / "minimal-pt.epub"
+    review_segments = []
+    options = TranslationOptions(language_pair=LanguagePair(source="en", target="pt"))
+    with TranslationCache(tmp_path / "cache.sqlite") as cache:
+        translate_epub(
+            minimal_epub_path,
+            output_path,
+            translator=PrefixTranslator(),
+            cache=cache,
+            options=options,
+            review_segments=review_segments,
+        )
+    return write_review_csv(tmp_path / "review.csv", review_segments)
+
+
+def _rewrite_csv(csv_path: Path, mutate) -> None:
+    with csv_path.open(encoding="utf-8", newline="") as input_file:
+        rows = list(csv.DictReader(input_file))
+    for row in rows:
+        mutate(row)
+    with csv_path.open("w", encoding="utf-8", newline="") as output_file:
+        writer = csv.DictWriter(output_file, fieldnames=list(REVIEW_CSV_COLUMNS))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def test_apply_reviewed_epub_applies_reviewed_translation(minimal_epub_path: Path, tmp_path: Path):
+    csv_path = _export_review_csv(minimal_epub_path, tmp_path)
+
+    def review_paragraph(row: dict) -> None:
+        if "Hello reader" in row["original"]:
+            row["translated"] = "REVISADO leitor."
+
+    _rewrite_csv(csv_path, review_paragraph)
+
+    output_path = tmp_path / "minimal-reviewed.epub"
+    report = apply_reviewed_epub(minimal_epub_path, output_path, read_review_csv(csv_path))
+
+    chapter = _read_chapter_one(output_path)
+    assert "REVISADO leitor." in chapter
+    assert report.applied >= 1
+    assert report.inconsistent == []
+    assert report.missing_in_epub == []
+    # Original EPUB is never modified (its English text is split by an inline link).
+    original_chapter = _read_chapter_one(minimal_epub_path)
+    assert "Hello reader. Visit" in original_chapter
+    assert "chapter two</a>" in original_chapter
+
+
+def test_apply_reviewed_epub_reports_inconsistent_when_original_changed(
+    minimal_epub_path: Path,
+    tmp_path: Path,
+):
+    csv_path = _export_review_csv(minimal_epub_path, tmp_path)
+
+    def tamper_paragraph(row: dict) -> None:
+        if "Hello reader" in row["original"]:
+            row["original"] = "Different source text."
+            row["translated"] = "Nao deve ser aplicado."
+
+    _rewrite_csv(csv_path, tamper_paragraph)
+
+    output_path = tmp_path / "minimal-reviewed.epub"
+    report = apply_reviewed_epub(minimal_epub_path, output_path, read_review_csv(csv_path))
+
+    assert "c0001-s0003" in report.inconsistent
+    assert "Nao deve ser aplicado." not in _read_chapter_one(output_path)
+
+
+def test_apply_reviewed_epub_reports_unknown_document(minimal_epub_path: Path, tmp_path: Path):
+    review = ReviewImportData(
+        rows=(
+            ReviewRow(
+                segment_id="c0001-s0001",
+                document_path="OEBPS/text/ghost.xhtml",
+                original="Whatever",
+                translated="Tanto faz",
+            ),
+        ),
+        duplicate_ids=(),
+    )
+
+    output_path = tmp_path / "minimal-reviewed.epub"
+    report = apply_reviewed_epub(minimal_epub_path, output_path, review)
+
+    assert report.unknown_documents == ["OEBPS/text/ghost.xhtml"]
+    assert report.applied == 0
+    assert output_path.exists()
+
+
+def test_apply_reviewed_epub_reports_missing_segment_index(minimal_epub_path: Path, tmp_path: Path):
+    csv_path = _export_review_csv(minimal_epub_path, tmp_path)
+    data = read_review_csv(csv_path)
+    document_path = next(row.document_path for row in data.rows if row.segment_id == "c0001-s0001")
+
+    review = ReviewImportData(
+        rows=(
+            ReviewRow(
+                segment_id="c0001-s9999",
+                document_path=document_path,
+                original="Out of range",
+                translated="Fora de alcance",
+            ),
+        ),
+        duplicate_ids=(),
+    )
+
+    output_path = tmp_path / "minimal-reviewed.epub"
+    report = apply_reviewed_epub(minimal_epub_path, output_path, review)
+
+    assert "c0001-s9999" in report.missing_in_epub

--- a/tests/test_html_translate.py
+++ b/tests/test_html_translate.py
@@ -7,7 +7,7 @@ from ayvu.glossary import (
     Glossary,
     GlossaryEntry,
 )
-from ayvu.html_translate import extract_visible_text, translate_html, translate_text
+from ayvu.html_translate import apply_reviewed_html, extract_visible_text, translate_html, translate_text
 from ayvu.translator import Translator
 
 
@@ -488,3 +488,61 @@ def test_translate_html_uses_cache_for_image_alt(tmp_path):
     assert translator.calls == []
     assert stats.alt_translated == 1
     assert stats.from_cache == 1
+
+
+def _resolver(reviewed: dict[int, str], seen: list[tuple[int, str, str]] | None = None):
+    def resolve(index: int, kind: str, original: str):
+        if seen is not None:
+            seen.append((index, kind, original))
+        return reviewed.get(index)
+
+    return resolve
+
+
+def test_apply_reviewed_html_replaces_segment_text_by_index():
+    html = "<html><body><p>Hello reader.</p><p>Second one.</p></body></html>"
+    seen: list[tuple[int, str, str]] = []
+
+    output, stats = apply_reviewed_html(html, _resolver({1: "Ola leitor."}, seen))
+
+    result = output.decode("utf-8")
+    assert "Ola leitor." in result
+    assert "Second one." in result  # left untouched (resolver returned None)
+    assert stats.applied == 1
+    assert seen == [(1, "text", "Hello reader."), (2, "text", "Second one.")]
+
+
+def test_apply_reviewed_html_flattens_inline_tags_in_replaced_segment():
+    html = '<html><body><p>Hello <a href="ch.xhtml"><em>reader</em></a>.</p></body></html>'
+
+    output, stats = apply_reviewed_html(html, _resolver({1: "Ola leitor."}))
+
+    result = output.decode("utf-8")
+    assert "Ola leitor." in result
+    assert "<a" not in result
+    assert "<em>" not in result
+    assert stats.applied == 1
+
+
+def test_apply_reviewed_html_escapes_special_characters():
+    html = "<html><body><p>Tom and Jerry</p></body></html>"
+
+    output, _stats = apply_reviewed_html(html, _resolver({1: "Tom & Jerry <3"}))
+
+    result = output.decode("utf-8")
+    assert "Tom &amp; Jerry &lt;3" in result
+
+
+def test_apply_reviewed_html_applies_image_alt_after_text_runs():
+    html = (
+        '<html><body><p>Hello reader.</p>'
+        '<p><img src="cover.png" alt="A red house" /></p></body></html>'
+    )
+    seen: list[tuple[int, str, str]] = []
+
+    output, stats = apply_reviewed_html(html, _resolver({2: "Uma casa vermelha"}, seen))
+
+    result = output.decode("utf-8")
+    assert 'alt="Uma casa vermelha"' in result
+    assert stats.applied == 1
+    assert seen == [(1, "text", "Hello reader."), (2, "alt", "A red house")]

--- a/tests/test_review_import.py
+++ b/tests/test_review_import.py
@@ -1,0 +1,98 @@
+import csv
+from pathlib import Path
+
+import pytest
+
+from ayvu.review_export import REVIEW_CSV_COLUMNS, ReviewSegment, write_review_csv
+from ayvu.review_import import ReviewImportError, read_review_csv
+
+
+def _write_csv(path: Path, rows: list[dict[str, object]], columns=REVIEW_CSV_COLUMNS) -> Path:
+    with path.open("w", encoding="utf-8", newline="") as output_file:
+        writer = csv.DictWriter(output_file, fieldnames=list(columns))
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+    return path
+
+
+def test_read_review_csv_reads_rows_and_languages(tmp_path: Path):
+    segment = ReviewSegment(
+        segment_id="c0001-s0002",
+        source_epub="book.epub",
+        output_epub="book-pt.epub",
+        chapter_index=1,
+        chapter_name="text/chapter1.xhtml",
+        document_name="text/chapter1.xhtml",
+        document_path="OEBPS/text/chapter1.xhtml",
+        segment_kind="text",
+        source_language="en",
+        target_language="pt",
+        original="Hello, reader.",
+        translated="Ola, leitor.",
+    )
+    csv_path = write_review_csv(tmp_path / "review.csv", [segment])
+
+    data = read_review_csv(csv_path)
+
+    assert len(data.rows) == 1
+    row = data.rows[0]
+    assert row.segment_id == "c0001-s0002"
+    assert row.document_path == "OEBPS/text/chapter1.xhtml"
+    assert row.original == "Hello, reader."
+    assert row.translated == "Ola, leitor."
+    assert row.segment_kind == "text"
+    assert data.source_language == "en"
+    assert data.target_language == "pt"
+    assert data.duplicate_ids == ()
+
+
+def test_read_review_csv_detects_duplicate_segment_ids(tmp_path: Path):
+    rows = [
+        {**_base_row(), "segment_id": "c0001-s0001"},
+        {**_base_row(), "segment_id": "c0001-s0001"},
+        {**_base_row(), "segment_id": "c0001-s0002"},
+    ]
+    csv_path = _write_csv(tmp_path / "review.csv", rows)
+
+    data = read_review_csv(csv_path)
+
+    assert data.duplicate_ids == ("c0001-s0001",)
+    assert len(data.rows) == 3
+
+
+def test_read_review_csv_rejects_missing_required_columns(tmp_path: Path):
+    csv_path = tmp_path / "broken.csv"
+    with csv_path.open("w", encoding="utf-8", newline="") as output_file:
+        writer = csv.DictWriter(output_file, fieldnames=["segment_id", "translated"])
+        writer.writeheader()
+        writer.writerow({"segment_id": "c0001-s0001", "translated": "x"})
+
+    with pytest.raises(ReviewImportError) as error:
+        read_review_csv(csv_path)
+
+    assert "document_path" in str(error.value)
+    assert "original" in str(error.value)
+
+
+def test_read_review_csv_rejects_missing_file(tmp_path: Path):
+    with pytest.raises(ReviewImportError):
+        read_review_csv(tmp_path / "missing.csv")
+
+
+def _base_row() -> dict[str, object]:
+    return {
+        "segment_id": "c0001-s0001",
+        "source_epub": "book.epub",
+        "output_epub": "book-pt.epub",
+        "chapter_index": 1,
+        "chapter_name": "text/chapter1.xhtml",
+        "document_name": "text/chapter1.xhtml",
+        "document_path": "OEBPS/text/chapter1.xhtml",
+        "segment_kind": "text",
+        "source_language": "en",
+        "target_language": "pt",
+        "from_cache": "false",
+        "original": "Hello.",
+        "translated": "Ola.",
+    }


### PR DESCRIPTION
## Objective

Close the external review loop by importing human-reviewed translations back
into a final EPUB.

## What changed

- New `apply-review` CLI command: `ayvu apply-review BOOK.epub REVIEW.csv [-o OUT] [--overwrite]`.
- `review_import.py`: read and validate the review CSV, expose its rows and detect duplicate segment ids.
- `html_translate.apply_reviewed_html`: re-apply reviewed plain text over the same translation runs as `translate_html`, without calling the translator.
- `epub_io.apply_reviewed_epub` + `ReviewApplyReport`: rebuild a new EPUB from the original, match each segment by document path and per-document index, validate the original text, and report applied / untranslated / missing / inconsistent / duplicated / unknown-document segments.
- `review_export.py`: centralize the segment-id contract (`format_segment_id`, `parse_segment_id`, metadata constants).
- Docs (README, tutorial, technical report, CHANGELOG), including the inline-formatting limitation.

The import rebuilds from the original EPUB and applies every reviewed segment ("apply and warn"); the original file is never modified.

## Out of scope

- Guided (common-mode) menu entry for the import.
- Preserving inline formatting (bold/italic/links) inside a reviewed segment: the review CSV stores plain visible text only, so inline tags inside a reviewed paragraph are flattened. EPUB block structure is preserved.
- Rewriting `DC:language` metadata (parity with `translate_epub`).

## Validation

- `COLUMNS=200 uv run pytest`: 233 tests passing.
- `git diff --check`: no errors.
- Manual end-to-end: translate a real EPUB with `--review-output`, edit one `translated` cell, run `apply-review`, confirm the reviewed text in the new EPUB and the original left untouched.

## Related issue

Closes #92
