### PR TITLE
Add selected chapter translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,9 @@ lancadas e secoes versionadas quando uma release for publicada.
 - Traducao em batch no comando `translate`, aceitando multiplos EPUBs,
   `--output-dir`, relatorios Markdown por livro e `--continue-on-error` para
   seguir processando apos falhas.
+- Opcao `--chapters` no comando `translate` para traduzir apenas capitulos
+  selecionados por indice, faixa ou padrao, preservando os demais capitulos sem
+  mudancas.
 
 ### Atualizado
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,21 @@ EPUB, porque um caminho único de saída ou CSV não é suficiente para represen
 vários livros. O batch salva automaticamente um relatório Markdown separado por
 livro na pasta de relatórios configurada.
 
+Traduzir apenas capítulos selecionados:
+
+```bash
+uv run ayvu translate livro.epub \
+  --target pt \
+  --chapters "1-3,5,*chapter2*"
+```
+
+`--chapters` aceita índices 1-based, faixas e padrões separados por vírgula.
+Padrões com `*`, `?` ou `[` usam glob simples; sem curinga, o Ayvu faz busca
+por trecho. A seleção é comparada com o título detectado, nome do item e caminho
+interno do documento no EPUB. Antes de traduzir, o Ayvu mostra a tabela
+`Selected chapters`. Capítulos não selecionados são copiados sem mudanças para o
+EPUB de saída.
+
 Se `--source` não for informado, o Ayvu lê o idioma do EPUB nos metadados, exibe o
 plano da tradução (`From`/`To`) antes de começar e usa o idioma detectado como
 origem. Quando o metadado estiver ausente ou inválido, o Ayvu avisa e usa `en`

--- a/docs/relatorio-tecnico.md
+++ b/docs/relatorio-tecnico.md
@@ -492,6 +492,14 @@ erro por padrão; com `--continue-on-error`, registra a falha, processa os itens
 restantes e termina com código 1 se qualquer livro falhar. Cada item salva um
 relatório Markdown próprio na pasta de relatórios configurada.
 
+O comando `translate` também aceita `--chapters` para tradução parcial. A CLI
+parseia a expressão e mostra a tabela `Selected chapters`, mas a resolução real
+fica em `epub_io`: os documentos traduzíveis são enumerados na ordem interna do
+EPUB, a seleção casa índices 1-based, faixas ou padrões por título/nome/caminho,
+e somente documentos selecionados entram em `translate_html`. Como a cópia final
+do EPUB substitui apenas documentos traduzidos, capítulos fora da seleção são
+preservados com o conteúdo original.
+
 No modo comum, o Ayvu também oferece salvar esse relatório em Markdown em `~/Documentos/Livros/Relatorios`, sem sobrescrever relatórios anteriores. O relatório Markdown repete o resumo de glossário e inclui seções com termos aplicados e avisos quando existirem.
 
 ## 16. Bug crítico: EPUB com tela branca

--- a/docs/tutorial-modo-comum-e-dev.md
+++ b/docs/tutorial-modo-comum-e-dev.md
@@ -352,6 +352,24 @@ desenvolvedor, ou confirme a substituição quando estiver no modo comum.
 Cada item do batch mostra seu relatório no terminal e salva um relatório
 Markdown separado na pasta de relatórios configurada.
 
