### PR TITLE
Add retry backoff and rate limiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ lancadas e secoes versionadas quando uma release for publicada.
 - Memoria de traducao opcional (`--translation-memory`) que reaproveita trechos
   parecidos por similaridade, com aplicacao acima de `--tm-apply-threshold` e
   sugestao de revisao entre `--tm-suggest-threshold` e `--tm-apply-threshold`.
+- Controles de execucao do tradutor com `--requests-per-second`,
+  `--retry-backoff` e `--retry-backoff-max`, incluindo retry de HTTP `429` e
+  HTTP `5xx` com backoff exponencial.
 - Estado local de retomada em `~/Documentos/Livros/Processando` ou na pasta de
   processamento configurada.
 - Checkpoints de progresso no estado de retomada, atualizados a cada capitulo com

--- a/README.md
+++ b/README.md
@@ -299,6 +299,35 @@ Antes de iniciar a tradução, o Ayvu verifica internamente o par de idiomas, o 
 
 O Ayvu também resolve a rota de tradução consultando os idiomas do LibreTranslate: se não houver caminho direto entre origem e destino, tenta uma rota intermediária via inglês (por exemplo `fr -> en -> pt`). Quando a rota intermediária é usada, o modo comum avisa que a tradução passará por 2 etapas e que a qualidade pode ficar comprometida; o modo desenvolvedor mostra a rota explicitamente. Se nenhuma rota estiver disponível, o comando falha antes de processar o EPUB.
 
+### Controle de requisições ao tradutor
+
+Por padrão, o Ayvu não limita a taxa de requisições ao tradutor local. Para servidores mais
+fracos ou instáveis, use `--requests-per-second` para limitar quantas chamadas HTTP podem
+começar por segundo:
+
+```bash
+uv run ayvu translate livro.epub \
+  --target pt \
+  --url http://localhost:5000 \
+  --requests-per-second 2
+```
+
+Retries são controlados por `--retries`. Falhas de conexão, timeout, HTTP `429` e HTTP `5xx`
+podem ser tentadas novamente. O atraso entre tentativas usa backoff exponencial: começa em
+`--retry-backoff` segundos, por padrão `0.5`, e é limitado por `--retry-backoff-max`, por
+padrão `8.0`.
+
+```bash
+uv run ayvu translate livro.epub \
+  --target pt \
+  --retries 4 \
+  --retry-backoff 1 \
+  --retry-backoff-max 10
+```
+
+As mesmas opções também existem em `test-translator` e `languages`, para testar o servidor com
+os controles que serão usados na tradução.
+
 Sem `--output`, o Ayvu salva por padrão em:
 
 ```text
@@ -446,6 +475,8 @@ uv run ayvu translate livro.epub \
 ```
 
 Trechos já traduzidos serão reaproveitados automaticamente.
+O checkpoint de retomada preserva as opções de execução do tradutor, como timeout, retries,
+limite de requisições por segundo e backoff.
 
 O cache pode ser inspecionado, limpo, exportado e importado separadamente dos
 comandos de tradução:

--- a/docs/tutorial-modo-comum-e-dev.md
+++ b/docs/tutorial-modo-comum-e-dev.md
@@ -550,8 +550,15 @@ uv run ayvu --mode developer translate livro.epub \
   --source en \
   --target pt \
   --url http://localhost:5000 \
