### PR TITLE
Add cache management commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ lancadas e secoes versionadas quando uma release for publicada.
   intermediaria via ingles quando nao houver rota direta.
 - Preflight antes da traducao real, verificando EPUB, cache, glossario, idiomas,
   rota de traducao e tradutor.
+- Comandos `cache inspect`, `cache clean`, `cache export` e `cache import` para
+  gerenciar o cache SQLite fora do fluxo normal de traducao.
 - Estado local de retomada em `~/Documentos/Livros/Processando` ou na pasta de
   processamento configurada.
 - Oferta de retomada no modo comum quando uma traducao em andamento e detectada.

--- a/README.md
+++ b/README.md
@@ -131,6 +131,15 @@ Traduzir usando um perfil salvo na configuração:
 uv run ayvu translate livro.epub --profile technical
 ```
 
+Gerenciar o cache de traduções:
+
+```bash
+uv run ayvu cache inspect --cache .cache/traducoes.sqlite
+uv run ayvu cache clean --cache .cache/traducoes.sqlite --source en --target pt --dry-run
+uv run ayvu cache export cache-ayvu.json --cache .cache/traducoes.sqlite
+uv run ayvu cache import cache-ayvu.json --cache .cache/traducoes.sqlite
+```
+
 Traduzir vários EPUBs em uma única execução:
 
 ```bash
@@ -418,6 +427,28 @@ uv run ayvu translate livro.epub \
 ```
 
 Trechos já traduzidos serão reaproveitados automaticamente.
+
+O cache pode ser inspecionado, limpo, exportado e importado separadamente dos
+comandos de tradução:
+
+```bash
+uv run ayvu cache inspect --cache .cache/traducoes.sqlite
+uv run ayvu cache clean --cache .cache/traducoes.sqlite --source en --target pt --dry-run
+uv run ayvu cache clean --cache .cache/traducoes.sqlite --source en --target pt --yes
+uv run ayvu cache export cache-ayvu.json --cache .cache/traducoes.sqlite
+uv run ayvu cache import cache-ayvu.json --cache .cache/traducoes.sqlite
+```
+
+`cache inspect` agrupa entradas por idioma de origem, idioma de destino,
+quantidade e datas da primeira e última entrada. `cache clean` aceita filtros
+por `--source`, `--target` e `--before`; para limpar tudo, use `--all`. A
+remoção real exige `--yes`, e `--dry-run` mostra quantas entradas seriam
+apagadas sem modificar o SQLite. `cache export` grava JSON legível e
+`cache import` lê esse JSON; entradas existentes são puladas por padrão e podem
+ser substituídas com `--replace`.
+
+O arquivo exportado inclui texto original e texto traduzido. Trate esse JSON
+como conteúdo privado do livro, da mesma forma que o EPUB e o cache SQLite.
 
 Durante traduções reais, o Ayvu também grava um estado local da execução em
 `~/Documentos/Livros/Processando`, ou na pasta de processamento configurada. Esse arquivo registra os caminhos e opções

--- a/docs/relatorio-tecnico.md
+++ b/docs/relatorio-tecnico.md
@@ -254,7 +254,7 @@ uv run ayvu --mode common translate livro.epub
 
 `src/ayvu/translator.py` define o contrato `Translator` e o backend `LibreTranslateTranslator`.
 
-`src/ayvu/cache.py` persiste traduções em SQLite usando idioma de origem, idioma de destino e hash do texto original.
+`src/ayvu/cache.py` persiste traduções em SQLite usando idioma de origem, idioma de destino e hash do texto original. Também centraliza inspeção, limpeza filtrada, exportação JSON e importação JSON do cache.
 
 `src/ayvu/glossary.py` lê glossários JSON no formato simples e no formato com
 regras explícitas `translate`, `preserve` e `forbidden`.
@@ -382,6 +382,12 @@ source_lang + target_lang + SHA-256(texto original)
 ```
 
 Com a tradução por bloco, o "texto original" é o bloco inteiro com placeholders de tags, então a unidade do cache é o bloco, não mais o nó de texto isolado. Blocos sem tags mantêm a mesma chave de antes; blocos com tags geram chaves novas, o que evita reaproveitar por engano entradas antigas guardadas por nó.
+
+O comando `ayvu cache` mantém o gerenciamento separado da tradução normal. Ele
+permite inspecionar entradas por par de idiomas e datas, limpar entradas com
+filtros ou `--all`, exportar JSON legível e importar o JSON exportado. A
+exportação contém texto original e traduzido, então deve ser tratada como dado
+privado.
 
 O glossário é aplicado depois da tradução e também sobre textos recuperados do cache. Isso mantém o comportamento consistente entre texto novo e texto reaproveitado.
 
@@ -586,7 +592,7 @@ Prioridades que ainda fazem sentido:
    `preserve` ou `forbidden`, sem empilhamento genérico.
 2. Melhorar validação pós-tradução, incluindo links, capítulos vazios, imagens ausentes e texto não traduzido.
 3. Criar configuração persistente para idioma padrão, pastas e preferências.
-4. Melhorar cache com inspeção, limpeza, exportação e escopo por backend/modelo/glossário.
+4. Avaliar escopo de cache por backend, modelo, glossário ou perfil quando esses fatores passarem a alterar o resultado esperado.
 5. Adicionar modo `--cache-only`.
 6. Suportar backends alternativos.
 7. Documentar arquitetura em um documento dedicado.

