### PR TITLE
Add cache-only translation mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ O EPUB original nunca é alterado. A saída é gravada em um novo arquivo `.epub
 - Biblioteca inicial para listar originais e traduções e abrir EPUBs no leitor configurado ou padrão do sistema.
 - Checagens internas antes de iniciar traduções reais.
 - Modo `dry-run` para simular o processamento sem gerar arquivo.
+- Modo `cache-only` para reconstruir o EPUB usando apenas o cache, sem chamar o tradutor.
 - Extração de texto visível para Markdown.
 - Relatório final no terminal e opção de salvar relatório Markdown no modo comum.
 - Validação do EPUB gerado com barra de progresso, avisando sobre capítulos vazios, links internos quebrados e imagens referenciadas ausentes.
@@ -356,7 +357,16 @@ uv run ayvu translate livro.epub \
   --dry-run
 ```
 
-Ao final da tradução, o Ayvu mostra um relatório no terminal com o EPUB original, idiomas, saída calculada, arquivo de revisão quando solicitado, capítulos processados, textos traduzidos, cache, erros e resumo do uso do glossário quando houver glossário configurado. No **Modo Comum**, também pergunta se deve salvar esse relatório em Markdown em `~/Documentos/Livros/Relatorios`. Em traduções em batch, o Ayvu salva automaticamente um relatório Markdown separado para cada livro.
+Reconstruir usando apenas o cache, sem chamar o tradutor:
+
+```bash
+uv run ayvu translate livro.epub \
+  --output teste.epub \
+  --cache-only \
+  --missing-output faltantes.txt
+```
+
+Ao final da tradução, o Ayvu mostra um relatório no terminal com o EPUB original, idiomas, saída calculada, arquivo de revisão quando solicitado, capítulos processados, textos traduzidos, cache, textos ausentes do cache (no modo cache-only), erros e resumo do uso do glossário quando houver glossário configurado. No **Modo Comum**, também pergunta se deve salvar esse relatório em Markdown em `~/Documentos/Livros/Relatorios`. Em traduções em batch, o Ayvu salva automaticamente um relatório Markdown separado para cada livro.
 
 Extrair texto visível para Markdown:
 
@@ -457,6 +467,39 @@ automaticamente.
 
 Ao executar `uv run ayvu`, o modo comum procura estados de tradução em andamento
 nessa pasta e oferece retomar uma execução detectada.
+
+### Modo cache-only
+
+O modo `--cache-only` reconstrói o EPUB usando **apenas** o que já está no cache e
+**nunca** chama o tradutor. Ele serve para testar a reconstrução, reaproveitar
+trabalho anterior de forma controlada e evitar chamadas acidentais ao tradutor.
+Como não há tráfego de rede, não é preciso um servidor LibreTranslate ativo.
+
+```bash
+uv run ayvu translate livro.epub \
+  --output livro-ptbr.epub \
+  --cache .cache/traducoes.sqlite \
+  --cache-only \
+  --missing-output faltantes.txt
+```
+
+Comportamento:
+
+- Trechos presentes no cache são aplicados (com glossário, quando configurado).
+- Trechos ausentes do cache ficam no idioma original e são contados como
+  `Texts missing` no relatório.
+- Por padrão, o EPUB é gerado mesmo com cobertura parcial. Use
+  `--require-full-cache` para gerar somente quando todos os trechos estiverem no
+  cache; se faltar algum, nada é escrito e o comando falha.
+- `--missing-output CAMINHO` salva os trechos originais ausentes do cache. Sem
+  essa opção, em cache-only com faltantes, o arquivo é gravado automaticamente na
+  pasta de Relatórios. O arquivo é gerado mesmo quando `--require-full-cache`
+  bloqueia a saída, para mostrar o que precisa ser traduzido.
+
+Diferença para a retomada normal: a retomada reexecuta a tradução e **chama o
+tradutor** para os trechos ainda não cacheados, gravando estado em
+`~/Documentos/Livros/Processando`. O cache-only nunca chama o tradutor, não cria
+estado de retomada e não exige servidor ativo.
 
 ## Biblioteca
 

--- a/docs/tutorial-modo-comum-e-dev.md
+++ b/docs/tutorial-modo-comum-e-dev.md
@@ -456,6 +456,41 @@ uv run ayvu translate livro.epub \
   --dry-run
 ```
 
+### Reconstruir usando apenas o cache
+
+O modo `--cache-only` monta o EPUB só com o que já está no cache e nunca chama o
+tradutor (não precisa de servidor ativo). Trechos ausentes do cache ficam no
+idioma original e são contados como `Texts missing` no relatório.
+
+```bash
+uv run ayvu translate livro.epub \
+  --output teste.epub \
+  --source en \
+  --target pt \
+  --cache .cache/traducoes.sqlite \
+  --cache-only \
+  --missing-output faltantes.txt
+```
+
+Por padrão, o EPUB é gerado mesmo com cobertura parcial. Para gerar somente
+quando todos os trechos estiverem no cache, adicione `--require-full-cache`: se
+faltar algum, nada é escrito e o comando falha, mas o arquivo de faltantes ainda
+é gravado.
+
+```bash
+uv run ayvu translate livro.epub \
+  --output teste.epub \
+  --source en \
+  --target pt \
+  --cache .cache/traducoes.sqlite \
+  --cache-only \
+  --require-full-cache
+```
+
+Diferente da retomada (que chama o tradutor para os trechos pendentes e grava
+estado em `~/Documentos/Livros/Processando`), o cache-only nunca chama o tradutor
+e não cria estado de retomada.
+
 ### Extrair texto visível para Markdown
 
 ```bash

