### PR TITLE
Add batch EPUB translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,9 @@ lancadas e secoes versionadas quando uma release for publicada.
   validando que cada segmento ainda corresponde ao EPUB original, aplicando as
   traducoes revisadas sem alterar o original e relatando trechos sem revisao,
   ausentes, inconsistentes, duplicados ou de documentos desconhecidos.
+- Traducao em batch no comando `translate`, aceitando multiplos EPUBs,
+  `--output-dir`, relatorios Markdown por livro e `--continue-on-error` para
+  seguir processando apos falhas.
 
 ### Atualizado
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,28 @@ Traduzir usando um perfil salvo na configuração:
 uv run ayvu translate livro.epub --profile technical
 ```
 
+Traduzir vários EPUBs em uma única execução:
+
+```bash
+uv run ayvu translate livro-1.epub livro-2.epub livro-3.epub \
+  --target pt \
+  --output-dir traduzidos/ \
+  --continue-on-error
+```
+
+No batch, cada livro gera um EPUB separado com o padrão
+`<nome>-<idioma>.epub` dentro de `--output-dir`. Se `--output-dir` não for
+informado, o Ayvu usa a pasta de traduzidos configurada. O comando para no
+primeiro erro por padrão; com `--continue-on-error`, continua nos livros
+restantes e termina com código 1 se algum item falhar. Saídas existentes não
+são sobrescritas sem confirmação no modo comum ou sem `--overwrite` no modo
+desenvolvedor.
+
+As opções `--output` e `--review-output` são exclusivas do fluxo de um único
+EPUB, porque um caminho único de saída ou CSV não é suficiente para representar
+vários livros. O batch salva automaticamente um relatório Markdown separado por
+livro na pasta de relatórios configurada.
+
 Se `--source` não for informado, o Ayvu lê o idioma do EPUB nos metadados, exibe o
 plano da tradução (`From`/`To`) antes de começar e usa o idioma detectado como
 origem. Quando o metadado estiver ausente ou inválido, o Ayvu avisa e usa `en`
@@ -310,7 +332,7 @@ uv run ayvu translate livro.epub \
   --dry-run
 ```
 
-Ao final da tradução, o Ayvu mostra um relatório no terminal com o EPUB original, idiomas, saída calculada, arquivo de revisão quando solicitado, capítulos processados, textos traduzidos, cache, erros e resumo do uso do glossário quando houver glossário configurado. No **Modo Comum**, também pergunta se deve salvar esse relatório em Markdown em `~/Documentos/Livros/Relatorios`.
+Ao final da tradução, o Ayvu mostra um relatório no terminal com o EPUB original, idiomas, saída calculada, arquivo de revisão quando solicitado, capítulos processados, textos traduzidos, cache, erros e resumo do uso do glossário quando houver glossário configurado. No **Modo Comum**, também pergunta se deve salvar esse relatório em Markdown em `~/Documentos/Livros/Relatorios`. Em traduções em batch, o Ayvu salva automaticamente um relatório Markdown separado para cada livro.
 
 Extrair texto visível para Markdown:
 

--- a/docs/relatorio-tecnico.md
+++ b/docs/relatorio-tecnico.md
@@ -483,6 +483,15 @@ Quando `--review-output` é informado, a CLI coleta os segmentos emitidos pelo f
 
 O comando `apply-review` fecha o ciclo: percorre o EPUB original com a mesma lógica de runs da tradução, casa cada segmento ao CSV por `document_path` e índice por documento, valida que o texto original ainda corresponde e aplica as traduções revisadas em um novo EPUB, preservando o original. Segmentos sem revisão ficam no idioma de origem; ausentes, inconsistentes, duplicados e documentos desconhecidos entram no relatório. Como o CSV guarda só o texto visível, formatação inline dentro de um parágrafo revisado vira texto plano, mantendo a estrutura de blocos do EPUB.
 