--- a/docs/tutorial-modo-comum-e-dev.md
+++ b/docs/tutorial-modo-comum-e-dev.md
@@ -231,6 +231,36 @@ uv run ayvu translate livro.epub \
 
 Se o processo for interrompido, rode o comando novamente com o mesmo cache. O Ayvu reaproveita os trechos já traduzidos.
 
+Para ver o que existe no cache, use:
+
+```bash
+uv run ayvu cache inspect --cache .cache/traducoes.sqlite
+```
+
+Para limpar entradas antigas ou de um par de idiomas específico, faça primeiro
+uma prévia:
+
+```bash
+uv run ayvu cache clean \
+  --cache .cache/traducoes.sqlite \
+  --source en \
+  --target pt \
+  --dry-run
+```
+
+Se o resultado estiver correto, repita com `--yes` no lugar de `--dry-run`.
+Para limpar o cache inteiro, use `--all --yes`.
+
+Também é possível exportar e importar o cache em JSON legível:
+
+```bash
+uv run ayvu cache export cache-ayvu.json --cache .cache/traducoes.sqlite
+uv run ayvu cache import cache-ayvu.json --cache .cache/traducoes.sqlite
+```
+
+Esse JSON contém textos originais e traduzidos. Trate o arquivo exportado como
+privado.
+
 ### Ajustar configurações
 
 No menu inicial, escolha `Settings` para ver os valores atuais e alterar preferências locais. A pasta base padrão inicial é:

--- a/src/ayvu/cache.py
+++ b/src/ayvu/cache.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import sqlite3
 from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from .domain import LanguagePair
 
@@ -27,6 +29,18 @@ def text_hash(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
+class CacheError(Exception):
+    pass
+
+
+class CacheExportError(CacheError):
+    pass
+
+
+class CacheImportError(CacheError):
+    pass
+
+
 @dataclass(frozen=True)
 class CacheKey:
     text: str
@@ -37,7 +51,87 @@ class CacheKey:
         return text_hash(self.text)
 
 
+@dataclass(frozen=True)
+class CacheSummaryRow:
+    source_lang: str
+    target_lang: str
+    count: int
+    first_created_at: str
+    last_created_at: str
+
+
+@dataclass(frozen=True)
+class CacheEntry:
+    source_lang: str
+    target_lang: str
+    original_text_hash: str
+    original_text: str
+    translated_text: str
+    created_at: str
+
+    @classmethod
+    def from_mapping(cls, value: object, index: int) -> "CacheEntry":
+        if not isinstance(value, dict):
+            raise CacheImportError(f"entry #{index} must be an object")
+
+        required_fields = (
+            "source_lang",
+            "target_lang",
+            "original_text_hash",
+            "original_text",
+            "translated_text",
+            "created_at",
+        )
+        values: dict[str, str] = {}
+        for field in required_fields:
+            raw_value = value.get(field)
+            if not isinstance(raw_value, str):
+                raise CacheImportError(f"entry #{index} field {field!r} must be a string")
+            values[field] = raw_value
+
+        expected_hash = text_hash(values["original_text"])
+        if values["original_text_hash"] != expected_hash:
+            raise CacheImportError(f"entry #{index} has an invalid original_text_hash")
+
+        return cls(**values)
+
+    def to_mapping(self) -> dict[str, str]:
+        return {
+            "source_lang": self.source_lang,
+            "target_lang": self.target_lang,
+            "original_text_hash": self.original_text_hash,
+            "original_text": self.original_text,
+            "translated_text": self.translated_text,
+            "created_at": self.created_at,
+        }
+
+
+@dataclass(frozen=True)
+class CacheDeleteReport:
+    matched: int
+    deleted: int
+
+
+@dataclass(frozen=True)
+class CacheExportReport:
+    path: Path
+    exported: int
+
+
+@dataclass(frozen=True)
+class CacheImportReport:
+    imported: int
+    skipped: int
+    replaced: int
+
+    @property
+    def total_read(self) -> int:
+        return self.imported + self.skipped + self.replaced
+
+
 class TranslationCache:
+    EXPORT_VERSION = 1
+
     def __init__(self, path: str | Path) -> None:
         self.path = Path(path)
         self.path.parent.mkdir(parents=True, exist_ok=True)
@@ -81,6 +175,194 @@ class TranslationCache:
             ),
         )
         self.connection.commit()