--- a/src/ayvu/cli.py
+++ b/src/ayvu/cli.py
@@ -456,6 +456,21 @@ def translate(
         help="Also translate the alt text of images. Text inside images (OCR) is out of scope.",
     ),
     chunk_limit: int = typer.Option(3000, "--chunk-limit", help="Maximum characters sent per request."),
+    cache_only: bool = typer.Option(
+        False,
+        "--cache-only",
+        help="Rebuild the EPUB using only cached translations; never call the translator.",
+    ),
+    require_full_cache: bool = typer.Option(
+        False,
+        "--require-full-cache",
+        help="With --cache-only, only write the EPUB when every text is in the cache.",
+    ),
+    missing_output: Optional[Path] = typer.Option(
+        None,
+        "--missing-output",
+        help="With --cache-only, path to save the original texts missing from the cache.",
+    ),
 ) -> None:
     """Translate EPUB visible text while preserving EPUB structure."""
     mode = ctx.obj.get("mode", UserMode.DEVELOPER)
@@ -466,6 +481,12 @@ def translate(
         output=output,
         output_dir=output_dir,
         review_output=review_output,
+        mode=mode,
+    )
+    _validate_cache_only_options(
+        cache_only=cache_only,
+        require_full_cache=require_full_cache,
+        missing_output=missing_output,
         mode=mode,
     )
     resolved_output_dir = _resolve_translation_output_dir(output_dir, mode=mode)
@@ -494,6 +515,8 @@ def translate(
             config=config,
             translate_metadata=translate_metadata,
             translate_alt_text=translate_alt_text,
+            cache_only=cache_only,
+            require_full_cache=require_full_cache,
         )
         return
 
@@ -520,6 +543,9 @@ def translate(
         config=config,
         translate_metadata=translate_metadata,
         translate_alt_text=translate_alt_text,
+        cache_only=cache_only,
+        require_full_cache=require_full_cache,
+        missing_output=missing_output,
         confirm_output_location=resolved_output_dir is None,
     )
 