+Quando vários EPUBs são informados no comando `translate`, a CLI entra em modo
+batch e chama o mesmo fluxo de tradução para cada livro. A saída de cada item é
+calculada em `--output-dir` ou na pasta de traduzidos configurada, usando o
+padrão `<nome>-<idioma>.epub`. `--output` e `--review-output` ficam restritos ao
+fluxo de um único EPUB para evitar caminhos ambíguos. O batch para no primeiro
+erro por padrão; com `--continue-on-error`, registra a falha, processa os itens
+restantes e termina com código 1 se qualquer livro falhar. Cada item salva um
+relatório Markdown próprio na pasta de relatórios configurada.
+
 No modo comum, o Ayvu também oferece salvar esse relatório em Markdown em `~/Documentos/Livros/Relatorios`, sem sobrescrever relatórios anteriores. O relatório Markdown repete o resumo de glossário e inclui seções com termos aplicados e avisos quando existirem.
 
 ## 16. Bug crítico: EPUB com tela branca

--- a/docs/tutorial-modo-comum-e-dev.md
+++ b/docs/tutorial-modo-comum-e-dev.md
@@ -328,6 +328,30 @@ os demais atributos; imagens decorativas (`alt=""`) são ignoradas. O relatório
 mostra a quantidade de textos alternativos traduzidos. Ler o texto que está
 dentro da imagem (OCR) continua fora do escopo.
 