+### Traduzir capítulos selecionados
+
+```bash
+uv run ayvu translate livro.epub \
+  --source en \
+  --target pt \
+  --chapters "1-3,5,*chapter2*"
+```
+
+`--chapters` limita a tradução a documentos internos selecionados. Use índices
+1-based, faixas e padrões separados por vírgula. Padrões com `*`, `?` ou `[`
+usam glob simples; sem curinga, o Ayvu procura o trecho no título detectado, no
+nome do item e no caminho interno do documento.
+
+Antes de iniciar a tradução, o Ayvu mostra uma tabela `Selected chapters` com os
+capítulos que serão processados. Capítulos fora da seleção permanecem no idioma
+original e são copiados sem alteração para o EPUB gerado.
+
 ### Exportar CSV para revisão externa
 
 ```bash

--- a/src/ayvu/cli.py
+++ b/src/ayvu/cli.py
@@ -21,6 +21,8 @@ from .config import (
     default_glossaries_dir,
 )
 from .domain import (
+    ChapterSelection,
+    ChapterSelectionError,
     LanguagePair,
     OutputPlan,
     TranslationOptions,
@@ -30,11 +32,13 @@ from .domain import (
 )
 from .epub_io import (
     ReviewApplyReport,
+    SelectedChapter,
     TranslationReport,
     apply_reviewed_epub,
     detect_epub_language,
     extract_markdown,
     inspect_epub,
+    resolve_chapter_selection,
     translate_epub,
 )
 from .glossary import (
@@ -276,6 +280,11 @@ def translate(
     ),
     dry_run: bool = typer.Option(False, "--dry-run", help="Process without writing translated EPUB."),
     fail_fast: bool = typer.Option(False, "--fail-fast", help="Stop at the first chapter/text error."),
+    chapters: Optional[str] = typer.Option(
+        None,
+        "--chapters",
+        help="Translate only selected chapters, e.g. '1-3,5,*chapter2*'.",
+    ),
     continue_on_error: bool = typer.Option(
         False,
         "--continue-on-error",
@@ -308,6 +317,7 @@ def translate(
         mode=mode,
     )
     resolved_output_dir = _resolve_translation_output_dir(output_dir, mode=mode)
+    chapter_selection = _parse_chapter_selection(chapters, mode=mode)
 
     if len(epub_list) > 1:
         _run_batch_translation(
@@ -322,6 +332,7 @@ def translate(
             profile_name=profile_name,
             dry_run=dry_run,
             fail_fast=fail_fast,
+            chapter_selection=chapter_selection,
             continue_on_error=continue_on_error,
             overwrite=overwrite,
             timeout=timeout,
@@ -348,6 +359,7 @@ def translate(
         profile_name=profile_name,
         dry_run=dry_run,
         fail_fast=fail_fast,
+        chapter_selection=chapter_selection,
         overwrite=overwrite,
         timeout=timeout,
         retries=retries,
@@ -488,6 +500,63 @@ def _resolve_glossary_path(
     return default_glossaries_dir() / profile_glossary
 
 
+def _parse_chapter_selection(value: str | None, mode: UserMode) -> ChapterSelection | None:
+    if value is None:
+        return None
+    try:
+        return ChapterSelection.parse(value)
+    except ChapterSelectionError as exc:
+        _print_expected_error(
+            "Seleção de capítulos inválida.",
+            "Use índices 1-based, faixas e padrões separados por vírgula, por exemplo --chapters '1-3,5,*chapter2*'.",
+            mode,
+            detail=str(exc),
+        )
+        raise typer.Exit(code=1) from exc
+
+
+def _resolve_chapter_selection_for_display(
+    epub_path: Path,
+    selection: ChapterSelection,
+    options: TranslationOptions,
+    mode: UserMode,
+) -> list[SelectedChapter]:
+    try:
+        return resolve_chapter_selection(
+            epub_path,
+            selection,
+            translate_metadata=options.translate_metadata,
+            max_documents=options.max_documents,
+        )
+    except ChapterSelectionError as exc:
+        _print_expected_error(
+            "Nenhum capítulo corresponde à seleção informada.",
+            "Confira --chapters e use índices 1-based, faixas ou padrões que existam no EPUB.",
+            mode,
+            detail=str(exc),
+        )
+        raise typer.Exit(code=1) from exc
+    except Exception as exc:
+        _print_epub_read_error(str(exc), mode)
+        raise typer.Exit(code=1) from exc
+
+
+def _print_selected_chapters(chapters: list[SelectedChapter]) -> None:
+    table = Table(title="Selected chapters")
+    table.add_column("#")
+    table.add_column("Name")
+    table.add_column("Title")
+    table.add_column("Archive path")
+    for chapter in chapters:
+        table.add_row(
+            str(chapter.index),
+            chapter.name,
+            chapter.title or "-",
+            chapter.archive_path,
+        )
+    console.print(table)
+
+
 def _validate_translate_command_options(
     epub_paths: list[Path],
     output: Path | None,
@@ -560,6 +629,7 @@ def _run_translation(
     profile_name: str | None,
     dry_run: bool,
     fail_fast: bool,
+    chapter_selection: ChapterSelection | None,
     overwrite: bool,
     timeout: float,
     retries: int,
@@ -593,7 +663,16 @@ def _run_translation(
         chunk_limit=chunk_limit,
         translate_metadata=translate_metadata,
         translate_alt_text=translate_alt_text,
+        chapter_selection=chapter_selection,
     )
+    if chapter_selection is not None:
+        selected_chapters = _resolve_chapter_selection_for_display(
+            epub_path=epub_path,
+            selection=chapter_selection,
+            options=translation_options,
+            mode=mode,
+        )
+        _print_selected_chapters(selected_chapters)
     output_plan = OutputPlan.for_translation(
         epub_path,
         output,
@@ -731,6 +810,7 @@ def _run_batch_translation(
     profile_name: str | None,
     dry_run: bool,
     fail_fast: bool,
+    chapter_selection: ChapterSelection | None,
     continue_on_error: bool,
     overwrite: bool,
     timeout: float,
@@ -769,6 +849,7 @@ def _run_batch_translation(
                 profile_name=profile_name,
                 dry_run=dry_run,
                 fail_fast=fail_fast,
+                chapter_selection=chapter_selection,
                 overwrite=overwrite,
                 timeout=timeout,
                 retries=retries,
@@ -1433,6 +1514,7 @@ def _run_guided_translation(config: AyvuConfig) -> None:
         profile_name=profile_name,
         dry_run=False,
         fail_fast=False,
+        chapter_selection=None,
         overwrite=False,
         timeout=30.0,
         retries=2,
@@ -2104,6 +2186,7 @@ def _resume_translation(state: TranslationResumeState, mode: UserMode) -> None:
             profile_name=None,
             dry_run=False,
             fail_fast=state.fail_fast,
+            chapter_selection=_parse_chapter_selection(state.chapter_selection, mode=mode),
             overwrite=state.overwrite,
             timeout=state.timeout,
             retries=state.retries,

--- a/src/ayvu/domain.py
+++ b/src/ayvu/domain.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
+from fnmatch import fnmatchcase
 from pathlib import Path
 
 
@@ -11,6 +12,10 @@ class UserMode(Enum):
 
 
 class LanguagePairError(ValueError):
+    pass
+
+
+class ChapterSelectionError(ValueError):
     pass
 
 
@@ -85,6 +90,86 @@ def default_preview_books_dir() -> Path:
 
 
 @dataclass(frozen=True)
+class ChapterSelectionItem:
+    raw: str
+    start: int | None = None
+    end: int | None = None
+    pattern: str | None = None
+
+    @property
+    def is_pattern(self) -> bool:
+        return self.pattern is not None
+
+    def matches_index(self, index: int) -> bool:
+        if self.is_pattern or self.start is None:
+            return False
+        end = self.end if self.end is not None else self.start
+        return self.start <= index <= end
+
+    def matches_text(self, values: tuple[str, ...]) -> bool:
+        if self.pattern is None:
+            return False
+
+        pattern = self.pattern.casefold()
+        uses_glob = any(char in pattern for char in "*?[")
+        for value in values:
+            candidate = value.casefold()
+            if uses_glob and fnmatchcase(candidate, pattern):
+                return True
+            if not uses_glob and pattern in candidate:
+                return True
+        return False
+
+
+@dataclass(frozen=True)
+class ChapterSelection:
+    source: str
+    items: tuple[ChapterSelectionItem, ...]
+
+    @classmethod
+    def parse(cls, value: str) -> "ChapterSelection":
+        raw_value = value.strip()
+        if not raw_value:
+            raise ChapterSelectionError("chapter selection cannot be empty")
+
+        items = tuple(_parse_chapter_selection_item(part.strip()) for part in raw_value.split(","))
+        return cls(source=raw_value, items=items)
+
+    def matches(self, index: int, *values: str | None) -> bool:
+        match_values = tuple(value for value in values if value)
+        return any(item.matches_index(index) or item.matches_text(match_values) for item in self.items)
+
+
+def _parse_chapter_selection_item(value: str) -> ChapterSelectionItem:
+    if not value:
+        raise ChapterSelectionError("chapter selection contains an empty item")
+
+    if value.isdecimal():
+        index = _parse_positive_chapter_index(value)
+        return ChapterSelectionItem(raw=value, start=index)
+
+    if "-" in value:
+        start, separator, end = value.partition("-")
+        start = start.strip()
+        end = end.strip()
+        if separator and start.isdecimal() and end.isdecimal():
+            start_index = _parse_positive_chapter_index(start)
+            end_index = _parse_positive_chapter_index(end)
+            if start_index > end_index:
+                raise ChapterSelectionError(f"chapter range is reversed: {value}")
+            return ChapterSelectionItem(raw=value, start=start_index, end=end_index)
+
+    return ChapterSelectionItem(raw=value, pattern=value)
+
+
+def _parse_positive_chapter_index(value: str) -> int:
+    index = int(value)
+    if index < 1:
+        raise ChapterSelectionError(f"chapter index must be 1 or greater: {value}")
+    return index
+
+
+@dataclass(frozen=True)
 class TranslationOptions:
     language_pair: LanguagePair
     dry_run: bool = False
@@ -93,6 +178,7 @@ class TranslationOptions:
     max_documents: int | None = None
     translate_metadata: bool = False
     translate_alt_text: bool = False
+    chapter_selection: ChapterSelection | None = None
 
     @property
     def source(self) -> str:

--- a/src/ayvu/epub_io.py
+++ b/src/ayvu/epub_io.py
@@ -11,7 +11,7 @@ from ebooklib import ITEM_DOCUMENT
 from ebooklib import epub
 
 from .cache import TranslationCache
-from .domain import TranslationOptions
+from .domain import ChapterSelection, ChapterSelectionError, TranslationOptions
 from .glossary import Glossary, GlossaryUsage
 from .html_translate import (
     HtmlTranslatedSegment,
@@ -59,6 +59,15 @@ class EpubInfo:
 class EpubDocument:
     name: str
     archive_path: str
+    title: str | None = None
+
+
+@dataclass(frozen=True)
+class SelectedChapter:
+    index: int
+    name: str
+    archive_path: str
+    title: str | None = None
 
 
 @dataclass(frozen=True)
@@ -194,15 +203,18 @@ def translate_epub(
 
     with ZipFile(source_path, "r") as source_epub:
         archive_names = set(source_epub.namelist())
-        navigation_documents = _navigation_document_entries(source_epub, opf_archive_path, opf_base_path)
         documents = _limited_documents(
-            _documents_for_translation(
-                _document_entries(book, opf_base_path),
-                navigation_documents,
-                translate_metadata=options.translate_metadata,
+            _translation_documents(
+                book,
+                source_epub,
+                opf_archive_path,
+                opf_base_path,
+                options.translate_metadata,
+                include_titles=options.chapter_selection is not None,
             ),
             options.max_documents,
         )
+        documents = _select_documents(documents, options.chapter_selection)
         total_documents = len(documents)
 
         if options.translate_metadata and opf_archive_path and opf_archive_path in archive_names:
@@ -292,6 +304,33 @@ def translate_epub(
         _copy_epub_with_replacements(source_path, destination_path, replacements)
 
     return report
+
+
+def resolve_chapter_selection(
+    input_path: str | Path,
+    selection: ChapterSelection,
+    translate_metadata: bool = False,
+    max_documents: int | None = None,
+) -> list[SelectedChapter]:
+    source_path = Path(input_path)
+    book = epub.read_epub(str(source_path))
+    opf_archive_path = _get_opf_archive_path(source_path)
+    opf_base_path = _opf_base_path(opf_archive_path)
+
+    with ZipFile(source_path, "r") as source_epub:
+        documents = _limited_documents(
+            _translation_documents(
+                book,
+                source_epub,
+                opf_archive_path,
+                opf_base_path,
+                translate_metadata,
+                include_titles=True,
+            ),
+            max_documents,
+        )
+
+    return _resolve_selected_chapters(documents, selection)
 
 
 def extract_markdown(input_path: str | Path, output_dir: str | Path) -> list[Path]:
@@ -515,11 +554,21 @@ def _document_zip_path(opf_base_path: PurePosixPath, item_name: str) -> str:
     return path.as_posix()
 
 
-def _document_entries(book: epub.EpubBook, opf_base_path: PurePosixPath) -> list[EpubDocument]:
+def _document_entries(
+    book: epub.EpubBook,
+    opf_base_path: PurePosixPath,
+    include_titles: bool = False,
+) -> list[EpubDocument]:
     documents: list[EpubDocument] = []
     for item in book.get_items_of_type(ITEM_DOCUMENT):
         name = item.get_name()
-        documents.append(EpubDocument(name=name, archive_path=_document_zip_path(opf_base_path, name)))
+        documents.append(
+            EpubDocument(
+                name=name,
+                archive_path=_document_zip_path(opf_base_path, name),
+                title=_document_title(item) if include_titles else None,
+            )
+        )
     return documents
 
 
@@ -545,6 +594,73 @@ def _documents_for_translation(
             selected.append(document)
             selected_paths.add(document.archive_path)
     return selected
+
+
+def _translation_documents(
+    book: epub.EpubBook,
+    source_epub: ZipFile,
+    opf_archive_path: str | None,
+    opf_base_path: PurePosixPath,
+    translate_metadata: bool,
+    include_titles: bool = False,
+) -> list[EpubDocument]:
+    return _documents_for_translation(
+        _document_entries(book, opf_base_path, include_titles=include_titles),
+        _navigation_document_entries(source_epub, opf_archive_path, opf_base_path),
+        translate_metadata=translate_metadata,
+    )
+
+
+def _select_documents(
+    documents: list[EpubDocument],
+    selection: ChapterSelection | None,
+) -> list[EpubDocument]:
+    if selection is None:
+        return documents
+    selected = _resolve_selected_chapters(documents, selection)
+    return [documents[chapter.index - 1] for chapter in selected]
+
+
+def _resolve_selected_chapters(
+    documents: list[EpubDocument],
+    selection: ChapterSelection,
+) -> list[SelectedChapter]:
+    selected: list[SelectedChapter] = []
+    for index, document in enumerate(documents, start=1):
+        if selection.matches(index, document.name, document.archive_path, document.title):
+            selected.append(
+                SelectedChapter(
+                    index=index,
+                    name=document.name,
+                    archive_path=document.archive_path,
+                    title=document.title,
+                )
+            )
+
+    if not selected:
+        raise ChapterSelectionError(f"no chapters matched selection: {selection.source}")
+    return selected
+
+
+def _document_title(item: object) -> str | None:
+    title = getattr(item, "title", None)
+    if isinstance(title, str) and title.strip():
+        return title.strip()
+    get_title = getattr(item, "get_title", None)
+    if callable(get_title):
+        title = get_title()
+        if isinstance(title, str) and title.strip():
+            return title.strip()
+    get_content = getattr(item, "get_content", None)
+    if callable(get_content):
+        try:
+            for text in extract_visible_text(get_content()):
+                clean = " ".join(text.split())
+                if clean:
+                    return clean
+        except Exception:
+            return None
+    return None
 
 
 def _navigation_document_entries(

--- a/src/ayvu/resume.py
+++ b/src/ayvu/resume.py
@@ -54,6 +54,7 @@ class TranslationResumeState:
     chunk_limit: int
     translate_metadata: bool
     translate_alt_text: bool
+    chapter_selection: str | None
     created_at: str
     updated_at: str
 
@@ -90,6 +91,7 @@ class TranslationResumeState:
             chunk_limit=options.chunk_limit,
             translate_metadata=options.translate_metadata,
             translate_alt_text=options.translate_alt_text,
+            chapter_selection=options.chapter_selection.source if options.chapter_selection else None,
             created_at=now,
             updated_at=now,
         )
@@ -125,6 +127,7 @@ class TranslationResumeState:
             chunk_limit=_required_int(data, "chunk_limit"),
             translate_metadata=_optional_bool(data, "translate_metadata", default=False),
             translate_alt_text=_optional_bool(data, "translate_alt_text", default=False),
+            chapter_selection=_optional_text(data, "chapter_selection"),
             created_at=_required_text(data, "created_at"),
             updated_at=_required_text(data, "updated_at"),
         )
@@ -218,6 +221,15 @@ def _optional_bool(data: dict[str, object], key: str, default: bool) -> bool:
     value = data[key]
     if not isinstance(value, bool):
         raise ResumeStateError(f"Resume state field {key} must be true or false.")
+    return value
+
+
+def _optional_text(data: dict[str, object], key: str) -> str | None:
+    value = data.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise ResumeStateError(f"Resume state field {key} must be a non-empty string or null.")
     return value
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2212,6 +2212,61 @@ def test_translate_alt_text_flag_reaches_translation_options(minimal_epub_path, 
     assert calls["options"].translate_alt_text
 
 
+def test_translate_chapters_option_reaches_translation_options_and_prints_selection(
+    minimal_epub_path, tmp_path, monkeypatch
+):
+    monkeypatch.setattr("ayvu.cli.default_translated_books_dir", lambda: tmp_path / "Traduzidos")
+    calls: dict[str, object] = {}
+    _mock_translation_pipeline(monkeypatch, calls)
+
+    result = runner.invoke(
+        app,
+        ["--mode", "developer", "translate", str(minimal_epub_path), "--chapters", "2"],
+    )
+
+    options = calls["options"]
+    assert result.exit_code == 0
+    assert options.chapter_selection is not None
+    assert options.chapter_selection.source == "2"
+    assert "Selected chapters" in result.output
+    assert "Chapter Two" in result.output
+    assert "text/chapter2.xhtml" in result.output
+
+
+def test_translate_chapters_option_reports_invalid_expression(minimal_epub_path, monkeypatch):
+    def fail_preflight(**_kwargs: object) -> object:
+        raise AssertionError("preflight should not run for invalid chapter selection")
+
+    monkeypatch.setattr("ayvu.cli.run_translation_preflight", fail_preflight)
+
+    result = runner.invoke(
+        app,
+        ["--mode", "developer", "translate", str(minimal_epub_path), "--chapters", "3-1"],
+    )
+
+    assert result.exit_code == 1
+    assert "Seleção de capítulos inválida." in result.output
+    assert "chapter range is reversed" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_translate_chapters_option_reports_unmatched_selection(minimal_epub_path, monkeypatch):
+    def fail_preflight(**_kwargs: object) -> object:
+        raise AssertionError("preflight should not run when no chapter matches")
+
+    monkeypatch.setattr("ayvu.cli.run_translation_preflight", fail_preflight)
+
+    result = runner.invoke(
+        app,
+        ["--mode", "developer", "translate", str(minimal_epub_path), "--chapters", "999"],
+    )
+
+    assert result.exit_code == 1
+    assert "Nenhum capítulo corresponde à seleção informada." in result.output
+    assert "no chapters matched selection" in result.output
+    assert "Traceback" not in result.output
+
+
 def test_translate_warns_when_epub_language_metadata_is_missing(tmp_path, monkeypatch):
     epub_path = tmp_path / "no-lang.epub"
     book = epub.EpubBook()

--- a/tests/test_epub_io.py
+++ b/tests/test_epub_io.py
@@ -2,10 +2,11 @@ import csv
 from pathlib import Path, PurePosixPath
 from zipfile import ZipFile
 
+import pytest
 from ebooklib import ITEM_DOCUMENT
 
 from ayvu.cache import TranslationCache
-from ayvu.domain import LanguagePair, TranslationOptions
+from ayvu.domain import ChapterSelection, ChapterSelectionError, LanguagePair, TranslationOptions
 from ayvu.epub_io import (
     EpubDocument,
     EpubReplacements,
@@ -21,6 +22,7 @@ from ayvu.epub_io import (
     extract_markdown,
     inspect_epub,
     normalize_language_code,
+    resolve_chapter_selection,
     translate_epub,
 )
 from ayvu.glossary import GLOSSARY_RULE_FORBIDDEN, GLOSSARY_RULE_PRESERVE, Glossary, GlossaryEntry
@@ -415,6 +417,59 @@ def test_translate_epub_limits_documents_for_preview(minimal_epub_path: Path, tm
     assert "PT:Hello reader. Visit" in chapter_one
     assert "PT:Goodbye reader." not in chapter_two
     assert "Goodbye reader." in chapter_two
+
+
+def test_translate_epub_translates_selected_chapter_by_index_without_changing_others(
+    minimal_epub_path: Path,
+    tmp_path: Path,
+):
+    output_path = tmp_path / "minimal-selected.epub"
+    translator = PrefixTranslator()
+    options = TranslationOptions(
+        language_pair=LanguagePair(source="en", target="pt"),
+        chapter_selection=ChapterSelection.parse("2"),
+    )
+
+    with TranslationCache(tmp_path / "cache.sqlite") as cache:
+        report = translate_epub(
+            minimal_epub_path,
+            output_path,
+            translator=translator,
+            cache=cache,
+            options=options,
+        )
+
+    assert report.chapters_processed == 1
+
+    with ZipFile(output_path) as output_epub:
+        names = output_epub.namelist()
+        chapter_one_name = next(name for name in names if name.endswith("text/chapter1.xhtml"))
+        chapter_two_name = next(name for name in names if name.endswith("text/chapter2.xhtml"))
+        chapter_one = output_epub.read(chapter_one_name).decode("utf-8")
+        chapter_two = output_epub.read(chapter_two_name).decode("utf-8")
+
+    assert "PT:Hello reader. Visit" not in chapter_one
+    assert "Hello reader. Visit" in chapter_one
+    assert "PT:Goodbye reader." in chapter_two
+
+
+def test_resolve_chapter_selection_matches_title_and_path_patterns(minimal_epub_path: Path):
+    by_title = resolve_chapter_selection(minimal_epub_path, ChapterSelection.parse("Chapter Two"))
+    by_path = resolve_chapter_selection(minimal_epub_path, ChapterSelection.parse("*chapter2*"))
+
+    assert [chapter.index for chapter in by_title] == [2]
+    assert by_title[0].title == "Chapter Two"
+    assert [chapter.index for chapter in by_path] == [2]
+
+
+def test_resolve_chapter_selection_rejects_unmatched_selection(minimal_epub_path: Path):
+    with pytest.raises(ChapterSelectionError, match="no chapters matched selection"):
+        resolve_chapter_selection(minimal_epub_path, ChapterSelection.parse("999"))
+
+
+def test_chapter_selection_rejects_invalid_range():
+    with pytest.raises(ChapterSelectionError, match="chapter range is reversed"):
+        ChapterSelection.parse("3-1")
 
 
 def test_translate_epub_reports_glossary_usage(minimal_epub_path: Path, tmp_path: Path):

--- a/tests/test_resume.py
+++ b/tests/test_resume.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from ayvu.domain import LanguagePair, TranslationOptions
+from ayvu.domain import ChapterSelection, LanguagePair, TranslationOptions
 from ayvu.resume import (
     COMPLETED_STATUS,
     RESUME_STATE_VERSION,
@@ -29,6 +29,7 @@ def make_state(tmp_path: Path, stem: str = "book") -> TranslationResumeState:
             chunk_limit=1200,
             translate_metadata=True,
             translate_alt_text=True,
+            chapter_selection=ChapterSelection.parse("1-2,*chapter3*"),
         ),
         overwrite=True,
         timeout=9.5,
@@ -54,6 +55,7 @@ def test_resume_state_round_trip(tmp_path):
     assert loaded.chunk_limit == 1200
     assert loaded.translate_metadata
     assert loaded.translate_alt_text
+    assert loaded.chapter_selection == "1-2,*chapter3*"
     assert loaded.timeout == 9.5
     assert loaded.retries == 3
 
@@ -116,6 +118,18 @@ def test_resume_state_load_defaults_missing_translate_alt_text_to_false(tmp_path
     loaded = store.load(path)
 
     assert not loaded.translate_alt_text
+
+
+def test_resume_state_load_defaults_missing_chapter_selection_to_none(tmp_path):
+    path = tmp_path / "old.ayvu-state.json"
+    data = make_state(tmp_path).to_dict()
+    data.pop("chapter_selection")
+    path.write_text(json.dumps(data), encoding="utf-8")
+    store = ResumeStateStore(tmp_path)
+
+    loaded = store.load(path)
+
+    assert loaded.chapter_selection is None
 
 
 def test_resume_state_scan_finds_running_and_invalid_states(tmp_path):


### PR DESCRIPTION
## Objective

Allow users to translate only selected chapters or chapter ranges while preserving the rest of the EPUB unchanged.

## What changed

- Added `--chapters` to the `translate` command with support for 1-based indexes, ranges, and simple title/path patterns.
- Added chapter selection parsing to the domain layer.
- Resolved selected EPUB documents in `epub_io` and filtered translation to the selected documents only.
- Printed a `Selected chapters` table before translation starts.
- Preserved chapter selection in resume state files.
- Documented selected chapter translation in README, tutorial, technical report, and changelog.

## Out of scope

- Interactive chapter picking in common mode is not included; users pass `--chapters` explicitly.

## Validation

- `uv run pytest tests/test_epub_io.py tests/test_cli.py tests/test_resume.py`: 127 passed.
- `uv run pytest`: 247 passed.
- `git diff --check`: no errors.
- `uv run ayvu translate --help`: confirmed `--chapters` is shown.

## Related issue

Closes #94