@@ -875,6 +901,32 @@ def _validate_translate_command_options(
         raise typer.Exit(code=1)
 
 
+def _validate_cache_only_options(
+    cache_only: bool,
+    require_full_cache: bool,
+    missing_output: Path | None,
+    mode: UserMode,
+) -> None:
+    if cache_only:
+        return
+
+    if require_full_cache:
+        _print_expected_error(
+            "--require-full-cache exige --cache-only.",
+            "Adicione --cache-only para reconstruir apenas com o cache, ou remova --require-full-cache.",
+            mode,
+        )
+        raise typer.Exit(code=1)
+
+    if missing_output is not None:
+        _print_expected_error(
+            "--missing-output exige --cache-only.",
+            "Adicione --cache-only para listar os textos ausentes do cache, ou remova --missing-output.",
+            mode,
+        )
+        raise typer.Exit(code=1)
+
+
 def _resolve_translation_output_dir(output_dir: Path | None, mode: UserMode) -> Path | None:
     if output_dir is None:
         return None
@@ -913,6 +965,9 @@ def _run_translation(
     config: AyvuConfig | None = None,
     translate_metadata: bool = False,
     translate_alt_text: bool = False,
+    cache_only: bool = False,
+    require_full_cache: bool = False,
+    missing_output: Path | None = None,
     output_dir: Path | None = None,
     auto_save_markdown_report: bool = False,
     report_dir: Path | None = None,
@@ -939,6 +994,8 @@ def _run_translation(
         translate_metadata=translate_metadata,
         translate_alt_text=translate_alt_text,
         chapter_selection=chapter_selection,
+        cache_only=cache_only,
+        require_full_cache=require_full_cache,
     )
     if chapter_selection is not None:
         selected_chapters = _resolve_chapter_selection_for_display(
@@ -977,6 +1034,7 @@ def _run_translation(
             retries=retries,
             language_pair=language_pair,
             dry_run=dry_run,
+            cache_only=cache_only,
         )
     except PreflightError as exc:
         _print_expected_error(exc.summary, exc.next_step, mode, detail=exc.detail)
@@ -986,7 +1044,7 @@ def _run_translation(
 
     resume_store: ResumeStateStore | None = None
     resume_state: TranslationResumeState | None = None
-    if not dry_run:
+    if not dry_run and not cache_only:
         resume_store, resume_state = _save_running_resume_state(
             epub_path=epub_path,
             output_path=output_path,
@@ -1040,7 +1098,18 @@ def _run_translation(
         _write_review_output(review_output_path, review_segments, overwrite=overwrite, mode=mode)
         report.review_output_path = review_output_path
 
-    validation = None if dry_run else _validate_with_progress(output_path)
+    if cache_only and report.missing_texts:
+        _save_missing_texts(
+            report,
+            missing_output=missing_output,
+            overwrite=overwrite,
+            directory=report_dir,
+            mode=mode,
+        )
+
+    validation = (
+        _validate_with_progress(output_path) if report.output_written and not dry_run else None
+    )
     validation_warnings = validation.warnings if validation else []
 
     _print_report(report, dry_run, validation_warnings)
@@ -1055,6 +1124,10 @@ def _run_translation(
         console.print(f"[green]Report saved to:[/green] {markdown_report_path}")
     else:
         _offer_markdown_report(report, dry_run, validation_warnings, mode=mode)
+
+    if cache_only and require_full_cache and not report.output_written:
+        _print_cache_coverage_blocked(report, mode)
+        raise typer.Exit(code=1)
 
     if validation is not None:
         if validation.ok:
@@ -1095,6 +1168,8 @@ def _run_batch_translation(
     config: AyvuConfig,
     translate_metadata: bool = False,
     translate_alt_text: bool = False,
+    cache_only: bool = False,
+    require_full_cache: bool = False,
 ) -> None:
     resolved_output_dir = output_dir or _translated_books_dir(config)
     report_dir = _reports_dir(config)
@@ -1133,6 +1208,8 @@ def _run_batch_translation(
                 config=config,
                 translate_metadata=translate_metadata,
                 translate_alt_text=translate_alt_text,
+                cache_only=cache_only,
+                require_full_cache=require_full_cache,
                 auto_save_markdown_report=True,
                 report_dir=report_dir,
                 confirm_output_location=False,
@@ -1488,6 +1565,8 @@ def _print_report(
     table.add_row("Chapters processed", str(report.chapters_processed))
     table.add_row("Texts translated", str(report.texts_translated))
     table.add_row("Texts from cache", str(report.texts_from_cache))
+    if report.texts_missing:
+        table.add_row("Texts missing", str(report.texts_missing))
     if report.alt_texts_translated:
         table.add_row("Alt texts translated", str(report.alt_texts_translated))
     table.add_row("Errors", str(len(report.errors)))
@@ -1602,6 +1681,7 @@ def _print_interrupted_translation(
     table.add_row("Texts translated", str(snapshot.texts_translated))
     table.add_row("Texts from cache", str(snapshot.texts_from_cache))
     table.add_row("Texts dry-run", str(snapshot.texts_dry_run))
+    table.add_row("Texts missing", str(snapshot.texts_missing))
     table.add_row("Text errors", str(snapshot.text_errors))
     table.add_row("Current chapter", snapshot.current_chapter or "-")
     console.print(table)
@@ -2579,6 +2659,76 @@ def _save_markdown_report(
     return path
 
 
+def _save_missing_texts(
+    report: TranslationReport,
+    missing_output: Path | None,
+    overwrite: bool,
+    directory: Path | None,
+    mode: UserMode,
+) -> None:
+    if missing_output is not None:
+        path = missing_output.expanduser()
+        if path.exists() and not overwrite:
+            _print_expected_error(
+                "Arquivo de textos ausentes já existe.",
+                "Use --overwrite para substituí-lo ou escolha outro caminho em --missing-output.",
+                mode,
+                detail=f"Missing output: {path}",
+            )
+            raise typer.Exit(code=1)
+    else:
+        directory = directory or _default_reports_dir()
+        directory.mkdir(parents=True, exist_ok=True)
+        path = _next_available_report_path(directory, _missing_filename_stem(report), suffix=".txt")
+
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(_render_missing_texts(report), encoding="utf-8")
+    except OSError as exc:
+        _print_expected_error(
+            "Não foi possível salvar o arquivo de textos ausentes.",
+            "Escolha um caminho gravável para --missing-output e tente novamente.",
+            mode,
+            detail=str(exc),
+        )
+        raise typer.Exit(code=1) from exc
+
+    console.print(f"[green]Missing texts saved to:[/green] {path}")
+
+
+def _render_missing_texts(report: TranslationReport) -> str:
+    lines = [
+        "# Ayvu cache-only missing texts",
+        f"# Original EPUB: {_display_optional_path(report.input_path)}",
+        f"# Source language: {report.detected_language or '-'}",
+        f"# Target language: {report.target_language or '-'}",
+        f"# Missing texts: {len(report.missing_texts)}",
+        "",
+    ]
+    for index, text in enumerate(report.missing_texts, start=1):
+        lines.append(f"[{index}]")
+        lines.append(text)
+        lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+def _missing_filename_stem(report: TranslationReport) -> str:
+    source = _safe_filename_part(report.input_path.stem if report.input_path else "translation")
+    target = _safe_filename_part(report.target_language or "translated")
+    return f"{source}-{target}-missing"
+
+
+def _print_cache_coverage_blocked(report: TranslationReport, mode: UserMode) -> None:
+    _print_expected_error(
+        f"Cache incompleto: {report.texts_missing} texto(s) sem tradução no cache.",
+        (
+            "Remova --require-full-cache para gerar mesmo assim, traduza o EPUB normalmente "
+            "para preencher o cache, ou consulte o arquivo de textos ausentes."
+        ),
+        mode,
+    )
+
+
 def _render_markdown_report(
     report: TranslationReport,
     dry_run: bool,
@@ -2598,6 +2748,8 @@ def _render_markdown_report(
     ]
     if report.review_output_path is not None:
         lines.insert(6, f"- Review file: {report.review_output_path}")
+    if report.texts_missing:
+        lines.append(f"- Texts missing: {report.texts_missing}")
     if report.alt_texts_translated:
         lines.append(f"- Alt texts translated: {report.alt_texts_translated}")
     lines.extend([
@@ -2647,11 +2799,11 @@ def _default_reports_dir() -> Path:
     return _reports_dir(_load_existing_config_or_default())
 
 
-def _next_available_report_path(directory: Path, stem: str) -> Path:
-    path = directory / f"{stem}.md"
+def _next_available_report_path(directory: Path, stem: str, suffix: str = ".md") -> Path:
+    path = directory / f"{stem}{suffix}"
     index = 2
     while path.exists():
-        path = directory / f"{stem}-{index}.md"
+        path = directory / f"{stem}-{index}{suffix}"
         index += 1
     return path
 
@@ -2684,6 +2836,8 @@ def _display_optional_path(path: Path | None) -> str:
 def _report_output_value(report: TranslationReport, dry_run: bool) -> str:
     if dry_run:
         return "(dry run, no file written)"
+    if not report.output_written:
+        return "(cache incompleto, nenhum arquivo gerado)"
     return _display_optional_path(report.output_path)
 
 

--- a/src/ayvu/cli_progress.py
+++ b/src/ayvu/cli_progress.py
@@ -14,6 +14,7 @@ class TranslationProgressSnapshot:
     texts_translated: int
     texts_from_cache: int
     texts_dry_run: int
+    texts_missing: int
     text_errors: int
 
 
@@ -22,6 +23,7 @@ class TextProgressCounters:
     translated: int = 0
     cache: int = 0
     dry_run: int = 0
+    missing: int = 0
     error: int = 0
 
     def record(self, status: str) -> None:
@@ -34,6 +36,9 @@ class TextProgressCounters:
         if status == "dry_run":
             self.dry_run += 1
             return
+        if status == "missing":
+            self.missing += 1
+            return
         if status == "error":
             self.error += 1
             return
@@ -41,7 +46,7 @@ class TextProgressCounters:
 
     @property
     def processed(self) -> int:
-        return self.translated + self.cache + self.dry_run + self.error
+        return self.translated + self.cache + self.dry_run + self.missing + self.error
 
     def new_count(self, dry_run: bool) -> int:
         if dry_run:
@@ -90,6 +95,7 @@ class TranslationProgress:
             texts_translated=self._counters.translated,
             texts_from_cache=self._counters.cache,
             texts_dry_run=self._counters.dry_run,
+            texts_missing=self._counters.missing,
             text_errors=self._counters.error,
         )
 
@@ -101,7 +107,8 @@ class TranslationProgress:
         new_count = self._counters.new_count(self._dry_run)
         return (
             f"Texts {self._counters.processed} | {new_label} {new_count} | "
-            f"cache {self._counters.cache} | errors {self._counters.error}"
+            f"cache {self._counters.cache} | missing {self._counters.missing} | "
+            f"errors {self._counters.error}"
         )
 
 

--- a/src/ayvu/domain.py
+++ b/src/ayvu/domain.py
@@ -179,6 +179,8 @@ class TranslationOptions:
     translate_metadata: bool = False
     translate_alt_text: bool = False
     chapter_selection: ChapterSelection | None = None
+    cache_only: bool = False
+    require_full_cache: bool = False
 
     @property
     def source(self) -> str:

--- a/src/ayvu/epub_io.py
+++ b/src/ayvu/epub_io.py
@@ -96,11 +96,14 @@ class TranslationReport:
     texts_translated: int = 0
     texts_from_cache: int = 0
     texts_skipped: int = 0
+    texts_missing: int = 0
     alt_texts_translated: int = 0
     errors: list[str] = field(default_factory=list)
+    missing_texts: list[str] = field(default_factory=list)
     glossary_terms_configured: int = 0
     glossary_usage: GlossaryUsage = field(default_factory=GlossaryUsage)
     output_path: Path | None = None
+    output_written: bool = True
     review_output_path: Path | None = None
     input_path: Path | None = None
     detected_language: str | None = None
@@ -113,13 +116,18 @@ class TranslationReport:
         self.texts_translated += stats.translated
         self.texts_from_cache += stats.from_cache
         self.texts_skipped += stats.skipped
+        self.texts_missing += stats.missing
         self.alt_texts_translated += stats.alt_translated
         self.errors.extend(stats.errors)
+        self.missing_texts.extend(stats.missing_texts)
         self.glossary_usage.merge(stats.glossary_usage)
         self.chapters_processed += 1
 
     def record_text(self, result: TextTranslationResult) -> None:
-        if result.from_cache:
+        if result.missing:
+            self.texts_missing += 1
+            self.missing_texts.append(result.text)
+        elif result.from_cache:
             self.texts_from_cache += 1
         else:
             self.texts_translated += 1
@@ -281,6 +289,7 @@ def translate_epub(
                     target=options.target,
                     glossary=glossary,
                     dry_run=options.dry_run,
+                    cache_only=options.cache_only,
                     fail_fast=options.fail_fast,
                     chunk_limit=options.chunk_limit,
                     on_text_processed=on_text_processed,
@@ -298,10 +307,14 @@ def translate_epub(
                     raise
 
     if not options.dry_run:
-        if glossary:
-            report.glossary_usage.finalize_required_terms(glossary)
-        destination_path.parent.mkdir(parents=True, exist_ok=True)
-        _copy_epub_with_replacements(source_path, destination_path, replacements)
+        blocked = options.cache_only and options.require_full_cache and report.texts_missing > 0
+        if blocked:
+            report.output_written = False
+        else:
+            if glossary:
+                report.glossary_usage.finalize_required_terms(glossary)
+            destination_path.parent.mkdir(parents=True, exist_ok=True)
+            _copy_epub_with_replacements(source_path, destination_path, replacements)
 
     return report
 
@@ -781,11 +794,13 @@ def _translate_opf_title(
         target=options.target,
         glossary=glossary,
         dry_run=options.dry_run,
+        cache_only=options.cache_only,
         chunk_limit=options.chunk_limit,
     )
     if on_review_text:
         on_review_text(title.text, result)
-    title.text = result.text
+    if not result.missing:
+        title.text = result.text
     report.record_text(result)
     _notify_text_processed(on_text_processed, _text_progress_status(result, options.dry_run))
     return ET.tostring(root, encoding="utf-8", xml_declaration=_has_xml_declaration(opf_content))
@@ -817,6 +832,8 @@ def _has_xml_declaration(content: bytes) -> bool:
 
 
 def _text_progress_status(result: TextTranslationResult, dry_run: bool) -> str:
+    if result.missing:
+        return "missing"
     if result.from_cache:
         return "cache"
     if dry_run:

--- a/src/ayvu/html_translate.py
+++ b/src/ayvu/html_translate.py
@@ -86,7 +86,9 @@ class HtmlTranslationStats:
     from_cache: int = 0
     skipped: int = 0
     alt_translated: int = 0
+    missing: int = 0
     errors: list[str] = field(default_factory=list)
+    missing_texts: list[str] = field(default_factory=list)
     glossary_usage: GlossaryUsage = field(default_factory=GlossaryUsage)
 
 
@@ -110,6 +112,7 @@ class TextParts:
 class TextTranslationResult:
     text: str
     from_cache: bool = False
+    missing: bool = False
     glossary_usage: GlossaryUsage = field(default_factory=GlossaryUsage)
 
 
@@ -149,6 +152,7 @@ def translate_html(
     target: str,
     glossary: Glossary | None = None,
     dry_run: bool = False,
+    cache_only: bool = False,
     fail_fast: bool = False,
     chunk_limit: int = 3000,
     on_error: Callable[[Exception], None] | None = None,
@@ -174,11 +178,14 @@ def translate_html(
                 target=target,
                 glossary=glossary,
                 dry_run=dry_run,
+                cache_only=cache_only,
                 chunk_limit=chunk_limit,
             )
-            if not dry_run:
+            if not dry_run and not result.missing:
                 fragment = _expand_tag_tokens(escape(result.text), tag_markup)
                 _replace_run(run, _parse_fragment_nodes(fragment))
+            if result.missing:
+                stats.missing_texts.append(_review_text_from_template(template, tag_markup))
             _notify_segment_translated(
                 on_segment_translated,
                 original_template=template,
@@ -188,7 +195,7 @@ def translate_html(
                 from_cache=result.from_cache,
             )
             stats.glossary_usage.merge(result.glossary_usage)
-            _record_success(stats, result.from_cache, dry_run, on_text_processed)
+            _record_success(stats, result, dry_run, on_text_processed)
         except Exception as exc:
             stats.errors.append(str(exc))
             _notify_text_processed(on_text_processed, "error")
@@ -206,6 +213,7 @@ def translate_html(
             target=target,
             glossary=glossary,
             dry_run=dry_run,
+            cache_only=cache_only,
             fail_fast=fail_fast,
             chunk_limit=chunk_limit,
             stats=stats,
@@ -225,6 +233,7 @@ def translate_text(
     target: str,
     glossary: Glossary | None = None,
     dry_run: bool = False,
+    cache_only: bool = False,
     chunk_limit: int = 3000,
 ) -> TextTranslationResult:
     parts = TextParts.from_text(text)
@@ -241,6 +250,9 @@ def translate_text(
             from_cache=True,
             glossary_usage=application.usage,
         )
+
+    if cache_only:
+        return TextTranslationResult(text=text, missing=True)
 
     if dry_run:
         return TextTranslationResult(text=text)
@@ -307,6 +319,7 @@ def _translate_image_alt_text(
     target: str,
     glossary: Glossary | None,
     dry_run: bool,
+    cache_only: bool,
     fail_fast: bool,
     chunk_limit: int,
     stats: HtmlTranslationStats,
@@ -333,10 +346,13 @@ def _translate_image_alt_text(
                 target=target,
                 glossary=glossary,
                 dry_run=dry_run,
+                cache_only=cache_only,
                 chunk_limit=chunk_limit,
             )
-            if not dry_run:
+            if not dry_run and not result.missing:
                 image["alt"] = result.text
+            if result.missing:
+                stats.missing_texts.append(_review_text_from_template(alt, []))
             _notify_segment_translated(
                 on_segment_translated,
                 original_template=alt,
@@ -346,8 +362,9 @@ def _translate_image_alt_text(
                 from_cache=result.from_cache,
             )
             stats.glossary_usage.merge(result.glossary_usage)
-            stats.alt_translated += 1
-            _record_success(stats, result.from_cache, dry_run, on_text_processed)
+            if not result.missing:
+                stats.alt_translated += 1
+            _record_success(stats, result, dry_run, on_text_processed)
         except Exception as exc:
             stats.errors.append(str(exc))
             _notify_text_processed(on_text_processed, "error")
@@ -626,11 +643,16 @@ def _review_visible_text_parts(node) -> list[str]:
 
 def _record_success(
     stats: HtmlTranslationStats,
-    used_cache: bool,
+    result: TextTranslationResult,
     dry_run: bool,
     on_text_processed: TextProgressCallback | None,
 ) -> None:
-    if used_cache:
+    if result.missing:
+        stats.missing += 1
+        _notify_text_processed(on_text_processed, "missing")
+        return
+
+    if result.from_cache:
         stats.from_cache += 1
         _notify_text_processed(on_text_processed, "cache")
         return

--- a/src/ayvu/preflight.py
+++ b/src/ayvu/preflight.py
@@ -45,6 +45,7 @@ def run_translation_preflight(
     retries: int,
     language_pair: LanguagePair,
     dry_run: bool,
+    cache_only: bool = False,
 ) -> TranslationPreflightResult:
     _check_language_pair(language_pair)
     glossary = _load_checked_glossary(glossary_path)
@@ -52,7 +53,7 @@ def run_translation_preflight(
     _check_cache(cache_path)
     _check_epub(epub_path)
     route: TranslationRoute | None = None
-    if not dry_run:
+    if not dry_run and not cache_only:
         route = _resolve_route_or_fallback(translator, language_pair, url)
         if route is not None and not route.is_direct:
             translator = RoutedTranslator(translator, route)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2083,6 +2083,136 @@ def test_translate_command_handles_keyboard_interrupt_cleanly(tmp_path, monkeypa
     assert not output_path.exists()
 
 
+def test_translate_command_require_full_cache_requires_cache_only(tmp_path):
+    epub_path = tmp_path / "book.epub"
+    epub_path.write_bytes(b"fake epub")
+
+    result = runner.invoke(app, ["translate", str(epub_path), "--require-full-cache"])
+
+    assert result.exit_code == 1
+    assert "--require-full-cache exige --cache-only" in result.output
+
+
+def test_translate_command_missing_output_requires_cache_only(tmp_path):
+    epub_path = tmp_path / "book.epub"
+    epub_path.write_bytes(b"fake epub")
+
+    result = runner.invoke(
+        app, ["translate", str(epub_path), "--missing-output", str(tmp_path / "missing.txt")]
+    )
+
+    assert result.exit_code == 1
+    assert "--missing-output exige --cache-only" in result.output
+
+
+def test_translate_command_cache_only_saves_missing_texts_file(tmp_path, monkeypatch):
+    epub_path = tmp_path / "book.epub"
+    output_path = tmp_path / "book-pt.epub"
+    missing_path = tmp_path / "missing.txt"
+    epub_path.write_bytes(b"fake epub")
+
+    report = TranslationReport(
+        chapters_processed=1,
+        texts_from_cache=1,
+        texts_missing=2,
+        missing_texts=["Hello reader.", "Another line."],
+        output_path=output_path,
+        output_written=True,
+        input_path=epub_path,
+        detected_language="en",
+        target_language="pt",
+    )
+    captured: dict[str, object] = {}
+
+    def fake_translate_epub(*_args: object, **kwargs: object) -> TranslationReport:
+        captured["options"] = kwargs["options"]
+        return report
+
+    def fake_preflight(**kwargs: object) -> SimpleNamespace:
+        captured["preflight_kwargs"] = kwargs
+        return SimpleNamespace(translator=object(), glossary=None, route=None)
+
+    monkeypatch.setattr("ayvu.cli.run_translation_preflight", fake_preflight)
+    monkeypatch.setattr("ayvu.cli.TranslationCache", lambda _path: FakeCache())
+    monkeypatch.setattr("ayvu.cli.translate_epub", fake_translate_epub)
+    monkeypatch.setattr(
+        "ayvu.cli.validate_output_epub",
+        lambda _path, on_progress=None: ValidationResult(ok=True, warnings=[], document_count=1),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "translate",
+            str(epub_path),
+            "--output",
+            str(output_path),
+            "--cache-only",
+            "--missing-output",
+            str(missing_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Texts missing" in result.output
+    assert captured["options"].cache_only is True
+    assert captured["preflight_kwargs"]["cache_only"] is True
+    assert missing_path.exists()
+    content = missing_path.read_text(encoding="utf-8")
+    assert "Missing texts: 2" in content
+    assert "Hello reader." in content
+    assert "Another line." in content
+
+
+def test_translate_command_cache_only_require_full_cache_blocks_output(tmp_path, monkeypatch):
+    epub_path = tmp_path / "book.epub"
+    output_path = tmp_path / "book-pt.epub"
+    missing_path = tmp_path / "missing.txt"
+    epub_path.write_bytes(b"fake epub")
+
+    report = TranslationReport(
+        chapters_processed=1,
+        texts_from_cache=1,
+        texts_missing=2,
+        missing_texts=["Hello reader.", "Another line."],
+        output_path=output_path,
+        output_written=False,
+        input_path=epub_path,
+        detected_language="en",
+        target_language="pt",
+    )
+    monkeypatch.setattr(
+        "ayvu.cli.run_translation_preflight",
+        lambda **_kwargs: SimpleNamespace(translator=object(), glossary=None, route=None),
+    )
+    monkeypatch.setattr("ayvu.cli.TranslationCache", lambda _path: FakeCache())
+    monkeypatch.setattr("ayvu.cli.translate_epub", lambda *_args, **_kwargs: report)
+
+    def fail_validate(*_args: object, **_kwargs: object) -> ValidationResult:
+        raise AssertionError("validation must not run when output is blocked")
+
+    monkeypatch.setattr("ayvu.cli.validate_output_epub", fail_validate)
+
+    result = runner.invoke(
+        app,
+        [
+            "translate",
+            str(epub_path),
+            "--output",
+            str(output_path),
+            "--cache-only",
+            "--require-full-cache",
+            "--missing-output",
+            str(missing_path),
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Cache incompleto" in result.output
+    assert "(cache incompleto, nenhum arquivo gerado)" in result.output
+    assert missing_path.exists()
+
+
 class FakeCache:
     def __enter__(self) -> "FakeCache":
         return self

--- a/tests/test_cli_progress.py
+++ b/tests/test_cli_progress.py
@@ -9,12 +9,14 @@ def test_text_progress_counters_track_known_statuses():
     counters.record("translated")
     counters.record("cache")
     counters.record("dry_run")
+    counters.record("missing")
     counters.record("error")
 
-    assert counters.processed == 4
+    assert counters.processed == 5
     assert counters.new_count(dry_run=False) == 1
     assert counters.new_count(dry_run=True) == 1
     assert counters.cache == 1
+    assert counters.missing == 1
     assert counters.error == 1
 
 
@@ -41,6 +43,7 @@ def test_translation_progress_snapshot_tracks_partial_state():
     progress.chapter_started(1, 2, "chapter-one.xhtml")
     progress.text_processed("translated")
     progress.text_processed("cache")
+    progress.text_processed("missing")
     progress.chapter_done(1, 2, "chapter-one.xhtml", object())
     progress.chapter_started(2, 2, "chapter-two.xhtml")
 
@@ -49,6 +52,7 @@ def test_translation_progress_snapshot_tracks_partial_state():
     assert snapshot.chapters_processed == 1
     assert snapshot.total_chapters == 2
     assert snapshot.current_chapter == "chapter-two.xhtml"
-    assert snapshot.texts_processed == 2
+    assert snapshot.texts_processed == 3
     assert snapshot.texts_translated == 1
     assert snapshot.texts_from_cache == 1
+    assert snapshot.texts_missing == 1

--- a/tests/test_epub_io.py
+++ b/tests/test_epub_io.py
@@ -61,6 +61,15 @@ class PrefixTranslator:
         return f"PT:{text}"
 
 
+class RaisingTranslator:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, str]] = []
+
+    def translate(self, text: str, source: str, target: str) -> str:
+        self.calls.append((text, source, target))
+        raise AssertionError("translator must not be called in cache-only mode")
+
+
 def _read_navigation_document(epub_path: Path) -> str:
     opf_archive_path = _get_opf_archive_path(epub_path)
     with ZipFile(epub_path) as source_epub:
@@ -191,6 +200,111 @@ def test_translate_epub_translates_minimal_generated_epub_without_mutating_input
     # The paragraph is translated as one block, keeping the inline link and its text.
     assert '<a href="chapter2.xhtml#answer">chapter two</a>' in chapter
     assert "../images/pixel.png" in chapter
+
+
+def test_translate_epub_cache_only_reuses_cache_without_calling_translator(
+    minimal_epub_path: Path,
+    tmp_path: Path,
+):
+    cache_path = tmp_path / "cache.sqlite"
+    options = TranslationOptions(language_pair=LanguagePair(source="en", target="pt"))
+    with TranslationCache(cache_path) as cache:
+        first = translate_epub(
+            minimal_epub_path,
+            tmp_path / "first-pt.epub",
+            translator=PrefixTranslator(),
+            cache=cache,
+            options=options,
+        )
+
+    output_path = tmp_path / "cache-only-pt.epub"
+    raising = RaisingTranslator()
+    cache_only_options = TranslationOptions(
+        language_pair=LanguagePair(source="en", target="pt"),
+        cache_only=True,
+    )
+    with TranslationCache(cache_path) as cache:
+        report = translate_epub(
+            minimal_epub_path,
+            output_path,
+            translator=raising,
+            cache=cache,
+            options=cache_only_options,
+        )
+
+    assert output_path.exists()
+    assert report.output_written
+    assert report.texts_missing == 0
+    assert report.texts_translated == 0
+    assert report.texts_from_cache == first.texts_translated + first.texts_from_cache
+    assert raising.calls == []
+
+    with ZipFile(output_path) as output_epub:
+        names = output_epub.namelist()
+        chapter_name = next(name for name in names if name.endswith("text/chapter1.xhtml"))
+        chapter = output_epub.read(chapter_name).decode("utf-8")
+    assert "PT:Hello reader. Visit" in chapter
+
+
+def test_translate_epub_cache_only_writes_with_missing_texts_by_default(
+    minimal_epub_path: Path,
+    tmp_path: Path,
+):
+    output_path = tmp_path / "cache-only-pt.epub"
+    raising = RaisingTranslator()
+    options = TranslationOptions(
+        language_pair=LanguagePair(source="en", target="pt"),
+        cache_only=True,
+    )
+    with TranslationCache(tmp_path / "cache.sqlite") as cache:
+        report = translate_epub(
+            minimal_epub_path,
+            output_path,
+            translator=raising,
+            cache=cache,
+            options=options,
+        )
+
+    assert output_path.exists()
+    assert report.output_written
+    assert report.texts_missing >= 4
+    assert report.texts_translated == 0
+    assert report.texts_from_cache == 0
+    assert len(report.missing_texts) == report.texts_missing
+    assert raising.calls == []
+
+    with ZipFile(output_path) as output_epub:
+        names = output_epub.namelist()
+        chapter_name = next(name for name in names if name.endswith("text/chapter1.xhtml"))
+        chapter = output_epub.read(chapter_name).decode("utf-8")
+    assert "Hello reader. Visit" in chapter
+    assert "PT:" not in chapter
+
+
+def test_translate_epub_cache_only_require_full_cache_blocks_output_when_missing(
+    minimal_epub_path: Path,
+    tmp_path: Path,
+):
+    output_path = tmp_path / "cache-only-pt.epub"
+    raising = RaisingTranslator()
+    options = TranslationOptions(
+        language_pair=LanguagePair(source="en", target="pt"),
+        cache_only=True,
+        require_full_cache=True,
+    )
+    with TranslationCache(tmp_path / "cache.sqlite") as cache:
+        report = translate_epub(
+            minimal_epub_path,
+            output_path,
+            translator=raising,
+            cache=cache,
+            options=options,
+        )
+
+    assert not output_path.exists()
+    assert not report.output_written
+    assert report.texts_missing >= 4
+    assert raising.calls == []
 
 
 def test_translate_epub_collects_review_segments_with_document_metadata(

--- a/tests/test_html_translate.py
+++ b/tests/test_html_translate.py
@@ -81,6 +81,66 @@ def test_translate_html_uses_cache(tmp_path):
     assert translator.calls == ["Keep me"]
 
 
+def test_translate_text_cache_only_marks_missing_without_calling_translator(tmp_path):
+    translator = FakeTranslator()
+    with TranslationCache(tmp_path / "cache.sqlite") as cache:
+        result = translate_text(
+            "Keep me",
+            translator=translator,
+            cache=cache,
+            source="en",
+            target="pt",
+            cache_only=True,
+        )
+
+    assert result.missing
+    assert not result.from_cache
+    assert result.text == "Keep me"
+    assert translator.calls == []
+
+
+def test_translate_text_cache_only_uses_cache_when_available(tmp_path):
+    translator = FakeTranslator()
+    with TranslationCache(tmp_path / "cache.sqlite") as cache:
+        cache.set(
+            CacheKey(text="Keep me", language_pair=LanguagePair(source="en", target="pt")),
+            "Mantenha-me",
+        )
+        result = translate_text(
+            "Keep me",
+            translator=translator,
+            cache=cache,
+            source="en",
+            target="pt",
+            cache_only=True,
+        )
+
+    assert result.from_cache
+    assert not result.missing
+    assert result.text == "Mantenha-me"
+    assert translator.calls == []
+
+
+def test_translate_html_cache_only_keeps_missing_text_and_reports_it(tmp_path):
+    translator = FakeTranslator()
+    html = "<html><body><p>Keep me</p><p>Hello reader.</p></body></html>"
+    with TranslationCache(tmp_path / "cache.sqlite") as cache:
+        cache.set(
+            CacheKey(text="Keep me", language_pair=LanguagePair(source="en", target="pt")),
+            "Mantenha-me",
+        )
+        output, stats = translate_html(html, translator, cache, "en", "pt", cache_only=True)
+
+    decoded = output.decode("utf-8")
+    assert "Mantenha-me" in decoded
+    assert "Hello reader." in decoded
+    assert stats.from_cache == 1
+    assert stats.missing == 1
+    assert stats.translated == 0
+    assert stats.missing_texts == ["Hello reader."]
+    assert translator.calls == []
+
+
 def test_translate_html_reports_review_segments_as_visible_text(tmp_path):
     html = '<html><body><p>Hello <a href="chapter.xhtml">reader</a>.</p></body></html>'
     segments = []

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -96,6 +96,32 @@ def test_preflight_dry_run_skips_translator_probe(monkeypatch, tmp_path):
     assert translator.calls == []
 
 
+def test_preflight_cache_only_skips_route_resolution(monkeypatch, tmp_path):
+    translator = TranslatorWithLanguages(
+        (TranslatorLanguage(code="en", name="English", targets=("pt",)),)
+    )
+    monkeypatch.setattr("ayvu.preflight.create_translator", lambda *_args, **_kwargs: translator)
+    monkeypatch.setattr("ayvu.preflight.inspect_epub", lambda _path: object())
+
+    result = run_translation_preflight(
+        epub_path=tmp_path / "book.epub",
+        cache_path=tmp_path / "cache.sqlite",
+        glossary_path=None,
+        translator_name="libretranslate",
+        url="http://localhost:5000",
+        timeout=1.0,
+        retries=0,
+        language_pair=LanguagePair(source="en", target="pt"),
+        dry_run=False,
+        cache_only=True,
+    )
+
+    assert result.route is None
+    assert result.translator is translator
+    assert translator.translate_calls == []
+    assert translator.list_calls == 0
+
+
 def test_preflight_rejects_blank_language_pair(tmp_path):
     with pytest.raises(PreflightError) as error:
         run_translation_preflight(


### PR DESCRIPTION
## Objective

Add a cache-only translation mode that rebuilds a translated EPUB using only translations already in the cache, without ever calling the translator.

## What changed

- Add `--cache-only`, `--require-full-cache` and `--missing-output` to the `translate` command, propagated through `TranslationOptions`.
- `translate_text` treats a cache miss as missing (text left in the source language) instead of translating; `translate_html`/`translate_epub` collect and count missing texts.
- Preflight skips route resolution in cache-only mode, so no running translator/server is required.
- Output write is gated: by default the EPUB is still written with partial coverage; with `--require-full-cache` it refuses to write and fails when any text is missing.
- Missing original texts are written to a file (explicit `--missing-output` path or auto-saved in the reports folder), even when `--require-full-cache` blocks the output.
- Terminal/Markdown report and the progress view now show a missing-texts count; the interrupted snapshot includes it too.
- Cache-only does not create resume state, unlike normal resume.
- README and tutorial document the mode and how it differs from resume.

## Out of scope

- Not exposed in the guided common-mode menu (advanced/developer flag).
- No percentage coverage threshold (binary, controlled by `--require-full-cache`).
- Preview (`--preview`) does not receive cache-only.

## Validation

- `uv run pytest`: 269 tests passing (258 existing + 11 new).
- `git diff --check`: no errors.
- Manual end-to-end with a seeded cache and an unreachable translator URL: full coverage writes the EPUB (translator never contacted); partial coverage writes by default and reports missing; `--require-full-cache` blocks the output and exits 1 while still saving the missing-texts file.

## Related issue

Closes #96