+### Traduzir vários EPUBs em batch
+
+```bash
+uv run ayvu translate livro-1.epub livro-2.epub livro-3.epub \
+  --source en \
+  --target pt \
+  --output-dir traduzidos/ \
+  --continue-on-error
+```
+
+Quando mais de um EPUB é informado, o Ayvu calcula uma saída por livro usando o
+padrão `<nome>-<idioma>.epub` dentro de `--output-dir`. Sem `--output-dir`, usa a
+pasta de traduzidos configurada. O batch não aceita `--output` nem
+`--review-output`, pois essas opções apontam para um único arquivo.
+
+Por padrão, o comando para no primeiro livro que falhar. Com
+`--continue-on-error`, os próximos EPUBs continuam sendo processados, mas a
+execução termina com código 1 se qualquer item falhar. Saídas existentes seguem
+a mesma regra do fluxo individual: use `--overwrite` para substituir no modo
+desenvolvedor, ou confirme a substituição quando estiver no modo comum.
+
+Cada item do batch mostra seu relatório no terminal e salva um relatório
+Markdown separado na pasta de relatórios configurada.
+
 ### Exportar CSV para revisão externa
 
 ```bash

--- a/src/ayvu/cli.py
+++ b/src/ayvu/cli.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import NoReturn, Optional
 
@@ -93,6 +93,22 @@ PROFILE_NO_PROFILE_OPTION = "0"
 EXISTING_OUTPUT_OVERWRITE_OPTION = "1"
 EXISTING_OUTPUT_RENAME_OPTION = "2"
 EXISTING_OUTPUT_CANCEL_OPTION = "0"
+
+
+@dataclass(frozen=True)
+class TranslationRunResult:
+    report: TranslationReport
+    validation_warnings: list[str]
+    markdown_report_path: Path | None = None
+
+
+@dataclass(frozen=True)
+class BatchTranslationResult:
+    epub_path: Path
+    succeeded: bool
+    output_path: Path | None = None
+    report_path: Path | None = None
+    detail: str = ""
 
 
 @app.callback(invoke_without_command=True)
@@ -214,12 +230,25 @@ def languages(
 @app.command()
 def translate(
     ctx: typer.Context,
-    epub_path: Path = typer.Argument(..., exists=True, dir_okay=False, readable=True),
+    epub_paths: list[Path] = typer.Argument(
+        ...,
+        exists=True,
+        dir_okay=False,
+        readable=True,
+        help="One or more input EPUB files.",
+    ),
     output: Optional[Path] = typer.Option(
         None,
         "--output",
         "-o",
         help="Output EPUB path. Defaults to <input-stem>-<target>.epub.",
+    ),
+    output_dir: Optional[Path] = typer.Option(
+        None,
+        "--output-dir",
+        help="Directory for translated EPUBs. Defaults to the translated books folder.",
+        file_okay=False,
+        dir_okay=True,
     ),
     review_output: Optional[Path] = typer.Option(
         None,
@@ -247,6 +276,11 @@ def translate(
     ),
     dry_run: bool = typer.Option(False, "--dry-run", help="Process without writing translated EPUB."),
     fail_fast: bool = typer.Option(False, "--fail-fast", help="Stop at the first chapter/text error."),
+    continue_on_error: bool = typer.Option(
+        False,
+        "--continue-on-error",
+        help="Continue translating remaining EPUBs after a batch item fails.",
+    ),
     overwrite: bool = typer.Option(False, "--overwrite", help="Allow replacing an existing output file."),
     timeout: float = typer.Option(30.0, "--timeout", help="Translator HTTP timeout in seconds."),
     retries: int = typer.Option(2, "--retries", help="Simple HTTP retry count."),
@@ -265,9 +299,45 @@ def translate(
     """Translate EPUB visible text while preserving EPUB structure."""
     mode = ctx.obj.get("mode", UserMode.DEVELOPER)
     config = _load_existing_config_or_default()
-    _run_translation(
-        epub_path=epub_path,
+    epub_list = list(epub_paths)
+    _validate_translate_command_options(
+        epub_paths=epub_list,
         output=output,
+        output_dir=output_dir,
+        review_output=review_output,
+        mode=mode,
+    )
+    resolved_output_dir = _resolve_translation_output_dir(output_dir, mode=mode)
+
+    if len(epub_list) > 1:
+        _run_batch_translation(
+            epub_paths=epub_list,
+            output_dir=resolved_output_dir,
+            source=source,
+            target=target,
+            translator_name=translator_name,
+            url=url,
+            cache_path=cache_path,
+            glossary_path=glossary_path,
+            profile_name=profile_name,
+            dry_run=dry_run,
+            fail_fast=fail_fast,
+            continue_on_error=continue_on_error,
+            overwrite=overwrite,
+            timeout=timeout,
+            retries=retries,
+            chunk_limit=chunk_limit,
+            mode=mode,
+            config=config,
+            translate_metadata=translate_metadata,
+            translate_alt_text=translate_alt_text,
+        )
+        return
+
+    _run_translation(
+        epub_path=epub_list[0],
+        output=output,
+        output_dir=resolved_output_dir,
         review_output=review_output,
         source=source,
         target=target,
@@ -286,6 +356,7 @@ def translate(
         config=config,
         translate_metadata=translate_metadata,
         translate_alt_text=translate_alt_text,
+        confirm_output_location=resolved_output_dir is None,
     )
 
 
@@ -417,6 +488,65 @@ def _resolve_glossary_path(
     return default_glossaries_dir() / profile_glossary
 
 
+def _validate_translate_command_options(
+    epub_paths: list[Path],
+    output: Path | None,
+    output_dir: Path | None,
+    review_output: Path | None,
+    mode: UserMode,
+) -> None:
+    if not epub_paths:
+        _print_expected_error(
+            "Nenhum EPUB informado para tradução.",
+            "Informe pelo menos um arquivo .epub no comando translate.",
+            mode,
+        )
+        raise typer.Exit(code=1)
+
+    if output is not None and output_dir is not None:
+        _print_expected_error(
+            "Opções de saída incompatíveis.",
+            "Use --output para um EPUB específico ou --output-dir para uma pasta de saída, não ambos.",
+            mode,
+        )
+        raise typer.Exit(code=1)
+
+    if len(epub_paths) == 1:
+        return
+
+    if output is not None:
+        _print_expected_error(
+            "Não é possível usar --output com múltiplos EPUBs.",
+            "Use --output-dir para escolher a pasta do batch, ou traduza um EPUB por vez com --output.",
+            mode,
+        )
+        raise typer.Exit(code=1)
+
+    if review_output is not None:
+        _print_expected_error(
+            "Não é possível usar --review-output com múltiplos EPUBs.",
+            "Gere arquivos de revisão traduzindo um EPUB por vez.",
+            mode,
+        )
+        raise typer.Exit(code=1)
+
+
+def _resolve_translation_output_dir(output_dir: Path | None, mode: UserMode) -> Path | None:
+    if output_dir is None:
+        return None
+
+    path = output_dir.expanduser()
+    if path.exists() and not path.is_dir():
+        _print_expected_error(
+            "A pasta de saída informada não é um diretório.",
+            "Escolha um diretório em --output-dir ou remova a opção para usar o padrão.",
+            mode,
+            detail=f"Output directory: {path}",
+        )
+        raise typer.Exit(code=1)
+    return path
+
+
 def _run_translation(
     epub_path: Path,
     output: Path | None,
@@ -438,7 +568,11 @@ def _run_translation(
     config: AyvuConfig | None = None,
     translate_metadata: bool = False,
     translate_alt_text: bool = False,
-) -> None:
+    output_dir: Path | None = None,
+    auto_save_markdown_report: bool = False,
+    report_dir: Path | None = None,
+    confirm_output_location: bool = True,
+) -> TranslationRunResult:
     config = config or _load_existing_config_or_default()
     resolved_profile_name, profile = _resolve_requested_profile(config, profile_name, mode=mode)
     resolved_target = _resolve_target_language(target, profile)
@@ -465,9 +599,10 @@ def _run_translation(
         output,
         language_pair,
         dry_run=dry_run,
-        default_dir=_translated_books_dir(config),
+        default_dir=output_dir or _translated_books_dir(config),
     )
-    output_plan = _confirm_default_output_location(output_plan, epub_path, mode=mode)
+    if confirm_output_location:
+        output_plan = _confirm_default_output_location(output_plan, epub_path, mode=mode)
     output_plan = _resolve_existing_output_conflict(output_plan, overwrite=overwrite, mode=mode)
     output_path = output_plan.path
     review_output_path = _resolve_review_output_path(
@@ -555,7 +690,17 @@ def _run_translation(
     validation_warnings = validation.warnings if validation else []
 
     _print_report(report, dry_run, validation_warnings)
-    _offer_markdown_report(report, dry_run, validation_warnings, mode=mode)
+    markdown_report_path = None
+    if auto_save_markdown_report:
+        markdown_report_path = _save_markdown_report(
+            report,
+            dry_run,
+            validation_warnings,
+            directory=report_dir,
+        )
+        console.print(f"[green]Report saved to:[/green] {markdown_report_path}")
+    else:
+        _offer_markdown_report(report, dry_run, validation_warnings, mode=mode)
 
     if validation is not None:
         if validation.ok:
@@ -566,6 +711,151 @@ def _run_translation(
                 _mark_resume_state_completed(resume_store, resume_state)
         else:
             raise typer.Exit(code=1)
+
+    return TranslationRunResult(
+        report=report,
+        validation_warnings=validation_warnings,
+        markdown_report_path=markdown_report_path,
+    )
+
+
+def _run_batch_translation(
+    epub_paths: list[Path],
+    output_dir: Path | None,
+    source: str | None,
+    target: str | None,
+    translator_name: str,
+    url: str,
+    cache_path: Path,
+    glossary_path: Path | None,
+    profile_name: str | None,
+    dry_run: bool,
+    fail_fast: bool,
+    continue_on_error: bool,
+    overwrite: bool,
+    timeout: float,
+    retries: int,
+    chunk_limit: int,
+    mode: UserMode,
+    config: AyvuConfig,
+    translate_metadata: bool = False,
+    translate_alt_text: bool = False,
+) -> None:
+    resolved_output_dir = output_dir or _translated_books_dir(config)
+    report_dir = _reports_dir(config)
+    _print_batch_plan(
+        epub_paths=epub_paths,
+        output_dir=resolved_output_dir,
+        report_dir=report_dir,
+        continue_on_error=continue_on_error,
+    )
+
+    results: list[BatchTranslationResult] = []
+    total = len(epub_paths)
+    for index, epub_path in enumerate(epub_paths, start=1):
+        console.print(f"[cyan]Batch item {index}/{total}:[/cyan] {epub_path}")
+        try:
+            run_result = _run_translation(
+                epub_path=epub_path,
+                output=None,
+                output_dir=resolved_output_dir,
+                review_output=None,
+                source=source,
+                target=target,
+                translator_name=translator_name,
+                url=url,
+                cache_path=cache_path,
+                glossary_path=glossary_path,
+                profile_name=profile_name,
+                dry_run=dry_run,
+                fail_fast=fail_fast,
+                overwrite=overwrite,
+                timeout=timeout,
+                retries=retries,
+                chunk_limit=chunk_limit,
+                mode=mode,
+                config=config,
+                translate_metadata=translate_metadata,
+                translate_alt_text=translate_alt_text,
+                auto_save_markdown_report=True,
+                report_dir=report_dir,
+                confirm_output_location=False,
+            )
+        except typer.Exit as exc:
+            if isinstance(exc.__cause__, KeyboardInterrupt):
+                raise
+            results.append(
+                BatchTranslationResult(
+                    epub_path=epub_path,
+                    succeeded=False,
+                    detail=f"exit code {exc.exit_code or 1}",
+                )
+            )
+            console.print(f"[red]Batch item failed:[/red] {epub_path}")
+            if continue_on_error:
+                continue
+            _print_batch_summary(results)
+            raise typer.Exit(code=exc.exit_code or 1) from exc
+        except Exception as exc:
+            detail = str(exc) or exc.__class__.__name__
+            _print_expected_error(
+                "Falha inesperada ao traduzir este EPUB.",
+                "Verifique o EPUB, o tradutor local e as opções usadas antes de tentar novamente.",
+                mode,
+                detail=detail,
+            )
+            results.append(BatchTranslationResult(epub_path=epub_path, succeeded=False, detail=detail))
+            if continue_on_error:
+                continue
+            _print_batch_summary(results)
+            raise typer.Exit(code=1) from exc
+
+        results.append(
+            BatchTranslationResult(
+                epub_path=epub_path,
+                succeeded=True,
+                output_path=run_result.report.output_path,
+                report_path=run_result.markdown_report_path,
+            )
+        )
+
+    _print_batch_summary(results)
+    if any(not result.succeeded for result in results):
+        raise typer.Exit(code=1)
+
+
+def _print_batch_plan(
+    epub_paths: list[Path],
+    output_dir: Path,
+    report_dir: Path,
+    continue_on_error: bool,
+) -> None:
+    table = Table(title="Batch translation plan")
+    table.add_column("Field")
+    table.add_column("Value")
+    table.add_row("EPUB files", str(len(epub_paths)))
+    table.add_row("Output folder", str(output_dir))
+    table.add_row("Reports folder", str(report_dir))
+    table.add_row("Continue on error", "yes" if continue_on_error else "no")
+    console.print(table)
+
+
+def _print_batch_summary(results: list[BatchTranslationResult]) -> None:
+    table = Table(title="Batch translation summary")
+    table.add_column("EPUB")
+    table.add_column("Status")
+    table.add_column("Output or detail")
+    table.add_column("Report")
+    for result in results:
+        status = "[green]OK[/green]" if result.succeeded else "[red]Failed[/red]"
+        detail = _display_optional_path(result.output_path) if result.succeeded else result.detail
+        table.add_row(
+            str(result.epub_path),
+            status,
+            detail or "-",
+            _display_optional_path(result.report_path),
+        )
+    console.print(table)
 
 
 def _run_preview(
@@ -1922,8 +2212,9 @@ def _save_markdown_report(
     report: TranslationReport,
     dry_run: bool,
     validation_warnings: list[str] | None = None,
+    directory: Path | None = None,
 ) -> Path:
-    directory = _default_reports_dir()
+    directory = directory or _default_reports_dir()
     directory.mkdir(parents=True, exist_ok=True)
     path = _next_available_report_path(directory, _report_filename_stem(report))
     path.write_text(_render_markdown_report(report, dry_run, validation_warnings), encoding="utf-8")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1335,6 +1335,240 @@ def test_translate_command_developer_mode_requires_overwrite_for_existing_output
     assert "Traceback" not in result.output
 
 
+def test_translate_command_batch_writes_outputs_and_markdown_reports(tmp_path, monkeypatch):
+    first_epub = tmp_path / "first.epub"
+    second_epub = tmp_path / "second.epub"
+    output_dir = tmp_path / "translated"
+    reports_dir = tmp_path / "reports"
+    processing_dir = tmp_path / "processing"
+    first_epub.write_bytes(b"fake epub")
+    second_epub.write_bytes(b"fake epub")
+    calls: list[tuple[Path, Path]] = []
+
+    def fake_translate(input_path: Path, output_path: Path, **kwargs: object) -> TranslationReport:
+        calls.append((input_path, output_path))
+        return TranslationReport(
+            output_path=output_path,
+            input_path=input_path,
+            detected_language=kwargs["options"].source,
+            target_language=kwargs["options"].target,
+            chapters_processed=1,
+            texts_translated=2,
+        )
+
+    monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: processing_dir)
+    monkeypatch.setattr("ayvu.cli._reports_dir", lambda _config: reports_dir)
+    monkeypatch.setattr(
+        "ayvu.cli.run_translation_preflight",
+        lambda **_kwargs: SimpleNamespace(translator=object(), glossary=None, route=None),
+    )
+    monkeypatch.setattr("ayvu.cli.TranslationCache", lambda _path: FakeCache())
+    monkeypatch.setattr("ayvu.cli.translate_epub", fake_translate)
+    monkeypatch.setattr(
+        "ayvu.cli.validate_output_epub",
+        lambda _path, on_progress=None: ValidationResult(ok=True, document_count=1),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "translate",
+            str(first_epub),
+            str(second_epub),
+            "--output-dir",
+            str(output_dir),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert calls == [
+        (first_epub, output_dir / "first-pt.epub"),
+        (second_epub, output_dir / "second-pt.epub"),
+    ]
+    assert "Batch translation plan" in result.output
+    assert "Batch translation summary" in result.output
+    assert "Report saved to:" in result.output
+    assert (reports_dir / "first-pt-report.md").exists()
+    assert (reports_dir / "second-pt-report.md").exists()
+    assert "- Original EPUB: " in (reports_dir / "first-pt-report.md").read_text(encoding="utf-8")
+
+
+def test_translate_command_uses_output_dir_for_single_epub(tmp_path, monkeypatch):
+    epub_path = tmp_path / "book.epub"
+    output_dir = tmp_path / "translated"
+    processing_dir = tmp_path / "processing"
+    epub_path.write_bytes(b"fake epub")
+    calls: dict[str, Path] = {}
+
+    def fake_translate(input_path: Path, output_path: Path, **_kwargs: object) -> TranslationReport:
+        calls["input_path"] = input_path
+        calls["output_path"] = output_path
+        return TranslationReport(output_path=output_path, input_path=input_path, target_language="pt")
+
+    monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: processing_dir)
+    monkeypatch.setattr(
+        "ayvu.cli.run_translation_preflight",
+        lambda **_kwargs: SimpleNamespace(translator=object(), glossary=None, route=None),
+    )
+    monkeypatch.setattr("ayvu.cli.TranslationCache", lambda _path: FakeCache())
+    monkeypatch.setattr("ayvu.cli.translate_epub", fake_translate)
+    monkeypatch.setattr(
+        "ayvu.cli.validate_output_epub",
+        lambda _path, on_progress=None: ValidationResult(ok=True, document_count=1),
+    )
+    monkeypatch.setattr("ayvu.cli._offer_markdown_report", lambda *_args, **_kwargs: None)
+
+    result = runner.invoke(
+        app,
+        ["--mode", "common", "translate", str(epub_path), "--output-dir", str(output_dir)],
+    )
+
+    assert result.exit_code == 0
+    assert calls["input_path"] == epub_path
+    assert calls["output_path"] == output_dir / "book-pt.epub"
+    assert "Keep this output location?" not in result.output
+
+
+def test_translate_command_batch_rejects_single_output_path(tmp_path):
+    first_epub = tmp_path / "first.epub"
+    second_epub = tmp_path / "second.epub"
+    first_epub.write_bytes(b"fake epub")
+    second_epub.write_bytes(b"fake epub")
+
+    result = runner.invoke(
+        app,
+        [
+            "translate",
+            str(first_epub),
+            str(second_epub),
+            "--output",
+            str(tmp_path / "book-pt.epub"),
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Não é possível usar --output com múltiplos EPUBs." in result.output
+    assert "--output-dir" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_translate_command_batch_rejects_review_output(tmp_path):
+    first_epub = tmp_path / "first.epub"
+    second_epub = tmp_path / "second.epub"
+    first_epub.write_bytes(b"fake epub")
+    second_epub.write_bytes(b"fake epub")
+
+    result = runner.invoke(
+        app,
+        [
+            "translate",
+            str(first_epub),
+            str(second_epub),
+            "--review-output",
+            str(tmp_path / "review.csv"),
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Não é possível usar --review-output com múltiplos EPUBs." in result.output
+    assert "Traceback" not in result.output
+
+
+def test_translate_command_batch_rejects_existing_output_without_overwrite(tmp_path, monkeypatch):
+    first_epub = tmp_path / "first.epub"
+    second_epub = tmp_path / "second.epub"
+    output_dir = tmp_path / "translated"
+    existing_output = output_dir / "first-pt.epub"
+    first_epub.write_bytes(b"fake epub")
+    second_epub.write_bytes(b"fake epub")
+    output_dir.mkdir()
+    existing_output.write_text("already here", encoding="utf-8")
+
+    def fail_preflight(**_kwargs: object) -> object:
+        raise AssertionError("preflight should not run when a batch output already exists")
+
+    monkeypatch.setattr("ayvu.cli.run_translation_preflight", fail_preflight)
+
+    result = runner.invoke(
+        app,
+        [
+            "translate",
+            str(first_epub),
+            str(second_epub),
+            "--output-dir",
+            str(output_dir),
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "existing output was not changed." in result.output
+    assert "Batch translation summary" in result.output
+    assert existing_output.read_text(encoding="utf-8") == "already here"
+    assert "Traceback" not in result.output
+
+
+def test_translate_command_batch_continues_after_failure_when_requested(tmp_path, monkeypatch):
+    first_epub = tmp_path / "first.epub"
+    second_epub = tmp_path / "second.epub"
+    output_dir = tmp_path / "translated"
+    reports_dir = tmp_path / "reports"
+    processing_dir = tmp_path / "processing"
+    first_epub.write_bytes(b"fake epub")
+    second_epub.write_bytes(b"fake epub")
+    translated_inputs: list[Path] = []
+
+    def fake_preflight(**kwargs: object) -> object:
+        if kwargs["epub_path"] == first_epub:
+            raise PreflightError(
+                "Não foi possível preparar o tradutor.",
+                "Verifique o tradutor local e tente novamente.",
+                detail="first failed",
+            )
+        return SimpleNamespace(translator=object(), glossary=None, route=None)
+
+    def fake_translate(input_path: Path, output_path: Path, **kwargs: object) -> TranslationReport:
+        translated_inputs.append(input_path)
+        return TranslationReport(
+            output_path=output_path,
+            input_path=input_path,
+            detected_language=kwargs["options"].source,
+            target_language=kwargs["options"].target,
+        )
+
+    monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: processing_dir)
+    monkeypatch.setattr("ayvu.cli._reports_dir", lambda _config: reports_dir)
+    monkeypatch.setattr("ayvu.cli.run_translation_preflight", fake_preflight)
+    monkeypatch.setattr("ayvu.cli.TranslationCache", lambda _path: FakeCache())
+    monkeypatch.setattr("ayvu.cli.translate_epub", fake_translate)
+    monkeypatch.setattr(
+        "ayvu.cli.validate_output_epub",
+        lambda _path, on_progress=None: ValidationResult(ok=True, document_count=1),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "translate",
+            str(first_epub),
+            str(second_epub),
+            "--output-dir",
+            str(output_dir),
+            "--continue-on-error",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert translated_inputs == [second_epub]
+    assert "Não foi possível preparar o tradutor." in result.output
+    assert "Batch item failed:" in result.output
+    assert "Batch translation summary" in result.output
+    assert "Failed" in result.output
+    assert "OK" in result.output
+    assert not (reports_dir / "first-pt-report.md").exists()
+    assert (reports_dir / "second-pt-report.md").exists()
+    assert "Traceback" not in result.output
+
+
 def test_translate_command_continues_when_existing_output_is_confirmed(tmp_path):
     epub_path = tmp_path / "book.epub"
     output_path = tmp_path / "book-pt.epub"


### PR DESCRIPTION
## Objective

Allow users to translate multiple EPUB files in one command while preserving the existing single-book translation flow.

## What changed

- Updated `translate` to accept one or more EPUB inputs.
- Added `--output-dir` for per-book translated EPUB outputs.
- Added `--continue-on-error` so batch runs can continue after item failures.
- Saves a separate Markdown report for each batch item.
- Rejects ambiguous batch combinations such as `--output` or `--review-output` with multiple EPUBs.
- Documented the batch workflow in README, tutorial, technical report, and changelog.

## Out of scope

- Batch CSV review export is intentionally left out; `--review-output` remains scoped to one EPUB at a time.

## Validation

- `uv run pytest tests/test_cli.py`: 86 passed.
- `uv run pytest`: 239 passed.
- `git diff --check`: no errors.
- `uv run ayvu translate --help`: confirmed `EPUB_PATHS...`, `--output-dir`, and `--continue-on-error` are shown.

## Related issue

Closes #93