+
+    def summary(
+        self,
+        *,
+        source_lang: str | None = None,
+        target_lang: str | None = None,
+        before: str | None = None,
+    ) -> tuple[CacheSummaryRow, ...]:
+        where_sql, params = _cache_filter_sql(source_lang=source_lang, target_lang=target_lang, before=before)
+        rows = self.connection.execute(
+            f"""
+            SELECT
+                source_lang,
+                target_lang,
+                COUNT(*) AS entry_count,
+                MIN(created_at) AS first_created_at,
+                MAX(created_at) AS last_created_at
+            FROM translations
+            {where_sql}
+            GROUP BY source_lang, target_lang
+            ORDER BY source_lang, target_lang
+            """,
+            params,
+        ).fetchall()
+
+        return tuple(
+            CacheSummaryRow(
+                source_lang=row[0],
+                target_lang=row[1],
+                count=row[2],
+                first_created_at=row[3],
+                last_created_at=row[4],
+            )
+            for row in rows
+        )
+
+    def entries(
+        self,
+        *,
+        source_lang: str | None = None,
+        target_lang: str | None = None,
+        before: str | None = None,
+    ) -> tuple[CacheEntry, ...]:
+        where_sql, params = _cache_filter_sql(source_lang=source_lang, target_lang=target_lang, before=before)
+        rows = self.connection.execute(
+            f"""
+            SELECT
+                source_lang,
+                target_lang,
+                original_text_hash,
+                original_text,
+                translated_text,
+                created_at
+            FROM translations
+            {where_sql}
+            ORDER BY created_at, id
+            """,
+            params,
+        ).fetchall()
+
+        return tuple(CacheEntry(*row) for row in rows)
+
+    def delete_entries(
+        self,
+        *,
+        source_lang: str | None = None,
+        target_lang: str | None = None,
+        before: str | None = None,
+    ) -> CacheDeleteReport:
+        where_sql, params = _cache_filter_sql(source_lang=source_lang, target_lang=target_lang, before=before)
+        matched = self.connection.execute(
+            f"SELECT COUNT(*) FROM translations {where_sql}",
+            params,
+        ).fetchone()[0]
+        cursor = self.connection.execute(
+            f"DELETE FROM translations {where_sql}",
+            params,
+        )
+        self.connection.commit()
+        return CacheDeleteReport(matched=matched, deleted=cursor.rowcount)
+
+    def export_json(
+        self,
+        path: str | Path,
+        *,
+        source_lang: str | None = None,
+        target_lang: str | None = None,
+        before: str | None = None,
+        overwrite: bool = False,
+    ) -> CacheExportReport:
+        output_path = Path(path)
+        if output_path.exists() and not overwrite:
+            raise CacheExportError(f"export file already exists: {output_path}")
+
+        entries = self.entries(source_lang=source_lang, target_lang=target_lang, before=before)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(
+            json.dumps(
+                {
+                    "version": self.EXPORT_VERSION,
+                    "entries": [entry.to_mapping() for entry in entries],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        return CacheExportReport(path=output_path, exported=len(entries))
+
+    def import_json(self, path: str | Path, *, replace: bool = False) -> CacheImportReport:
+        input_path = Path(path)
+        try:
+            payload = json.loads(input_path.read_text(encoding="utf-8"))
+        except OSError as exc:
+            raise CacheImportError(f"could not read cache export: {exc}") from exc
+        except json.JSONDecodeError as exc:
+            raise CacheImportError(f"invalid JSON export: {exc}") from exc
+
+        entries = _parse_cache_export(payload)
+        imported = 0
+        skipped = 0
+        replaced = 0
+
+        with self.connection:
+            for entry in entries:
+                exists = self.connection.execute(
+                    """
+                    SELECT 1
+                    FROM translations
+                    WHERE source_lang = ?
+                      AND target_lang = ?
+                      AND original_text_hash = ?
+                    """,
+                    (entry.source_lang, entry.target_lang, entry.original_text_hash),
+                ).fetchone()
+
+                if exists and not replace:
+                    skipped += 1
+                    continue
+
+                if exists:
+                    self.connection.execute(
+                        """
+                        UPDATE translations
+                        SET original_text = ?,
+                            translated_text = ?,
+                            created_at = ?
+                        WHERE source_lang = ?
+                          AND target_lang = ?
+                          AND original_text_hash = ?
+                        """,
+                        (
+                            entry.original_text,
+                            entry.translated_text,
+                            entry.created_at,
+                            entry.source_lang,
+                            entry.target_lang,
+                            entry.original_text_hash,
+                        ),
+                    )
+                    replaced += 1
+                    continue
+
+                self.connection.execute(
+                    """
+                    INSERT INTO translations (
+                        source_lang,
+                        target_lang,
+                        original_text_hash,
+                        original_text,
+                        translated_text,
+                        created_at
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        entry.source_lang,
+                        entry.target_lang,
+                        entry.original_text_hash,
+                        entry.original_text,
+                        entry.translated_text,
+                        entry.created_at,
+                    ),
+                )
+                imported += 1
+
+        return CacheImportReport(imported=imported, skipped=skipped, replaced=replaced)
 
     def verify_writable(self) -> None:
         original_text = "__ayvu_cache_write_check__"
@@ -130,3 +412,40 @@ class TranslationCache:
 
     def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
         self.close()
+
+
+def _cache_filter_sql(
+    *,
+    source_lang: str | None,
+    target_lang: str | None,
+    before: str | None,
+) -> tuple[str, tuple[str, ...]]:
+    clauses: list[str] = []
+    params: list[str] = []
+    if source_lang:
+        clauses.append("source_lang = ?")
+        params.append(source_lang)
+    if target_lang:
+        clauses.append("target_lang = ?")
+        params.append(target_lang)
+    if before:
+        clauses.append("created_at < ?")
+        params.append(before)
+
+    if not clauses:
+        return "", ()
+
+    return "WHERE " + " AND ".join(clauses), tuple(params)
+
+
+def _parse_cache_export(payload: Any) -> tuple[CacheEntry, ...]:
+    if not isinstance(payload, dict):
+        raise CacheImportError("cache export must be a JSON object")
+    if payload.get("version") != TranslationCache.EXPORT_VERSION:
+        raise CacheImportError(f"unsupported cache export version: {payload.get('version')!r}")
+
+    raw_entries = payload.get("entries")
+    if not isinstance(raw_entries, list):
+        raise CacheImportError("cache export entries must be a list")
+
+    return tuple(CacheEntry.from_mapping(entry, index) for index, entry in enumerate(raw_entries, start=1))

--- a/src/ayvu/cli.py
+++ b/src/ayvu/cli.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
+from datetime import datetime, timezone
 from pathlib import Path
+import sqlite3
 from typing import NoReturn, Optional
 
 import typer
@@ -9,7 +11,7 @@ from rich.console import Console
 from rich.progress import BarColumn, Progress, SpinnerColumn, TaskProgressColumn, TextColumn, TimeElapsedColumn
 from rich.table import Table
 
-from .cache import TranslationCache
+from .cache import CacheError, CacheImportReport, CacheSummaryRow, TranslationCache
 from .cli_progress import TranslationProgress, TranslationProgressSnapshot
 from .config import (
     DEFAULT_BOOKS_DIR,
@@ -67,10 +69,13 @@ from .validation import validate_output_epub
 
 
 app = typer.Typer(help="Translate local EPUB files with a local HTTP translator.")
+cache_app = typer.Typer(help="Inspect, clean, export, and import the translation cache.")
+app.add_typer(cache_app, name="cache")
 console = Console()
 DEFAULT_SOURCE_LANGUAGE = "en"
 DEFAULT_TARGET_LANGUAGE = "pt"
 DEFAULT_TRANSLATOR_URL = "http://localhost:5000"
+DEFAULT_CACHE_PATH = Path(".cache/traducoes.sqlite")
 DEFAULT_PREVIEW_DOCUMENT_LIMIT = 12
 GUIDED_TRANSLATE_OPTION = "1"
 GUIDED_PREVIEW_OPTION = "2"
@@ -231,6 +236,153 @@ def languages(
     _print_languages(available_languages)
 
 
+@cache_app.command("inspect")
+def cache_inspect(
+    ctx: typer.Context,
+    cache_path: Path = typer.Option(DEFAULT_CACHE_PATH, "--cache", help="SQLite cache path."),
+    source: Optional[str] = typer.Option(None, "--source", help="Filter by source language."),
+    target: Optional[str] = typer.Option(None, "--target", help="Filter by target language."),
+    before: Optional[str] = typer.Option(
+        None,
+        "--before",
+        help="Only include entries created before this date (YYYY-MM-DD or ISO datetime).",
+    ),
+) -> None:
+    """Show cached translations grouped by language pair."""
+    mode = ctx.obj.get("mode", UserMode.DEVELOPER)
+    before_value = _normalize_cache_before(before, mode)
+    try:
+        with TranslationCache(cache_path) as cache:
+            rows = cache.summary(source_lang=source, target_lang=target, before=before_value)
+    except (CacheError, OSError, sqlite3.Error) as exc:
+        _print_expected_error(
+            "Não foi possível inspecionar o cache.",
+            "Verifique o caminho informado em --cache e tente novamente.",
+            mode,
+            detail=str(exc),
+        )
+        raise typer.Exit(code=1) from exc
+
+    _print_cache_summary(rows, cache_path)
+
+
+@cache_app.command("clean")
+def cache_clean(
+    ctx: typer.Context,
+    cache_path: Path = typer.Option(DEFAULT_CACHE_PATH, "--cache", help="SQLite cache path."),
+    source: Optional[str] = typer.Option(None, "--source", help="Remove only this source language."),
+    target: Optional[str] = typer.Option(None, "--target", help="Remove only this target language."),
+    before: Optional[str] = typer.Option(
+        None,
+        "--before",
+        help="Remove only entries created before this date (YYYY-MM-DD or ISO datetime).",
+    ),
+    all_entries: bool = typer.Option(False, "--all", help="Allow cleaning the whole cache."),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Show how many entries would be removed."),
+    yes: bool = typer.Option(False, "--yes", help="Confirm destructive cleanup."),
+) -> None:
+    """Remove cache entries by filter or clear the whole cache."""
+    mode = ctx.obj.get("mode", UserMode.DEVELOPER)
+    before_value = _normalize_cache_before(before, mode)
+    _validate_cache_clean_options(
+        source=source,
+        target=target,
+        before=before_value,
+        all_entries=all_entries,
+        dry_run=dry_run,
+        yes=yes,
+        mode=mode,
+    )
+
+    try:
+        with TranslationCache(cache_path) as cache:
+            if dry_run:
+                matched = _count_cache_entries(cache, source=source, target=target, before=before_value)
+                console.print(f"[yellow]Dry run:[/yellow] {_plural_cache_entries(matched)} would be removed.")
+                return
+
+            report = cache.delete_entries(source_lang=source, target_lang=target, before=before_value)
+    except (CacheError, OSError, sqlite3.Error) as exc:
+        _print_expected_error(
+            "Não foi possível limpar o cache.",
+            "Verifique o caminho informado em --cache e tente novamente.",
+            mode,
+            detail=str(exc),
+        )
+        raise typer.Exit(code=1) from exc
+
+    console.print(f"[green]Deleted {_plural_cache_entries(report.deleted)}.[/green]")
+
+
+@cache_app.command("export")
+def cache_export(
+    ctx: typer.Context,
+    output: Path = typer.Argument(..., dir_okay=False, help="JSON file to write."),
+    cache_path: Path = typer.Option(DEFAULT_CACHE_PATH, "--cache", help="SQLite cache path."),
+    source: Optional[str] = typer.Option(None, "--source", help="Export only this source language."),
+    target: Optional[str] = typer.Option(None, "--target", help="Export only this target language."),
+    before: Optional[str] = typer.Option(
+        None,
+        "--before",
+        help="Export only entries created before this date (YYYY-MM-DD or ISO datetime).",
+    ),
+    overwrite: bool = typer.Option(False, "--overwrite", help="Allow replacing an existing JSON file."),
+) -> None:
+    """Export cached translations to readable JSON."""
+    mode = ctx.obj.get("mode", UserMode.DEVELOPER)
+    before_value = _normalize_cache_before(before, mode)
+    try:
+        with TranslationCache(cache_path) as cache:
+            report = cache.export_json(
+                output,
+                source_lang=source,
+                target_lang=target,
+                before=before_value,
+                overwrite=overwrite,
+            )
+    except (CacheError, OSError, sqlite3.Error) as exc:
+        _print_expected_error(
+            "Não foi possível exportar o cache.",
+            "Verifique --cache, o caminho de saída e tente novamente.",
+            mode,
+            detail=str(exc),
+        )
+        raise typer.Exit(code=1) from exc
+
+    console.print(f"[green]Cache export saved to:[/green] {report.path}")
+    console.print(f"Entries exported: {report.exported}")
+
+
+@cache_app.command("import")
+def cache_import(
+    ctx: typer.Context,
+    input_path: Path = typer.Argument(
+        ...,
+        exists=True,
+        dir_okay=False,
+        readable=True,
+        help="JSON export to import.",
+    ),
+    cache_path: Path = typer.Option(DEFAULT_CACHE_PATH, "--cache", help="SQLite cache path."),
+    replace: bool = typer.Option(False, "--replace", help="Replace existing cache entries."),
+) -> None:
+    """Import cached translations from an Ayvu JSON export."""
+    mode = ctx.obj.get("mode", UserMode.DEVELOPER)
+    try:
+        with TranslationCache(cache_path) as cache:
+            report = cache.import_json(input_path, replace=replace)
+    except (CacheError, OSError, sqlite3.Error) as exc:
+        _print_expected_error(
+            "Não foi possível importar o cache.",
+            "Confirme que o arquivo foi exportado pelo Ayvu e tente novamente.",
+            mode,
+            detail=str(exc),
+        )
+        raise typer.Exit(code=1) from exc
+
+    _print_cache_import_report(report)
+
+
 @app.command()
 def translate(
     ctx: typer.Context,
@@ -271,7 +423,7 @@ def translate(
     ),
     translator_name: str = typer.Option("libretranslate", "--translator", help="Translator backend."),
     url: str = typer.Option(DEFAULT_TRANSLATOR_URL, "--url", help="Translator base URL."),
-    cache_path: Path = typer.Option(Path(".cache/traducoes.sqlite"), "--cache", help="SQLite cache path."),
+    cache_path: Path = typer.Option(DEFAULT_CACHE_PATH, "--cache", help="SQLite cache path."),
     glossary_path: Optional[Path] = typer.Option(None, "--glossary", help="Optional JSON glossary."),
     profile_name: Optional[str] = typer.Option(
         None,
@@ -377,6 +529,129 @@ def _print_expected_error(summary: str, next_step: str, mode: UserMode, detail: 
     if mode == UserMode.DEVELOPER and detail:
         console.print(f"[dim]Detalhe técnico: {detail}[/dim]")
     console.print(next_step)
+
+
+def _normalize_cache_before(value: str | None, mode: UserMode) -> str | None:
+    if value is None:
+        return None
+
+    raw_value = value.strip()
+    if not raw_value:
+        _print_expected_error(
+            "Data de cache inválida.",
+            "Use --before no formato YYYY-MM-DD ou em formato ISO, como 2026-01-31T10:30:00.",
+            mode,
+        )
+        raise typer.Exit(code=1)
+
+    try:
+        if len(raw_value) == 10:
+            parsed = datetime.strptime(raw_value, "%Y-%m-%d")
+        else:
+            parsed = datetime.fromisoformat(raw_value.replace("T", " "))
+    except ValueError as exc:
+        _print_expected_error(
+            "Data de cache inválida.",
+            "Use --before no formato YYYY-MM-DD ou em formato ISO, como 2026-01-31T10:30:00.",
+            mode,
+            detail=str(exc),
+        )
+        raise typer.Exit(code=1) from exc
+
+    if parsed.tzinfo is not None:
+        parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
+
+    return parsed.strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _validate_cache_clean_options(
+    *,
+    source: str | None,
+    target: str | None,
+    before: str | None,
+    all_entries: bool,
+    dry_run: bool,
+    yes: bool,
+    mode: UserMode,
+) -> None:
+    has_filter = bool(source or target or before)
+    if all_entries and has_filter:
+        _print_expected_error(
+            "Opções de limpeza de cache conflitantes.",
+            "Use --all sozinho para limpar tudo, ou remova --all e use filtros como --source, --target ou --before.",
+            mode,
+        )
+        raise typer.Exit(code=1)
+
+    if not all_entries and not has_filter:
+        _print_expected_error(
+            "A limpeza de cache precisa de um escopo explícito.",
+            "Informe --source, --target, --before ou use --all para limpar o cache inteiro.",
+            mode,
+        )
+        raise typer.Exit(code=1)
+
+    if dry_run:
+        return
+
+    if not yes:
+        _print_expected_error(
+            "Limpeza de cache não confirmada.",
+            "Use --dry-run para pré-visualizar ou adicione --yes para confirmar a remoção.",
+            mode,
+        )
+        raise typer.Exit(code=1)
+
+
+def _count_cache_entries(
+    cache: TranslationCache,
+    *,
+    source: str | None,
+    target: str | None,
+    before: str | None,
+) -> int:
+    rows = cache.summary(source_lang=source, target_lang=target, before=before)
+    return sum(row.count for row in rows)
+
+
+def _print_cache_summary(rows: tuple[CacheSummaryRow, ...], cache_path: Path) -> None:
+    console.print(f"[dim]Cache path:[/dim] {cache_path}")
+    if not rows:
+        console.print("No cache entries found.")
+        return
+
+    table = Table(title="Cache summary")
+    table.add_column("Source")
+    table.add_column("Target")
+    table.add_column("Entries")
+    table.add_column("First entry")
+    table.add_column("Last entry")
+    for row in rows:
+        table.add_row(
+            row.source_lang,
+            row.target_lang,
+            str(row.count),
+            row.first_created_at,
+            row.last_created_at,
+        )
+    console.print(table)
+    console.print(f"Total: {_plural_cache_entries(sum(row.count for row in rows))}")
+
+
+def _print_cache_import_report(report: CacheImportReport) -> None:
+    table = Table(title="Cache import", show_header=False)
+    table.add_column("Metric", style="bold")
+    table.add_column("Value")
+    table.add_row("Entries read", str(report.total_read))
+    table.add_row("Imported", str(report.imported))
+    table.add_row("Skipped existing", str(report.skipped))
+    table.add_row("Replaced", str(report.replaced))
+    console.print(table)
+
+
+def _plural_cache_entries(count: int) -> str:
+    noun = "entry" if count == 1 else "entries"
+    return f"{count} cache {noun}"
 
 
 def _print_epub_read_error(detail: str, mode: UserMode) -> None:
@@ -945,7 +1220,7 @@ def _run_preview(
     target: str = DEFAULT_TARGET_LANGUAGE,
     translator_name: str = "libretranslate",
     url: str = DEFAULT_TRANSLATOR_URL,
-    cache_path: Path = Path(".cache/traducoes.sqlite"),
+    cache_path: Path = DEFAULT_CACHE_PATH,
     glossary_path: Path | None = None,
     timeout: float = 30.0,
     retries: int = 2,
@@ -1509,7 +1784,7 @@ def _run_guided_translation(config: AyvuConfig) -> None:
         target=target,
         translator_name="libretranslate",
         url=DEFAULT_TRANSLATOR_URL,
-        cache_path=Path(".cache/traducoes.sqlite"),
+        cache_path=DEFAULT_CACHE_PATH,
         glossary_path=glossary_path,
         profile_name=profile_name,
         dry_run=False,

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,9 +1,32 @@
-from ayvu.cache import CacheKey, TranslationCache
+import json
+
+import pytest
+
+from ayvu.cache import CacheImportError, CacheKey, TranslationCache, text_hash
 from ayvu.domain import LanguagePair
 
 
 def _cache_key(text: str, source: str = "en", target: str = "pt") -> CacheKey:
     return CacheKey(text=text, language_pair=LanguagePair(source=source, target=target))
+
+
+def _set_created_at(cache: TranslationCache, key: CacheKey, created_at: str) -> None:
+    cache.connection.execute(
+        """
+        UPDATE translations
+        SET created_at = ?
+        WHERE source_lang = ?
+          AND target_lang = ?
+          AND original_text_hash = ?
+        """,
+        (
+            created_at,
+            key.language_pair.source,
+            key.language_pair.target,
+            key.original_text_hash,
+        ),
+    )
+    cache.connection.commit()
 
 
 def test_cache_round_trip(tmp_path):
@@ -30,3 +53,140 @@ def test_cache_writable_check_does_not_persist_probe(tmp_path):
         cache.verify_writable()
 
         assert cache.get(_cache_key("__ayvu_cache_write_check__", "ayvu", "ayvu")) is None
+
+
+def test_cache_summary_groups_by_language_pair_with_dates(tmp_path):
+    cache_path = tmp_path / "translations.sqlite"
+    with TranslationCache(cache_path) as cache:
+        first = _cache_key("Hello", "en", "pt")
+        second = _cache_key("World", "en", "pt")
+        third = _cache_key("Hola", "es", "pt")
+        cache.set(first, "Olá")
+        cache.set(second, "Mundo")
+        cache.set(third, "Olá")
+        _set_created_at(cache, first, "2024-01-01 10:00:00")
+        _set_created_at(cache, second, "2024-01-03 10:00:00")
+        _set_created_at(cache, third, "2024-01-02 10:00:00")
+
+        rows = cache.summary()
+
+    assert len(rows) == 2
+    assert rows[0].source_lang == "en"
+    assert rows[0].target_lang == "pt"
+    assert rows[0].count == 2
+    assert rows[0].first_created_at == "2024-01-01 10:00:00"
+    assert rows[0].last_created_at == "2024-01-03 10:00:00"
+    assert rows[1].source_lang == "es"
+    assert rows[1].count == 1
+
+
+def test_cache_delete_entries_uses_filters(tmp_path):
+    cache_path = tmp_path / "translations.sqlite"
+    with TranslationCache(cache_path) as cache:
+        old_entry = _cache_key("Hello", "en", "pt")
+        new_entry = _cache_key("World", "en", "pt")
+        other_pair = _cache_key("Hello", "en", "es")
+        cache.set(old_entry, "Olá")
+        cache.set(new_entry, "Mundo")
+        cache.set(other_pair, "Hola")
+        _set_created_at(cache, old_entry, "2024-01-01 10:00:00")
+        _set_created_at(cache, new_entry, "2024-02-01 10:00:00")
+        _set_created_at(cache, other_pair, "2024-01-01 10:00:00")
+
+        report = cache.delete_entries(source_lang="en", target_lang="pt", before="2024-02-01 00:00:00")
+
+        assert report.matched == 1
+        assert report.deleted == 1
+        assert cache.get(old_entry) is None
+        assert cache.get(new_entry) == "Mundo"
+        assert cache.get(other_pair) == "Hola"
+
+
+def test_cache_export_and_import_json(tmp_path):
+    source_path = tmp_path / "source.sqlite"
+    export_path = tmp_path / "cache-export.json"
+    first = _cache_key("Hello", "en", "pt")
+    second = _cache_key("World", "en", "pt")
+
+    with TranslationCache(source_path) as cache:
+        cache.set(first, "Olá")
+        cache.set(second, "Mundo")
+        _set_created_at(cache, first, "2024-01-01 10:00:00")
+        _set_created_at(cache, second, "2024-01-02 10:00:00")
+        export_report = cache.export_json(export_path, source_lang="en", target_lang="pt")
+
+    assert export_report.exported == 2
+    payload = json.loads(export_path.read_text(encoding="utf-8"))
+    assert payload["version"] == 1
+    assert [entry["original_text"] for entry in payload["entries"]] == ["Hello", "World"]
+
+    target_path = tmp_path / "target.sqlite"
+    with TranslationCache(target_path) as cache:
+        import_report = cache.import_json(export_path)
+        skipped_report = cache.import_json(export_path)
+
+        assert import_report.imported == 2
+        assert import_report.skipped == 0
+        assert cache.get(first) == "Olá"
+        assert skipped_report.imported == 0
+        assert skipped_report.skipped == 2
+
+
+def test_cache_import_json_can_replace_existing_entries(tmp_path):
+    cache_path = tmp_path / "translations.sqlite"
+    export_path = tmp_path / "cache-export.json"
+    key = _cache_key("Hello", "en", "pt")
+    export_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "entries": [
+                    {
+                        "source_lang": "en",
+                        "target_lang": "pt",
+                        "original_text_hash": key.original_text_hash,
+                        "original_text": "Hello",
+                        "translated_text": "Oi",
+                        "created_at": "2024-01-01 10:00:00",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with TranslationCache(cache_path) as cache:
+        cache.set(key, "Olá")
+
+        report = cache.import_json(export_path, replace=True)
+
+        assert report.imported == 0
+        assert report.replaced == 1
+        assert cache.get(key) == "Oi"
+
+
+def test_cache_import_json_rejects_hash_mismatch(tmp_path):
+    cache_path = tmp_path / "translations.sqlite"
+    export_path = tmp_path / "bad-export.json"
+    export_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "entries": [
+                    {
+                        "source_lang": "en",
+                        "target_lang": "pt",
+                        "original_text_hash": text_hash("different text"),
+                        "original_text": "Hello",
+                        "translated_text": "Olá",
+                        "created_at": "2024-01-01 10:00:00",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with TranslationCache(cache_path) as cache:
+        with pytest.raises(CacheImportError, match="invalid original_text_hash"):
+            cache.import_json(export_path)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ import pytest
 from ebooklib import epub
 from typer.testing import CliRunner
 
+from ayvu.cache import CacheKey, TranslationCache
 from ayvu.cli import (
     DEFAULT_PREVIEW_DOCUMENT_LIMIT,
     _offer_markdown_report,
@@ -26,6 +27,32 @@ from ayvu.validation import ValidationResult
 
 
 runner = CliRunner()
+
+
+def _seed_cache_entry(
+    cache_path: Path,
+    text: str,
+    translated: str,
+    *,
+    source: str = "en",
+    target: str = "pt",
+    created_at: str = "2024-01-01 10:00:00",
+) -> CacheKey:
+    key = CacheKey(text=text, language_pair=LanguagePair(source=source, target=target))
+    with TranslationCache(cache_path) as cache:
+        cache.set(key, translated)
+        cache.connection.execute(
+            """
+            UPDATE translations
+            SET created_at = ?
+            WHERE source_lang = ?
+              AND target_lang = ?
+              AND original_text_hash = ?
+            """,
+            (created_at, source, target, key.original_text_hash),
+        )
+        cache.connection.commit()
+    return key
 
 
 @pytest.fixture(autouse=True)
@@ -180,6 +207,96 @@ def test_languages_command_reports_failure_without_traceback(monkeypatch):
     assert "Não foi possível listar os idiomas." in result.output
     assert "server unavailable" in result.output
     assert "Inicie o LibreTranslate" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_cache_inspect_command_lists_entries_by_language_pair(tmp_path):
+    cache_path = tmp_path / "translations.sqlite"
+    _seed_cache_entry(cache_path, "Hello", "Olá", created_at="2024-01-01 10:00:00")
+    _seed_cache_entry(cache_path, "World", "Mundo", created_at="2024-01-02 10:00:00")
+    _seed_cache_entry(cache_path, "Hola", "Olá", source="es", target="pt", created_at="2024-01-03 10:00:00")
+
+    result = runner.invoke(app, ["cache", "inspect", "--cache", str(cache_path)])
+
+    assert result.exit_code == 0
+    assert "Cache summary" in result.output
+    assert "en" in result.output
+    assert "es" in result.output
+    assert "pt" in result.output
+    assert "2024-01-01 10:00:00" in result.output
+    assert "3 cache entries" in result.output
+
+
+def test_cache_clean_requires_filter_or_all(tmp_path):
+    cache_path = tmp_path / "translations.sqlite"
+    _seed_cache_entry(cache_path, "Hello", "Olá")
+
+    result = runner.invoke(app, ["cache", "clean", "--cache", str(cache_path), "--yes"])
+
+    assert result.exit_code == 1
+    assert "escopo explícito" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_cache_clean_dry_run_does_not_delete_entries(tmp_path):
+    cache_path = tmp_path / "translations.sqlite"
+    key = _seed_cache_entry(cache_path, "Hello", "Olá")
+
+    result = runner.invoke(app, ["cache", "clean", "--cache", str(cache_path), "--source", "en", "--dry-run"])
+
+    assert result.exit_code == 0
+    assert "Dry run" in result.output
+    assert "1 cache entry would be removed" in result.output
+    with TranslationCache(cache_path) as cache:
+        assert cache.get(key) == "Olá"
+
+
+def test_cache_clean_deletes_confirmed_entries(tmp_path):
+    cache_path = tmp_path / "translations.sqlite"
+    removed_key = _seed_cache_entry(cache_path, "Hello", "Olá", target="pt")
+    kept_key = _seed_cache_entry(cache_path, "Hello", "Hola", target="es")
+
+    result = runner.invoke(app, ["cache", "clean", "--cache", str(cache_path), "--target", "pt", "--yes"])
+
+    assert result.exit_code == 0
+    assert "Deleted 1 cache entry" in result.output
+    with TranslationCache(cache_path) as cache:
+        assert cache.get(removed_key) is None
+        assert cache.get(kept_key) == "Hola"
+
+
+def test_cache_export_and_import_commands(tmp_path):
+    source_cache = tmp_path / "source.sqlite"
+    target_cache = tmp_path / "target.sqlite"
+    export_path = tmp_path / "cache-export.json"
+    key = _seed_cache_entry(source_cache, "Hello", "Olá")
+
+    export_result = runner.invoke(
+        app,
+        ["cache", "export", str(export_path), "--cache", str(source_cache), "--source", "en"],
+    )
+    import_result = runner.invoke(
+        app,
+        ["cache", "import", str(export_path), "--cache", str(target_cache)],
+    )
+
+    assert export_result.exit_code == 0
+    assert "Cache export saved to" in export_result.output
+    assert "Entries exported: 1" in export_result.output
+    assert import_result.exit_code == 0
+    assert "Cache import" in import_result.output
+    assert "Imported" in import_result.output
+    with TranslationCache(target_cache) as cache:
+        assert cache.get(key) == "Olá"
+
+
+def test_cache_command_reports_invalid_before_without_traceback(tmp_path):
+    cache_path = tmp_path / "translations.sqlite"
+
+    result = runner.invoke(app, ["cache", "inspect", "--cache", str(cache_path), "--before", "not-a-date"])
+
+    assert result.exit_code == 1
+    assert "Data de cache inválida." in result.output
     assert "Traceback" not in result.output
 
 


### PR DESCRIPTION
## Objective

Add user-facing commands to inspect, clean, export, and import the translation cache.

## What changed

- Added structured cache summary, delete, JSON export, and JSON import operations in the cache module.
- Added `ayvu cache inspect`, `ayvu cache clean`, `ayvu cache export`, and `ayvu cache import` commands with filters and destructive cleanup confirmation.
- Documented cache management commands, JSON privacy implications, and the new behavior in user and technical docs.
- Added focused cache and CLI coverage for inspection, cleanup protections, export, import, replacement, and invalid export handling.

## Out of scope

- Changing the cache key scope for backend, model, glossary, or profile-specific translation outputs.
- Changing the normal translation or resume flow.

## Validation

- `uv run pytest`: 258 tests passing.
- `git diff --check`: no errors.

## Related issue

Closes #95