-  --cache .cache/traducoes.sqlite
+  --cache .cache/traducoes.sqlite \
+  --requests-per-second 2 \
+  --retries 4 \
+  --retry-backoff 1 \
+  --retry-backoff-max 10
 ```
+
+Use `--requests-per-second` quando o servidor local ficar instável sob muitas chamadas. O retry
+usa backoff exponencial para falhas de conexão, timeout, HTTP `429` e HTTP `5xx`.
 
 ## Checklist recomendado
 

--- a/src/ayvu/cli.py
+++ b/src/ayvu/cli.py
@@ -80,6 +80,8 @@ DEFAULT_TARGET_LANGUAGE = "pt"
 DEFAULT_TRANSLATOR_URL = "http://localhost:5000"
 DEFAULT_CACHE_PATH = Path(".cache/traducoes.sqlite")
 DEFAULT_PREVIEW_DOCUMENT_LIMIT = 12
+DEFAULT_RETRY_BACKOFF = 0.5
+DEFAULT_RETRY_BACKOFF_MAX = 8.0
 GUIDED_TRANSLATE_OPTION = "1"
 GUIDED_PREVIEW_OPTION = "2"
 GUIDED_LIBRARY_OPTION = "3"
@@ -198,11 +200,33 @@ def test_translator(
     target: str = typer.Option(DEFAULT_TARGET_LANGUAGE, "--target"),
     timeout: float = typer.Option(10.0, "--timeout"),
     retries: int = typer.Option(1, "--retries"),
+    requests_per_second: Optional[float] = typer.Option(
+        None,
+        "--requests-per-second",
+        help="Maximum translator HTTP requests per second. Omit for no rate limit.",
+    ),
+    retry_backoff: float = typer.Option(
+        DEFAULT_RETRY_BACKOFF,
+        "--retry-backoff",
+        help="Initial retry backoff delay in seconds.",
+    ),
+    retry_backoff_max: float = typer.Option(
+        DEFAULT_RETRY_BACKOFF_MAX,
+        "--retry-backoff-max",
+        help="Maximum retry backoff delay in seconds.",
+    ),
 ) -> None:
     """Test connectivity with the local translator."""
     mode = ctx.obj.get("mode", UserMode.DEVELOPER)
-    translator = LibreTranslateTranslator(url=url, timeout=timeout, retries=retries)
     try:
+        translator = LibreTranslateTranslator(
+            url=url,
+            timeout=timeout,
+            retries=retries,
+            requests_per_second=requests_per_second,
+            retry_backoff=retry_backoff,
+            retry_backoff_max=retry_backoff_max,
+        )
         translated = translator.translate("Hello world", source, target)
     except TranslatorError as exc:
         _print_expected_error(
@@ -221,11 +245,33 @@ def languages(
     url: str = typer.Option(DEFAULT_TRANSLATOR_URL, "--url", help="LibreTranslate base URL or /translate endpoint."),
     timeout: float = typer.Option(10.0, "--timeout"),
     retries: int = typer.Option(1, "--retries"),
+    requests_per_second: Optional[float] = typer.Option(
+        None,
+        "--requests-per-second",
+        help="Maximum translator HTTP requests per second. Omit for no rate limit.",
+    ),
+    retry_backoff: float = typer.Option(
+        DEFAULT_RETRY_BACKOFF,
+        "--retry-backoff",
+        help="Initial retry backoff delay in seconds.",
+    ),
+    retry_backoff_max: float = typer.Option(
+        DEFAULT_RETRY_BACKOFF_MAX,
+        "--retry-backoff-max",
+        help="Maximum retry backoff delay in seconds.",
+    ),
 ) -> None:
     """List languages reported by the local LibreTranslate server."""
     mode = ctx.obj.get("mode", UserMode.DEVELOPER)
-    translator = LibreTranslateTranslator(url=url, timeout=timeout, retries=retries)
     try:
+        translator = LibreTranslateTranslator(
+            url=url,
+            timeout=timeout,
+            retries=retries,
+            requests_per_second=requests_per_second,
+            retry_backoff=retry_backoff,
+            retry_backoff_max=retry_backoff_max,
+        )
         available_languages = translator.list_languages()
     except TranslatorError as exc:
         _print_expected_error(
@@ -447,7 +493,26 @@ def translate(
     ),
     overwrite: bool = typer.Option(False, "--overwrite", help="Allow replacing an existing output file."),
     timeout: float = typer.Option(30.0, "--timeout", help="Translator HTTP timeout in seconds."),
-    retries: int = typer.Option(2, "--retries", help="Simple HTTP retry count."),
+    retries: int = typer.Option(
+        2,
+        "--retries",
+        help="HTTP retry count for connection errors, timeouts, 429, and 5xx.",
+    ),
+    requests_per_second: Optional[float] = typer.Option(
+        None,
+        "--requests-per-second",
+        help="Maximum translator HTTP requests per second. Omit for no rate limit.",
+    ),
+    retry_backoff: float = typer.Option(
+        DEFAULT_RETRY_BACKOFF,
+        "--retry-backoff",
+        help="Initial retry backoff delay in seconds.",
+    ),
+    retry_backoff_max: float = typer.Option(
+        DEFAULT_RETRY_BACKOFF_MAX,
+        "--retry-backoff-max",
+        help="Maximum retry backoff delay in seconds.",
+    ),
     translate_metadata: bool = typer.Option(
         False,
         "--translate-metadata",
@@ -534,6 +599,9 @@ def translate(
             overwrite=overwrite,
             timeout=timeout,
             retries=retries,
+            requests_per_second=requests_per_second,
+            retry_backoff=retry_backoff,
+            retry_backoff_max=retry_backoff_max,
             chunk_limit=chunk_limit,
             mode=mode,
             config=config,
@@ -563,6 +631,9 @@ def translate(
         overwrite=overwrite,
         timeout=timeout,
         retries=retries,
+        requests_per_second=requests_per_second,
+        retry_backoff=retry_backoff,
+        retry_backoff_max=retry_backoff_max,
         chunk_limit=chunk_limit,
         mode=mode,
         config=config,
@@ -1042,6 +1113,9 @@ def _run_translation(
     overwrite: bool,
     timeout: float,
     retries: int,
+    requests_per_second: float | None,
+    retry_backoff: float,
+    retry_backoff_max: float,
     chunk_limit: int,
     mode: UserMode,
     config: AyvuConfig | None = None,
@@ -1116,6 +1190,9 @@ def _run_translation(
             url=url,
             timeout=timeout,
             retries=retries,
+            requests_per_second=requests_per_second,
+            retry_backoff=retry_backoff,
+            retry_backoff_max=retry_backoff_max,
             language_pair=language_pair,
             dry_run=dry_run,
             cache_only=cache_only,
@@ -1140,6 +1217,9 @@ def _run_translation(
             overwrite=overwrite,
             timeout=timeout,
             retries=retries,
+            requests_per_second=requests_per_second,
+            retry_backoff=retry_backoff,
+            retry_backoff_max=retry_backoff_max,
             processing_dir=_processing_dir(config),
         )
 
@@ -1268,6 +1348,9 @@ def _run_batch_translation(
     overwrite: bool,
     timeout: float,
     retries: int,
+    requests_per_second: float | None,
+    retry_backoff: float,
+    retry_backoff_max: float,
     chunk_limit: int,
     mode: UserMode,
     config: AyvuConfig,
@@ -1309,6 +1392,9 @@ def _run_batch_translation(
                 overwrite=overwrite,
                 timeout=timeout,
                 retries=retries,
+                requests_per_second=requests_per_second,
+                retry_backoff=retry_backoff,
+                retry_backoff_max=retry_backoff_max,
                 chunk_limit=chunk_limit,
                 mode=mode,
                 config=config,
@@ -1408,6 +1494,9 @@ def _run_preview(
     glossary_path: Path | None = None,
     timeout: float = 30.0,
     retries: int = 2,
+    requests_per_second: float | None = None,
+    retry_backoff: float = DEFAULT_RETRY_BACKOFF,
+    retry_backoff_max: float = DEFAULT_RETRY_BACKOFF_MAX,
     chunk_limit: int = 3000,
     max_documents: int = DEFAULT_PREVIEW_DOCUMENT_LIMIT,
     mode: UserMode = UserMode.DEVELOPER,
@@ -1444,6 +1533,9 @@ def _run_preview(
             url=url,
             timeout=timeout,
             retries=retries,
+            requests_per_second=requests_per_second,
+            retry_backoff=retry_backoff,
+            retry_backoff_max=retry_backoff_max,
             language_pair=language_pair,
             dry_run=False,
         )
@@ -1988,6 +2080,9 @@ def _run_guided_translation(config: AyvuConfig) -> None:
         overwrite=False,
         timeout=30.0,
         retries=2,
+        requests_per_second=None,
+        retry_backoff=DEFAULT_RETRY_BACKOFF,
+        retry_backoff_max=DEFAULT_RETRY_BACKOFF_MAX,
         chunk_limit=3000,
         mode=UserMode.COMMON,
         config=config,
@@ -2661,6 +2756,9 @@ def _resume_translation(state: TranslationResumeState, mode: UserMode) -> None:
             overwrite=True,
             timeout=state.timeout,
             retries=state.retries,
+            requests_per_second=state.requests_per_second,
+            retry_backoff=state.retry_backoff,
+            retry_backoff_max=state.retry_backoff_max,
             chunk_limit=state.chunk_limit,
             mode=mode,
             translate_metadata=state.translate_metadata,
@@ -2782,6 +2880,9 @@ def _save_running_resume_state(
     overwrite: bool,
     timeout: float,
     retries: int,
+    requests_per_second: float | None,
+    retry_backoff: float,
+    retry_backoff_max: float,
     processing_dir: Path,
 ) -> tuple[ResumeStateStore, TranslationResumeState]:
     store = ResumeStateStore(processing_dir)
@@ -2796,6 +2897,9 @@ def _save_running_resume_state(
         overwrite=overwrite,
         timeout=timeout,
         retries=retries,
+        requests_per_second=requests_per_second,
+        retry_backoff=retry_backoff,
+        retry_backoff_max=retry_backoff_max,
     )
     _save_resume_state(store, state)
     return store, state

--- a/src/ayvu/preflight.py
+++ b/src/ayvu/preflight.py
@@ -46,10 +46,21 @@ def run_translation_preflight(
     language_pair: LanguagePair,
     dry_run: bool,
     cache_only: bool = False,
+    requests_per_second: float | None = None,
+    retry_backoff: float = 0.5,
+    retry_backoff_max: float = 8.0,
 ) -> TranslationPreflightResult:
     _check_language_pair(language_pair)
     glossary = _load_checked_glossary(glossary_path)
-    translator = _create_checked_translator(translator_name, url, timeout, retries)
+    translator = _create_checked_translator(
+        translator_name,
+        url,
+        timeout,
+        retries,
+        requests_per_second=requests_per_second,
+        retry_backoff=retry_backoff,
+        retry_backoff_max=retry_backoff_max,
+    )
     _check_cache(cache_path)
     _check_epub(epub_path)
     route: TranslationRoute | None = None
@@ -82,9 +93,25 @@ def _load_checked_glossary(glossary_path: Path | None) -> Glossary:
         ) from exc
 
 
-def _create_checked_translator(name: str, url: str, timeout: float, retries: int) -> Translator:
+def _create_checked_translator(
+    name: str,
+    url: str,
+    timeout: float,
+    retries: int,
+    requests_per_second: float | None,
+    retry_backoff: float,
+    retry_backoff_max: float,
+) -> Translator:
     try:
-        return create_translator(name, url=url, timeout=timeout, retries=retries)
+        return create_translator(
+            name,
+            url=url,
+            timeout=timeout,
+            retries=retries,
+            requests_per_second=requests_per_second,
+            retry_backoff=retry_backoff,
+            retry_backoff_max=retry_backoff_max,
+        )
     except TranslatorError as exc:
         raise PreflightError(
             "Não foi possível preparar o tradutor.",

--- a/src/ayvu/resume.py
+++ b/src/ayvu/resume.py
@@ -61,6 +61,9 @@ class TranslationResumeState:
     translation_memory_apply_threshold: float | None = None
     translation_memory_suggest_threshold: float | None = None
     translation_memory_max_candidates: int | None = None
+    requests_per_second: float | None = None
+    retry_backoff: float = 0.5
+    retry_backoff_max: float = 8.0
     total_chapters: int | None = None
     current_chapter: str | None = None
     completed_chapters: tuple[str, ...] = ()
@@ -80,6 +83,9 @@ class TranslationResumeState:
         overwrite: bool,
         timeout: float,
         retries: int,
+        requests_per_second: float | None = None,
+        retry_backoff: float = 0.5,
+        retry_backoff_max: float = 8.0,
     ) -> "TranslationResumeState":
         now = _utc_now()
         return cls(
@@ -113,6 +119,9 @@ class TranslationResumeState:
             translation_memory_max_candidates=(
                 options.translation_memory.max_candidates if options.translation_memory else None
             ),
+            requests_per_second=requests_per_second,
+            retry_backoff=retry_backoff,
+            retry_backoff_max=retry_backoff_max,
         )
 
     @classmethod
@@ -159,6 +168,9 @@ class TranslationResumeState:
             translation_memory_max_candidates=_optional_int_or_none(
                 data, "translation_memory_max_candidates"
             ),
+            requests_per_second=_optional_number_or_none(data, "requests_per_second"),
+            retry_backoff=_optional_number(data, "retry_backoff", default=0.5),
+            retry_backoff_max=_optional_number(data, "retry_backoff_max", default=8.0),
             total_chapters=_optional_int_or_none(data, "total_chapters"),
             current_chapter=_optional_text(data, "current_chapter"),
             completed_chapters=_optional_str_tuple(data, "completed_chapters"),
@@ -328,6 +340,15 @@ def _optional_number_or_none(data: dict[str, object], key: str) -> float | None:
     value = data[key]
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         raise ResumeStateError(f"Resume state field {key} must be a number or null.")
+    return float(value)
+
+
+def _optional_number(data: dict[str, object], key: str, default: float) -> float:
+    if key not in data:
+        return default
+    value = data[key]
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ResumeStateError(f"Resume state field {key} must be a number.")
     return float(value)
 
 

--- a/src/ayvu/translator.py
+++ b/src/ayvu/translator.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import time
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Protocol
 
 import requests
@@ -131,6 +131,16 @@ class LibreTranslatePayload:
 @dataclass(frozen=True)
 class RetryPolicy:
     retries: int
+    backoff: float = 0.5
+    max_backoff: float = 8.0
+
+    def __post_init__(self) -> None:
+        if self.retries < 0:
+            raise TranslatorError("retry count must be zero or greater")
+        if self.backoff < 0:
+            raise TranslatorError("retry backoff must be zero or greater")
+        if self.max_backoff < 0:
+            raise TranslatorError("retry backoff max must be zero or greater")
 
     @property
     def max_attempts(self) -> int:
@@ -143,7 +153,41 @@ class RetryPolicy:
         return attempt < self.max_attempts
 
     def delay_for(self, attempt: int) -> float:
-        return 0.5 * attempt
+        if self.backoff == 0 or self.max_backoff == 0:
+            return 0.0
+        return min(self.max_backoff, self.backoff * (2 ** max(0, attempt - 1)))
+
+    def should_retry_status(self, status_code: int, attempt: int) -> bool:
+        return (status_code == 429 or status_code >= 500) and self.can_retry(attempt)
+
+
+@dataclass
+class RequestRateLimiter:
+    requests_per_second: float | None = None
+    _last_request_at: float | None = field(default=None, init=False)
+
+    def __post_init__(self) -> None:
+        if self.requests_per_second is not None and self.requests_per_second <= 0:
+            raise TranslatorError("requests per second must be greater than zero")
+
+    def wait(self) -> None:
+        if self.requests_per_second is None:
+            return
+
+        interval = 1.0 / self.requests_per_second
+        now = time.monotonic()
+        if self._last_request_at is None:
+            self._last_request_at = now
+            return
+
+        next_request_at = self._last_request_at + interval
+        delay = next_request_at - now
+        if delay > 0:
+            time.sleep(delay)
+            self._last_request_at = next_request_at
+            return
+
+        self._last_request_at = now
 
 
 class LibreTranslateResponseParser:
@@ -193,11 +237,19 @@ class LibreTranslateTranslator(Translator):
     url: str = "http://localhost:5000"
     timeout: float = 30.0
     retries: int = 2
+    requests_per_second: float | None = None
+    retry_backoff: float = 0.5
+    retry_backoff_max: float = 8.0
 
     def __post_init__(self) -> None:
         self.endpoint = self._normalize_endpoint(self.url)
         self.session: HttpSession = requests.Session()
-        self.retry_policy = RetryPolicy(self.retries)
+        self.retry_policy = RetryPolicy(
+            self.retries,
+            backoff=self.retry_backoff,
+            max_backoff=self.retry_backoff_max,
+        )
+        self.rate_limiter = RequestRateLimiter(self.requests_per_second)
         self.response_parser = LibreTranslateResponseParser()
 
     def translate(self, text: str, source: str, target: str) -> str:
@@ -274,13 +326,15 @@ class LibreTranslateTranslator(Translator):
         raise TranslatorError(f"LibreTranslate languages request failed: {last_error}")
 
     def _post(self, payload: LibreTranslatePayload) -> requests.Response:
+        self.rate_limiter.wait()
         return self.session.post(self.endpoint, json=payload.as_json(), timeout=self.timeout)
 
     def _get_languages(self, endpoint: str) -> requests.Response:
+        self.rate_limiter.wait()
         return self.session.get(endpoint, timeout=self.timeout)
 
     def _should_retry_response(self, response: requests.Response, attempt: int) -> bool:
-        return response.status_code >= 500 and self.retry_policy.can_retry(attempt)
+        return self.retry_policy.should_retry_status(response.status_code, attempt)
 
     def _retry_after_exception(self, attempt: int) -> bool:
         if not self.retry_policy.can_retry(attempt):
@@ -315,8 +369,23 @@ class LibreTranslateTranslator(Translator):
         return clean
 
 
-def create_translator(name: str, url: str, timeout: float = 30.0, retries: int = 2) -> Translator:
+def create_translator(
+    name: str,
+    url: str,
+    timeout: float = 30.0,
+    retries: int = 2,
+    requests_per_second: float | None = None,
+    retry_backoff: float = 0.5,
+    retry_backoff_max: float = 8.0,
+) -> Translator:
     if name != "libretranslate":
         supported = ", ".join(SUPPORTED_TRANSLATORS)
         raise UnsupportedTranslatorError(f"Unsupported translator: {name}. Supported translators: {supported}.")
-    return LibreTranslateTranslator(url=url, timeout=timeout, retries=retries)
+    return LibreTranslateTranslator(
+        url=url,
+        timeout=timeout,
+        retries=retries,
+        requests_per_second=requests_per_second,
+        retry_backoff=retry_backoff,
+        retry_backoff_max=retry_backoff_max,
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -177,10 +177,21 @@ def test_languages_command_lists_translator_languages(monkeypatch):
     calls: dict[str, object] = {}
 
     class FakeLanguageTranslator:
-        def __init__(self, url: str, timeout: float, retries: int) -> None:
+        def __init__(
+            self,
+            url: str,
+            timeout: float,
+            retries: int,
+            requests_per_second: float | None = None,
+            retry_backoff: float = 0.5,
+            retry_backoff_max: float = 8.0,
+        ) -> None:
             calls["url"] = url
             calls["timeout"] = timeout
             calls["retries"] = retries
+            calls["requests_per_second"] = requests_per_second
+            calls["retry_backoff"] = retry_backoff
+            calls["retry_backoff_max"] = retry_backoff_max
 
         def list_languages(self) -> tuple[TranslatorLanguage, ...]:
             return (
@@ -190,10 +201,34 @@ def test_languages_command_lists_translator_languages(monkeypatch):
 
     monkeypatch.setattr("ayvu.cli.LibreTranslateTranslator", FakeLanguageTranslator)
 
-    result = runner.invoke(app, ["languages", "--url", "http://localhost:5000", "--timeout", "2", "--retries", "0"])
+    result = runner.invoke(
+        app,
+        [
+            "languages",
+            "--url",
+            "http://localhost:5000",
+            "--timeout",
+            "2",
+            "--retries",
+            "0",
+            "--requests-per-second",
+            "3.5",
+            "--retry-backoff",
+            "0.25",
+            "--retry-backoff-max",
+            "2",
+        ],
+    )
 
     assert result.exit_code == 0
-    assert calls == {"url": "http://localhost:5000", "timeout": 2.0, "retries": 0}
+    assert calls == {
+        "url": "http://localhost:5000",
+        "timeout": 2.0,
+        "retries": 0,
+        "requests_per_second": 3.5,
+        "retry_backoff": 0.25,
+        "retry_backoff_max": 2.0,
+    }
     assert "LibreTranslate languages" in result.output
     assert "Portuguese" in result.output
     assert "pt" in result.output
@@ -2539,6 +2574,45 @@ def test_translate_explicit_source_overrides_epub_metadata(minimal_epub_path, tm
     assert result.exit_code == 0
     assert calls["options"].source == "fr"
     assert "inferido do EPUB" not in result.output
+
+
+def test_translate_command_passes_execution_controls_to_preflight_and_resume(
+    minimal_epub_path,
+    tmp_path,
+    monkeypatch,
+):
+    processing_dir = tmp_path / "Processando"
+    monkeypatch.setattr("ayvu.cli.default_translated_books_dir", lambda: tmp_path / "Traduzidos")
+    monkeypatch.setattr("ayvu.cli.default_processing_dir", lambda: processing_dir)
+    calls: dict[str, object] = {}
+    _mock_translation_pipeline(monkeypatch, calls)
+
+    result = runner.invoke(
+        app,
+        [
+            "--mode",
+            "developer",
+            "translate",
+            str(minimal_epub_path),
+            "--requests-per-second",
+            "3.5",
+            "--retry-backoff",
+            "0.25",
+            "--retry-backoff-max",
+            "2",
+        ],
+    )
+
+    preflight = calls["preflight"]
+    state_paths = list(processing_dir.glob("*.ayvu-state.json"))
+    saved_state = ResumeStateStore(processing_dir).load(state_paths[0])
+    assert result.exit_code == 0
+    assert preflight["requests_per_second"] == 3.5
+    assert preflight["retry_backoff"] == 0.25
+    assert preflight["retry_backoff_max"] == 2.0
+    assert saved_state.requests_per_second == 3.5
+    assert saved_state.retry_backoff == 0.25
+    assert saved_state.retry_backoff_max == 2.0
 
 
 def test_translate_command_uses_profile_target_and_glossary(

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -96,6 +96,44 @@ def test_preflight_dry_run_skips_translator_probe(monkeypatch, tmp_path):
     assert translator.calls == []
 
 
+def test_preflight_passes_execution_controls_to_translator_factory(monkeypatch, tmp_path):
+    translator = FakeTranslator()
+    calls: dict[str, object] = {}
+
+    def fake_create_translator(*args: object, **kwargs: object) -> FakeTranslator:
+        calls["args"] = args
+        calls["kwargs"] = kwargs
+        return translator
+
+    monkeypatch.setattr("ayvu.preflight.create_translator", fake_create_translator)
+    monkeypatch.setattr("ayvu.preflight.inspect_epub", lambda _path: object())
+
+    run_translation_preflight(
+        epub_path=tmp_path / "book.epub",
+        cache_path=tmp_path / "cache.sqlite",
+        glossary_path=None,
+        translator_name="libretranslate",
+        url="http://localhost:5000",
+        timeout=1.0,
+        retries=0,
+        requests_per_second=3.5,
+        retry_backoff=0.25,
+        retry_backoff_max=2.0,
+        language_pair=LanguagePair(source="en", target="pt"),
+        dry_run=True,
+    )
+
+    assert calls["args"] == ("libretranslate",)
+    assert calls["kwargs"] == {
+        "url": "http://localhost:5000",
+        "timeout": 1.0,
+        "retries": 0,
+        "requests_per_second": 3.5,
+        "retry_backoff": 0.25,
+        "retry_backoff_max": 2.0,
+    }
+
+
 def test_preflight_cache_only_skips_route_resolution(monkeypatch, tmp_path):
     translator = TranslatorWithLanguages(
         (TranslatorLanguage(code="en", name="English", targets=("pt",)),)

--- a/tests/test_resume.py
+++ b/tests/test_resume.py
@@ -39,6 +39,9 @@ def make_state(tmp_path: Path, stem: str = "book") -> TranslationResumeState:
         overwrite=True,
         timeout=9.5,
         retries=3,
+        requests_per_second=2.5,
+        retry_backoff=0.25,
+        retry_backoff_max=2.0,
     )
 
 
@@ -63,6 +66,9 @@ def test_resume_state_round_trip(tmp_path):
     assert loaded.chapter_selection == "1-2,*chapter3*"
     assert loaded.timeout == 9.5
     assert loaded.retries == 3
+    assert loaded.requests_per_second == 2.5
+    assert loaded.retry_backoff == 0.25
+    assert loaded.retry_backoff_max == 2.0
 
 
 def test_resume_state_round_trips_translation_memory(tmp_path):
@@ -111,6 +117,9 @@ def test_resume_state_loads_legacy_file_without_translation_memory(tmp_path):
         "translation_memory_apply_threshold",
         "translation_memory_suggest_threshold",
         "translation_memory_max_candidates",
+        "requests_per_second",
+        "retry_backoff",
+        "retry_backoff_max",
     ):
         data.pop(key, None)
     path = tmp_path / "legacy.ayvu-state.json"
@@ -120,6 +129,9 @@ def test_resume_state_loads_legacy_file_without_translation_memory(tmp_path):
 
     assert loaded.translation_memory_enabled is False
     assert loaded.translation_memory_options() is None
+    assert loaded.requests_per_second is None
+    assert loaded.retry_backoff == 0.5
+    assert loaded.retry_backoff_max == 8.0
 
 
 def test_resume_state_can_be_marked_completed(tmp_path):

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -94,6 +94,113 @@ def test_libretranslate_retries_5xx_before_success(monkeypatch: pytest.MonkeyPat
     assert sleeps == [0.5]
 
 
+def test_libretranslate_retries_429_before_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    sleeps: list[float] = []
+    session = FakeSession(
+        [
+            make_response(429, "too many requests"),
+            make_response(200, '{"translatedText": "Tudo certo"}'),
+        ]
+    )
+    translator = LibreTranslateTranslator(retries=1)
+    translator.session = session
+    monkeypatch.setattr("ayvu.translator.time.sleep", lambda delay: sleeps.append(delay))
+
+    result = translator.translate("All right", "en", "pt")
+
+    assert result == "Tudo certo"
+    assert len(session.posts) == 2
+    assert sleeps == [0.5]
+
+
+def test_libretranslate_retries_any_5xx_before_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    sleeps: list[float] = []
+    session = FakeSession(
+        [
+            make_response(508, "loop detected"),
+            make_response(200, '{"translatedText": "Tudo certo"}'),
+        ]
+    )
+    translator = LibreTranslateTranslator(retries=1)
+    translator.session = session
+    monkeypatch.setattr("ayvu.translator.time.sleep", lambda delay: sleeps.append(delay))
+
+    result = translator.translate("All right", "en", "pt")
+
+    assert result == "Tudo certo"
+    assert len(session.posts) == 2
+    assert sleeps == [0.5]
+
+
+def test_libretranslate_uses_exponential_backoff_with_max(monkeypatch: pytest.MonkeyPatch) -> None:
+    sleeps: list[float] = []
+    session = FakeSession(
+        [
+            make_response(503, "temporarily unavailable"),
+            make_response(503, "temporarily unavailable"),
+            make_response(503, "temporarily unavailable"),
+            make_response(200, '{"translatedText": "Tudo certo"}'),
+        ]
+    )
+    translator = LibreTranslateTranslator(retries=3, retry_backoff=0.25, retry_backoff_max=0.5)
+    translator.session = session
+    monkeypatch.setattr("ayvu.translator.time.sleep", lambda delay: sleeps.append(delay))
+
+    result = translator.translate("All right", "en", "pt")
+
+    assert result == "Tudo certo"
+    assert len(session.posts) == 4
+    assert sleeps == [0.25, 0.5, 0.5]
+
+
+def test_libretranslate_rate_limits_requests(monkeypatch: pytest.MonkeyPatch) -> None:
+    sleeps: list[float] = []
+    times = iter([10.0, 10.1])
+    session = FakeSession(
+        [
+            make_response(200, '{"translatedText": "Ola"}'),
+            make_response(200, '{"translatedText": "Mundo"}'),
+        ]
+    )
+    translator = LibreTranslateTranslator(retries=0, requests_per_second=2.0)
+    translator.session = session
+    monkeypatch.setattr("ayvu.translator.time.monotonic", lambda: next(times))
+    monkeypatch.setattr("ayvu.translator.time.sleep", lambda delay: sleeps.append(delay))
+
+    translator.translate("Hello", "en", "pt")
+    translator.translate("World", "en", "pt")
+
+    assert len(session.posts) == 2
+    assert sleeps == [pytest.approx(0.4)]
+
+
+def test_libretranslate_rate_limiter_is_shared_between_languages_and_translate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sleeps: list[float] = []
+    times = iter([20.0, 20.2])
+    session = FakeSession(
+        responses=[make_response(200, '{"translatedText": "Ola"}')],
+        get_responses=[
+            make_response(
+                200,
+                '[{"code": "en", "name": "English", "targets": ["pt"]}]',
+            )
+        ],
+    )
+    translator = LibreTranslateTranslator(retries=0, requests_per_second=1.0)
+    translator.session = session
+    monkeypatch.setattr("ayvu.translator.time.monotonic", lambda: next(times))
+    monkeypatch.setattr("ayvu.translator.time.sleep", lambda delay: sleeps.append(delay))
+
+    translator.list_languages()
+    translator.translate("Hello", "en", "pt")
+
+    assert len(session.gets) == 1
+    assert len(session.posts) == 1
+    assert sleeps == [pytest.approx(0.8)]
+
+
 def test_libretranslate_reports_http_error() -> None:
     session = FakeSession([make_response(400, "bad language pair")])
     translator = LibreTranslateTranslator(retries=0)


### PR DESCRIPTION
## Objective

Add configurable translator request pacing and retry backoff for long EPUB translations against limited-capacity LibreTranslate servers.

## What changed

- Added request rate limiting with `--requests-per-second` for translator HTTP calls.
- Added exponential retry backoff controls with `--retry-backoff` and `--retry-backoff-max`.
- Retried connection errors, timeouts, HTTP 429, and HTTP 5xx consistently for translation and language listing calls.
- Persisted the new execution controls in resume state so interrupted translations resume with the same settings.
- Updated user documentation, changelog, and tests for the new execution controls.

## Out of scope

- Parallel workers and concurrent cache handling remain for #116.
- Progress and report UX changes for parallel execution remain for #117.

## Validation

- `uv run pytest`: 309 tests passing.
- `git diff --check`: no errors.

## Related issue

Closes #115
Refs #99