### PR TITLE
Add safe resume checkpoints (#97)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ lancadas e secoes versionadas quando uma release for publicada.
   gerenciar o cache SQLite fora do fluxo normal de traducao.
 - Estado local de retomada em `~/Documentos/Livros/Processando` ou na pasta de
   processamento configurada.
+- Checkpoints de progresso no estado de retomada, atualizados a cada capitulo com
+  total de capitulos, capitulo atual, capitulos concluidos, capitulos com falha e
+  contagem de segmentos que falharam.
+- Comando `resume` para retomar uma traducao em andamento a partir do checkpoint
+  salvo, reaproveitando as opcoes da execucao e o cache.
 - Oferta de retomada no modo comum quando uma traducao em andamento e detectada.
 - Relatorio Markdown opcional no modo comum.
 - Validacao do EPUB gerado com barra de progresso, avisos de capitulos vazios,

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ O EPUB original nunca é alterado. A saída é gravada em um novo arquivo `.epub
 - Tradução por bloco (parágrafos, títulos e listas) preservando tags internas como `em`, `strong` e links via placeholders.
 - Preservação de tags, CSS, imagens, links, sumário e nomes de arquivos internos.
 - Cache SQLite para retomar traduções interrompidas e evitar chamadas repetidas.
+- Checkpoints de progresso por capítulo e comando `resume` para retomar com segurança traduções longas.
 - Glossário JSON opcional e fluxo guiado para padronizar termos técnicos.
 - Perfis de tradução para agrupar idioma de destino, glossário e estilo planejado.
 - Proteção de URLs, caminhos, comandos, versões, código inline e identificadores técnicos simples durante a tradução.
@@ -139,6 +140,13 @@ uv run ayvu cache inspect --cache .cache/traducoes.sqlite
 uv run ayvu cache clean --cache .cache/traducoes.sqlite --source en --target pt --dry-run
 uv run ayvu cache export cache-ayvu.json --cache .cache/traducoes.sqlite
 uv run ayvu cache import cache-ayvu.json --cache .cache/traducoes.sqlite
+```
+
+Retomar uma tradução interrompida a partir do checkpoint salvo:
+
+```bash
+uv run ayvu resume
+uv run ayvu resume livro.epub --target pt
 ```
 
 Traduzir vários EPUBs em uma única execução:
@@ -460,13 +468,35 @@ ser substituídas com `--replace`.
 O arquivo exportado inclui texto original e texto traduzido. Trate esse JSON
 como conteúdo privado do livro, da mesma forma que o EPUB e o cache SQLite.
 
-Durante traduções reais, o Ayvu também grava um estado local da execução em
-`~/Documentos/Livros/Processando`, ou na pasta de processamento configurada. Esse arquivo registra os caminhos e opções
-necessários para uma retomada futura. Ele não substitui o cache e não é apagado
+Durante traduções reais, o Ayvu também grava um checkpoint local da execução em
+`~/Documentos/Livros/Processando`, ou na pasta de processamento configurada
+(arquivo `*.ayvu-state.json`). Além dos caminhos e opções da execução, esse
+checkpoint é atualizado **a cada capítulo** e registra o progresso: total de
+capítulos, o capítulo atual, os capítulos concluídos, os capítulos com falha e
+quantos segmentos falharam. Ele não substitui o cache e não é apagado
 automaticamente.
 
-Ao executar `uv run ayvu`, o modo comum procura estados de tradução em andamento
-nessa pasta e oferece retomar uma execução detectada.
+Para retomar uma tradução interrompida sem redigitar as opções, use o comando
+`resume`:
+
+```bash
+uv run ayvu resume
+uv run ayvu resume livro.epub --target pt
+```
+
+Sem argumentos, `resume` continua a única tradução em andamento; havendo mais de
+uma, informe o EPUB e o `--target` para escolher. O comando mostra o checkpoint
+(até onde foi) e reexecuta a tradução com as opções salvas. Ao executar apenas
+`uv run ayvu`, o modo comum também procura estados em andamento e oferece retomar
+a execução detectada, mostrando o mesmo resumo de checkpoint.
+
+Checkpoint e cache se complementam: o **cache** guarda cada trecho já traduzido e
+evita retraduzi-lo, enquanto o **checkpoint** registra o progresso e as falhas.
+Como o EPUB de saída só é escrito por inteiro ao final, a retomada reprocessa
+todos os capítulos, mas, graças ao cache, apenas os segmentos ainda não cacheados
+(os que faltaram ou falharam antes) chamam de fato o tradutor — ou seja, a
+retomada já reprocessa só o que ficou pendente. Por isso o checkpoint e o cache
+devem usar os mesmos caminhos entre as execuções.
 
 ### Modo cache-only
 

--- a/docs/tutorial-modo-comum-e-dev.md
+++ b/docs/tutorial-modo-comum-e-dev.md
@@ -96,13 +96,15 @@ arquivo automaticamente.
 
 ### Retomar uma tradução interrompida
 
-Durante traduções reais, o Ayvu registra um estado local em:
+Durante traduções reais, o Ayvu registra um checkpoint local em:
 
 ```text
 ~/Documentos/Livros/Processando
 ```
 
-Ao executar `uv run ayvu`, o modo comum procura estados em andamento e oferece retomar uma tradução detectada. O cache SQLite continua sendo a parte que evita retraduzir textos já concluídos.
+Esse checkpoint (`*.ayvu-state.json`) é atualizado a cada capítulo e guarda o progresso: total de capítulos, capítulo atual, capítulos concluídos e capítulos com falha.
+
+Ao executar `uv run ayvu`, o modo comum procura estados em andamento, mostra o resumo do checkpoint e oferece retomar a tradução detectada. O cache SQLite continua sendo a parte que evita retraduzir textos já concluídos: na retomada, só os trechos ainda não cacheados (os que faltaram ou falharam) chamam o tradutor de novo.
 
 ## Tutorial intermediário: preview, glossário e organização
 
@@ -455,6 +457,22 @@ uv run ayvu translate livro.epub \
   --target pt \
   --dry-run
 ```
+
+### Retomar a partir do checkpoint
+
+O comando `resume` continua uma tradução em andamento usando o checkpoint salvo,
+sem redigitar as opções:
+
+```bash
+uv run ayvu resume
+uv run ayvu resume livro.epub --target pt
+```
+
+Sem argumentos, ele retoma a única tradução em andamento; havendo mais de uma,
+informe o EPUB e o `--target`. O comando mostra o checkpoint (capítulos
+concluídos, capítulo atual e falhas) e reexecuta a tradução com as opções da
+execução original. O cache evita retraduzir o que já foi concluído, então só os
+trechos pendentes chamam o tradutor.
 
 ### Reconstruir usando apenas o cache
 

--- a/src/ayvu/cli.py
+++ b/src/ayvu/cli.py
@@ -52,6 +52,7 @@ from .glossary import (
     load_glossary,
     save_glossary,
 )
+from .html_translate import HtmlTranslationStats
 from .library import LibraryBook, LibraryOpenError, open_library_epub, scan_library
 from .preflight import PreflightError, run_translation_preflight
 from .resume import (
@@ -548,6 +549,36 @@ def translate(
         missing_output=missing_output,
         confirm_output_location=resolved_output_dir is None,
     )
+
+
+@app.command()
+def resume(
+    ctx: typer.Context,
+    epub_path: Optional[Path] = typer.Argument(
+        None,
+        help="EPUB to resume. If omitted, resumes the only translation in progress.",
+    ),
+    target: Optional[str] = typer.Option(
+        None,
+        "--target",
+        help="Target language, to choose when several translations are in progress.",
+    ),
+) -> None:
+    """Resume a translation in progress from its saved checkpoint."""
+    mode = ctx.obj.get("mode", UserMode.DEVELOPER)
+    config = _load_existing_config_or_default()
+    store = ResumeStateStore(_processing_dir(config))
+    scan = store.scan()
+
+    state = _select_resume_state(scan.running, epub_path, target, mode=mode)
+    if state is None:
+        raise typer.Exit(code=1)
+
+    console.print(
+        f"[green]Resuming translation:[/green] {state.input_path.name} -> {state.output_path.name}"
+    )
+    _print_resume_checkpoint(state)
+    _resume_translation(state, mode=mode)
 
 
 def _print_expected_error(summary: str, next_step: str, mode: UserMode, detail: str = "") -> None:
@@ -1072,6 +1103,27 @@ def _run_translation(
         ) as progress:
             progress_view = TranslationProgress(progress, dry_run=dry_run)
 
+            def on_chapter_start(index: int, total: int, name: str) -> None:
+                nonlocal resume_state
+                progress_view.chapter_started(index, total, name)
+                if resume_store and resume_state:
+                    resume_state = resume_state.start_chapter(name, total)
+                    _save_resume_state(resume_store, resume_state)
+
+            def on_chapter_done(index: int, total: int, name: str, stats: HtmlTranslationStats) -> None:
+                nonlocal resume_state
+                progress_view.chapter_done(index, total, name, stats)
+                if resume_store and resume_state:
+                    ok = not stats.errors and stats.missing == 0
+                    failed = len(stats.errors) + stats.missing
+                    resume_state = resume_state.record_chapter(
+                        name=name,
+                        total=total,
+                        ok=ok,
+                        failed_segment_count=failed,
+                    )
+                    _save_resume_state(resume_store, resume_state)
+
             with TranslationCache(cache_path) as cache:
                 report = translate_epub(
                     epub_path,
@@ -1080,8 +1132,8 @@ def _run_translation(
                     cache=cache,
                     options=translation_options,
                     glossary=preflight.glossary,
-                    on_chapter_start=progress_view.chapter_started,
-                    on_chapter_done=progress_view.chapter_done,
+                    on_chapter_start=on_chapter_start,
+                    on_chapter_done=on_chapter_done,
                     on_text_processed=progress_view.text_processed,
                     review_segments=review_segments,
                 )
@@ -1669,6 +1721,8 @@ def _print_interrupted_translation(
     console.print("Cached translations saved before the interruption can be reused with the same --cache path.")
     console.print(f"Cache path: {cache_path}")
     console.print(_interrupted_output_message(output_path, dry_run))
+    if not dry_run:
+        console.print("Run 'ayvu resume' to continue this translation from the saved checkpoint.")
 
     if snapshot is None:
         return
@@ -2517,6 +2571,7 @@ def _offer_detected_translation_resume(states: tuple[TranslationResumeState, ...
         return False
 
     state = states[0]
+    _print_resume_checkpoint(state)
     if not typer.confirm("Continue detected translation?", default=False):
         console.print("Detected translation was not resumed. Processing files were left unchanged.")
         return False
@@ -2542,7 +2597,7 @@ def _resume_translation(state: TranslationResumeState, mode: UserMode) -> None:
             dry_run=False,
             fail_fast=state.fail_fast,
             chapter_selection=_parse_chapter_selection(state.chapter_selection, mode=mode),
-            overwrite=state.overwrite,
+            overwrite=True,
             timeout=state.timeout,
             retries=state.retries,
             chunk_limit=state.chunk_limit,
@@ -2555,6 +2610,75 @@ def _resume_translation(state: TranslationResumeState, mode: UserMode) -> None:
             "Não foi possível retomar a tradução detectada. Verifique a mensagem acima e reinicie a tradução se necessário."
         )
         raise
+
+
+def _select_resume_state(
+    running: tuple[TranslationResumeState, ...],
+    epub_path: Path | None,
+    target: str | None,
+    mode: UserMode,
+) -> TranslationResumeState | None:
+    candidates = list(running)
+    if epub_path is not None:
+        resolved = epub_path.expanduser().resolve()
+        candidates = [state for state in candidates if state.input_path == resolved]
+    if target is not None:
+        candidates = [state for state in candidates if state.target == target]
+
+    if not candidates:
+        _print_expected_error(
+            "No translation in progress was found to resume.",
+            "Start a translation with 'ayvu translate <epub>' or check the processing folder.",
+            mode,
+        )
+        return None
+
+    if len(candidates) == 1:
+        return candidates[0]
+
+    _print_running_resume_states(tuple(candidates))
+    _print_expected_error(
+        "Several translations in progress match the request.",
+        "Specify the EPUB and --target to choose which one to resume.",
+        mode,
+    )
+    return None
+
+
+def _print_resume_checkpoint(state: TranslationResumeState) -> None:
+    if not _has_checkpoint_progress(state):
+        return
+
+    table = Table(title="Resume checkpoint")
+    table.add_column("Metric")
+    table.add_column("Value")
+    table.add_row("Chapters completed", _checkpoint_chapter_value(state))
+    if state.current_chapter:
+        table.add_row("Current chapter", state.current_chapter)
+    if state.failed_chapters:
+        table.add_row("Chapters with failures", str(len(state.failed_chapters)))
+        table.add_row("Failed segments", str(state.failed_segment_count))
+    table.add_row("Last update", state.updated_at)
+    console.print(table)
+    console.print(
+        "Cached translations are reused; only segments still missing from the cache are retried."
+    )
+
+
+def _has_checkpoint_progress(state: TranslationResumeState) -> bool:
+    return bool(
+        state.completed_chapters
+        or state.failed_chapters
+        or state.current_chapter
+        or state.total_chapters
+    )
+
+
+def _checkpoint_chapter_value(state: TranslationResumeState) -> str:
+    done = len(state.completed_chapters)
+    if state.total_chapters is None:
+        return str(done)
+    return f"{done}/{state.total_chapters}"
 
 
 def _print_running_resume_states(states: tuple[TranslationResumeState, ...]) -> None:

--- a/src/ayvu/resume.py
+++ b/src/ayvu/resume.py
@@ -57,6 +57,11 @@ class TranslationResumeState:
     chapter_selection: str | None
     created_at: str
     updated_at: str
+    total_chapters: int | None = None
+    current_chapter: str | None = None
+    completed_chapters: tuple[str, ...] = ()
+    failed_chapters: tuple[str, ...] = ()
+    failed_segment_count: int = 0
 
     @classmethod
     def create(
@@ -130,6 +135,11 @@ class TranslationResumeState:
             chapter_selection=_optional_text(data, "chapter_selection"),
             created_at=_required_text(data, "created_at"),
             updated_at=_required_text(data, "updated_at"),
+            total_chapters=_optional_int_or_none(data, "total_chapters"),
+            current_chapter=_optional_text(data, "current_chapter"),
+            completed_chapters=_optional_str_tuple(data, "completed_chapters"),
+            failed_chapters=_optional_str_tuple(data, "failed_chapters"),
+            failed_segment_count=_optional_int_default(data, "failed_segment_count", default=0),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -141,6 +151,39 @@ class TranslationResumeState:
 
     def mark_completed(self) -> "TranslationResumeState":
         return replace(self, status=COMPLETED_STATUS, updated_at=_utc_now())
+
+    def start_chapter(self, name: str, total: int) -> "TranslationResumeState":
+        return replace(
+            self,
+            current_chapter=name,
+            total_chapters=total,
+            updated_at=_utc_now(),
+        )
+
+    def record_chapter(
+        self,
+        name: str,
+        total: int,
+        ok: bool,
+        failed_segment_count: int = 0,
+    ) -> "TranslationResumeState":
+        completed = self.completed_chapters
+        failed = self.failed_chapters
+        failures = self.failed_segment_count
+        if ok:
+            completed = completed + (name,)
+        else:
+            failed = failed + (name,)
+            failures = failures + failed_segment_count
+        return replace(
+            self,
+            total_chapters=total,
+            current_chapter=None,
+            completed_chapters=completed,
+            failed_chapters=failed,
+            failed_segment_count=failures,
+            updated_at=_utc_now(),
+        )
 
 
 @dataclass(frozen=True)
@@ -231,6 +274,35 @@ def _optional_text(data: dict[str, object], key: str) -> str | None:
     if not isinstance(value, str) or not value.strip():
         raise ResumeStateError(f"Resume state field {key} must be a non-empty string or null.")
     return value
+
+
+def _optional_int_or_none(data: dict[str, object], key: str) -> int | None:
+    if key not in data or data[key] is None:
+        return None
+    value = data[key]
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ResumeStateError(f"Resume state field {key} must be an integer or null.")
+    return value
+
+
+def _optional_int_default(data: dict[str, object], key: str, default: int) -> int:
+    if key not in data:
+        return default
+    value = data[key]
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ResumeStateError(f"Resume state field {key} must be an integer.")
+    return value
+
+
+def _optional_str_tuple(data: dict[str, object], key: str) -> tuple[str, ...]:
+    if key not in data:
+        return ()
+    value = data[key]
+    if not isinstance(value, list) or not all(
+        isinstance(item, str) and item.strip() for item in value
+    ):
+        raise ResumeStateError(f"Resume state field {key} must be a list of non-empty strings.")
+    return tuple(value)
 
 
 def _required_number(data: dict[str, object], key: str) -> float:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,6 +18,7 @@ from ayvu.cli import (
 from ayvu.domain import LanguagePair, OutputPlan, TranslationOptions, UserMode
 from ayvu.epub_io import ReviewApplyReport, TranslationReport
 from ayvu.glossary import GlossaryUsage
+from ayvu.html_translate import HtmlTranslationStats
 from ayvu.library import LibraryOpenError
 from ayvu.preflight import PreflightError
 from ayvu.resume import COMPLETED_STATUS, ResumeStateStore, TranslationResumeState
@@ -531,6 +532,168 @@ def test_root_command_without_processing_state_has_no_processing_noise(tmp_path,
     assert "Canceled." in result.output
     assert "Translations in progress were found." not in result.output
     assert "Invalid processing state files were found." not in result.output
+
+
+def _running_resume_state(
+    tmp_path: Path,
+    stem: str,
+    target: str,
+    create_epub: bool = True,
+) -> TranslationResumeState:
+    epub_path = tmp_path / "Original" / f"{stem}.epub"
+    if create_epub:
+        epub_path.parent.mkdir(parents=True, exist_ok=True)
+        epub_path.write_bytes(b"fake epub")
+    return TranslationResumeState.create(
+        input_path=epub_path,
+        output_path=tmp_path / "Traduzidos" / f"{stem}-{target}.epub",
+        cache_path=tmp_path / "cache.sqlite",
+        translator_name="libretranslate",
+        url="http://localhost:5000",
+        glossary_path=None,
+        options=TranslationOptions(language_pair=LanguagePair(source="en", target=target)),
+        overwrite=False,
+        timeout=30.0,
+        retries=2,
+    )
+
+
+def _patch_resume_pipeline(monkeypatch, processing_dir: Path, calls: dict[str, object]) -> None:
+    def fake_translate(input_path: Path, output_path: Path, **kwargs: object) -> TranslationReport:
+        options = kwargs["options"]
+        calls["options"] = options
+        return TranslationReport(
+            output_path=output_path,
+            input_path=input_path,
+            target_language=options.target,
+        )
+
+    monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: processing_dir)
+    monkeypatch.setattr(
+        "ayvu.cli.run_translation_preflight",
+        lambda **_kwargs: SimpleNamespace(translator=object(), glossary=None, route=None),
+    )
+    monkeypatch.setattr("ayvu.cli.TranslationCache", lambda _path: FakeCache())
+    monkeypatch.setattr("ayvu.cli.translate_epub", fake_translate)
+    monkeypatch.setattr(
+        "ayvu.cli.validate_output_epub",
+        lambda _path, on_progress=None: ValidationResult(ok=True, document_count=1),
+    )
+    monkeypatch.setattr("ayvu.cli._offer_markdown_report", lambda *_args, **_kwargs: None)
+
+
+def test_resume_command_resumes_single_state(tmp_path, monkeypatch):
+    processing_dir = tmp_path / "Processando"
+    state = _running_resume_state(tmp_path, "book", "pt").record_chapter(
+        "chapter-one.xhtml", 2, ok=True
+    )
+    ResumeStateStore(processing_dir).save(state)
+    calls: dict[str, object] = {}
+    _patch_resume_pipeline(monkeypatch, processing_dir, calls)
+
+    result = runner.invoke(app, ["resume"])
+
+    assert result.exit_code == 0
+    assert "Resuming translation:" in result.output
+    assert "Resume checkpoint" in result.output
+    assert "1/2" in result.output
+    assert calls["options"].source == "en"
+    assert calls["options"].target == "pt"
+
+
+def test_resume_command_without_state_reports_clear_error(tmp_path, monkeypatch):
+    monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: tmp_path / "missing")
+
+    result = runner.invoke(app, ["resume"])
+
+    assert result.exit_code == 1
+    assert "No translation in progress was found to resume." in result.output
+    assert "ayvu translate" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_resume_command_selects_state_by_epub_and_target(tmp_path, monkeypatch):
+    processing_dir = tmp_path / "Processando"
+    store = ResumeStateStore(processing_dir)
+    store.save(_running_resume_state(tmp_path, "alpha", "pt"))
+    beta = _running_resume_state(tmp_path, "beta", "es")
+    store.save(beta)
+    calls: dict[str, object] = {}
+    _patch_resume_pipeline(monkeypatch, processing_dir, calls)
+
+    result = runner.invoke(app, ["resume", str(beta.input_path), "--target", "es"])
+
+    assert result.exit_code == 0
+    assert "beta.epub" in result.output
+    assert calls["options"].target == "es"
+
+
+def test_resume_command_requires_disambiguation_for_multiple_states(tmp_path, monkeypatch):
+    processing_dir = tmp_path / "Processando"
+    store = ResumeStateStore(processing_dir)
+    store.save(_running_resume_state(tmp_path, "alpha", "pt"))
+    store.save(_running_resume_state(tmp_path, "beta", "es"))
+    monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: processing_dir)
+
+    result = runner.invoke(app, ["resume"])
+
+    assert result.exit_code == 1
+    assert "Several translations in progress match the request." in result.output
+    assert "Specify the EPUB and --target" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_translate_command_records_chapter_checkpoint(tmp_path, monkeypatch):
+    epub_path = tmp_path / "book.epub"
+    output_path = tmp_path / "book-pt.epub"
+    cache_path = tmp_path / "cache.sqlite"
+    processing_dir = tmp_path / "Processando"
+    epub_path.write_bytes(b"fake epub")
+
+    def fake_translate(*_args: object, **kwargs: object) -> TranslationReport:
+        kwargs["on_chapter_start"](1, 2, "chapter-one.xhtml")
+        kwargs["on_chapter_done"](1, 2, "chapter-one.xhtml", HtmlTranslationStats())
+        kwargs["on_chapter_start"](2, 2, "chapter-two.xhtml")
+        kwargs["on_chapter_done"](
+            2, 2, "chapter-two.xhtml", HtmlTranslationStats(errors=["boom"], missing=1)
+        )
+        return TranslationReport(output_path=output_path, input_path=epub_path, target_language="pt")
+
+    monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: processing_dir)
+    monkeypatch.setattr(
+        "ayvu.cli.run_translation_preflight",
+        lambda **_kwargs: SimpleNamespace(translator=object(), glossary=None, route=None),
+    )
+    monkeypatch.setattr("ayvu.cli.TranslationCache", lambda _path: FakeCache())
+    monkeypatch.setattr("ayvu.cli.translate_epub", fake_translate)
+    monkeypatch.setattr(
+        "ayvu.cli.validate_output_epub",
+        lambda _path, on_progress=None: ValidationResult(ok=True, document_count=1),
+    )
+    monkeypatch.setattr("ayvu.cli._offer_markdown_report", lambda *_args, **_kwargs: None)
+
+    result = runner.invoke(
+        app,
+        [
+            "translate",
+            str(epub_path),
+            "--output",
+            str(output_path),
+            "--cache",
+            str(cache_path),
+            "--source",
+            "en",
+            "--target",
+            "pt",
+        ],
+    )
+
+    saved = ResumeStateStore(processing_dir).load(processing_dir / "book-pt.ayvu-state.json")
+    assert result.exit_code == 0
+    assert saved.completed_chapters == ("chapter-one.xhtml",)
+    assert saved.failed_chapters == ("chapter-two.xhtml",)
+    assert saved.failed_segment_count == 2
+    assert saved.total_chapters == 2
 
 
 def test_root_command_generates_guided_preview_when_confirmed(tmp_path, monkeypatch):
@@ -2042,10 +2205,11 @@ def test_translate_command_handles_keyboard_interrupt_cleanly(tmp_path, monkeypa
         kwargs["on_text_processed"]("translated")
         kwargs["on_text_processed"]("cache")
         kwargs["on_text_processed"]("error")
-        kwargs["on_chapter_done"](1, 3, "chapter-one.xhtml", object())
+        kwargs["on_chapter_done"](1, 3, "chapter-one.xhtml", HtmlTranslationStats())
         kwargs["on_chapter_start"](2, 3, "chapter-two.xhtml")
         raise KeyboardInterrupt
 
+    monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: tmp_path / "Processando")
     monkeypatch.setattr(
         "ayvu.cli.run_translation_preflight",
         lambda **_kwargs: SimpleNamespace(translator=object(), glossary=None, route=None),

--- a/tests/test_resume.py
+++ b/tests/test_resume.py
@@ -132,6 +132,85 @@ def test_resume_state_load_defaults_missing_chapter_selection_to_none(tmp_path):
     assert loaded.chapter_selection is None
 
 
+def test_resume_state_starts_with_empty_progress(tmp_path):
+    state = make_state(tmp_path)
+
+    assert state.total_chapters is None
+    assert state.current_chapter is None
+    assert state.completed_chapters == ()
+    assert state.failed_chapters == ()
+    assert state.failed_segment_count == 0
+
+
+def test_resume_state_start_chapter_sets_current_and_total(tmp_path):
+    state = make_state(tmp_path)
+
+    started = state.start_chapter("chapter-one.xhtml", 12)
+
+    assert started.current_chapter == "chapter-one.xhtml"
+    assert started.total_chapters == 12
+    assert started.completed_chapters == ()
+
+
+def test_resume_state_record_chapter_accumulates_completed_and_failed(tmp_path):
+    state = make_state(tmp_path).start_chapter("chapter-one.xhtml", 3)
+
+    after_first = state.record_chapter("chapter-one.xhtml", 3, ok=True)
+    after_second = after_first.record_chapter(
+        "chapter-two.xhtml", 3, ok=False, failed_segment_count=2
+    )
+
+    assert after_first.completed_chapters == ("chapter-one.xhtml",)
+    assert after_first.current_chapter is None
+    assert after_second.completed_chapters == ("chapter-one.xhtml",)
+    assert after_second.failed_chapters == ("chapter-two.xhtml",)
+    assert after_second.failed_segment_count == 2
+    assert after_second.total_chapters == 3
+
+
+def test_resume_state_progress_round_trip(tmp_path):
+    store = ResumeStateStore(tmp_path / "Processando")
+    state = (
+        make_state(tmp_path)
+        .record_chapter("chapter-one.xhtml", 4, ok=True)
+        .record_chapter("chapter-two.xhtml", 4, ok=False, failed_segment_count=3)
+        .start_chapter("chapter-three.xhtml", 4)
+    )
+
+    path = store.save(state)
+    loaded = store.load(path)
+
+    assert loaded == state
+    assert loaded.completed_chapters == ("chapter-one.xhtml",)
+    assert loaded.failed_chapters == ("chapter-two.xhtml",)
+    assert loaded.failed_segment_count == 3
+    assert loaded.current_chapter == "chapter-three.xhtml"
+    assert loaded.total_chapters == 4
+
+
+def test_resume_state_load_defaults_missing_progress_fields(tmp_path):
+    path = tmp_path / "old.ayvu-state.json"
+    data = make_state(tmp_path).to_dict()
+    for key in (
+        "total_chapters",
+        "current_chapter",
+        "completed_chapters",
+        "failed_chapters",
+        "failed_segment_count",
+    ):
+        data.pop(key, None)
+    path.write_text(json.dumps(data), encoding="utf-8")
+    store = ResumeStateStore(tmp_path)
+
+    loaded = store.load(path)
+
+    assert loaded.total_chapters is None
+    assert loaded.current_chapter is None
+    assert loaded.completed_chapters == ()
+    assert loaded.failed_chapters == ()
+    assert loaded.failed_segment_count == 0
+
+
 def test_resume_state_scan_finds_running_and_invalid_states(tmp_path):
     store = ResumeStateStore(tmp_path / "Processando")
     running = make_state(tmp_path, "running-book")


### PR DESCRIPTION
## Objective

Make resuming long translations clearer and more reliable by turning the
resume state into an explicit progress checkpoint and exposing a resume
command.

## What changed

- resume.py: optional progress fields on TranslationResumeState
  (total_chapters, current_chapter, completed_chapters, failed_chapters,
  failed_segment_count) plus start_chapter/record_chapter; existing state
  files remain loadable (no version bump).
- cli.py: the checkpoint is saved after each chapter during a real
  translation; new "ayvu resume [EPUB] [--target]" command loads the saved
  checkpoint and reuses its options; the checkpoint summary is shown on
  resume, in the common-mode resume prompt and after an interruption;
  resume forces overwrite so a partial output never blocks it.
- Docs: README, tutorial and CHANGELOG, documenting the command and how
  checkpoints relate to the translation cache.

## Out of scope

- Persisting the original text of each failed segment in the state file
  (segment-level retry is handled by the cache).
- Skipping already-completed chapters on resume (the EPUB is rewritten in
  full, so all chapters are reprocessed; the cache keeps this cheap).

## Validation

- COLUMNS=200 uv run pytest: 279 tests passing.
- git diff --check: no errors.

## Related issue

Closes #97
