### PR TITLE
Add parallel translation workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ lancadas e secoes versionadas quando uma release for publicada.
 - Controles de execucao do tradutor com `--requests-per-second`,
   `--retry-backoff` e `--retry-backoff-max`, incluindo retry de HTTP `429` e
   HTTP `5xx` com backoff exponencial.
+- Opcao `--workers` no comando `translate` para processar documentos internos do
+  EPUB em paralelo, mantendo `1` como padrao conservador, conexoes SQLite e
+  sessoes HTTP separadas por worker e montagem final em ordem deterministica.
 - Estado local de retomada em `~/Documentos/Livros/Processando` ou na pasta de
   processamento configurada.
 - Checkpoints de progresso no estado de retomada, atualizados a cada capitulo com

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ O EPUB original nunca é alterado. A saída é gravada em um novo arquivo `.epub
 - Tradução por bloco (parágrafos, títulos e listas) preservando tags internas como `em`, `strong` e links via placeholders.
 - Preservação de tags, CSS, imagens, links, sumário e nomes de arquivos internos.
 - Cache SQLite para retomar traduções interrompidas e evitar chamadas repetidas.
+- Execução paralela opcional por documento com `--workers`, mantendo `1` como padrão conservador.
 - Memória de tradução opcional para reaproveitar trechos parecidos por similaridade, com aplicação ou sugestão por limiar.
 - Checkpoints de progresso por capítulo e comando `resume` para retomar com segurança traduções longas.
 - Glossário JSON opcional e fluxo guiado para padronizar termos técnicos.
@@ -328,6 +329,20 @@ uv run ayvu translate livro.epub \
 As mesmas opções também existem em `test-translator` e `languages`, para testar o servidor com
 os controles que serão usados na tradução.
 
+Para processar vários documentos internos do EPUB em paralelo, use `--workers`.
+O padrão é `--workers 1`, que mantém a execução sequencial conservadora. Com
+`--workers` maior que `1`, o Ayvu cria uma instância de tradutor e uma conexão
+SQLite separadas por worker, aplica os resultados na ordem original dos capítulos
+e preserva a ordem do EPUB, do relatório e do CSV de revisão. Se
+`--requests-per-second` estiver ativo, o limite é compartilhado entre os workers.
+
+```bash
+uv run ayvu translate livro.epub \
+  --target pt \
+  --workers 2 \
+  --requests-per-second 2
+```
+
 Sem `--output`, o Ayvu salva por padrão em:
 
 ```text
@@ -583,6 +598,10 @@ A memória usa os mesmos pares original/traduzido já guardados no cache SQLite,
 disco. Para cada trecho novo sem correspondência exata, o Ayvu busca candidatos
 parecidos do mesmo par de idiomas e mede a similaridade. O comportamento é em
 camadas, controlado por dois limiares de similaridade (entre 0 e 1):
+
+No momento, `--translation-memory` exige `--workers 1`. Para execução paralela,
+remova `--translation-memory`; para usar memória de tradução, mantenha o padrão
+sequencial.
 
 - **Similaridade ≥ `--tm-apply-threshold`** (padrão `0.95`): a tradução guardada é
   reaproveitada direto, sem chamar o tradutor. Conta como `Texts from memory` no

--- a/docs/tutorial-modo-comum-e-dev.md
+++ b/docs/tutorial-modo-comum-e-dev.md
@@ -283,7 +283,8 @@ correspondência fica registrada como sugestão de revisão no relatório.
 
 Cuidado: trechos parecidos podem ter sentido diferente. Use limiares altos, mantenha
 a memória desligada em livros novos e sensíveis, ou combine com `--review-output`
-para conferir o resultado.
+para conferir o resultado. A memória de tradução ainda não roda junto com
+`--workers` maior que `1`; use uma das duas otimizações por execução.
 
 ### Ajustar configurações
 
@@ -552,6 +553,7 @@ uv run ayvu --mode developer translate livro.epub \
   --url http://localhost:5000 \
   --cache .cache/traducoes.sqlite \
   --requests-per-second 2 \
+  --workers 2 \
   --retries 4 \
   --retry-backoff 1 \
   --retry-backoff-max 10
@@ -559,6 +561,10 @@ uv run ayvu --mode developer translate livro.epub \
 
 Use `--requests-per-second` quando o servidor local ficar instável sob muitas chamadas. O retry
 usa backoff exponencial para falhas de conexão, timeout, HTTP `429` e HTTP `5xx`.
+Use `--workers` para processar documentos internos do EPUB em paralelo; o padrão
+é `1`, e valores maiores criam tradutor e conexão SQLite separados por worker,
+mantendo a montagem final em ordem. Se usar `--translation-memory`, mantenha
+`--workers 1` nesta versão.
 
 ## Checklist recomendado
 

--- a/src/ayvu/cache.py
+++ b/src/ayvu/cache.py
@@ -136,7 +136,8 @@ class TranslationCache:
     def __init__(self, path: str | Path) -> None:
         self.path = Path(path)
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        self.connection = sqlite3.connect(self.path)
+        self.connection = sqlite3.connect(self.path, timeout=30.0)
+        self.connection.execute("PRAGMA busy_timeout = 30000")
         self.connection.execute(SCHEMA)
         self.connection.commit()
 

--- a/src/ayvu/cli.py
+++ b/src/ayvu/cli.py
@@ -524,6 +524,11 @@ def translate(
         help="Also translate the alt text of images. Text inside images (OCR) is out of scope.",
     ),
     chunk_limit: int = typer.Option(3000, "--chunk-limit", help="Maximum characters sent per request."),
+    workers: int = typer.Option(
+        1,
+        "--workers",
+        help="Number of parallel document workers. Defaults to 1 for conservative sequential execution.",
+    ),
     cache_only: bool = typer.Option(
         False,
         "--cache-only",
@@ -580,6 +585,7 @@ def translate(
         suggest_threshold=tm_suggest_threshold,
         mode=mode,
     )
+    _validate_worker_options(workers=workers, translation_memory=tm_options, mode=mode)
 
     if len(epub_list) > 1:
         _run_batch_translation(
@@ -603,6 +609,7 @@ def translate(
             retry_backoff=retry_backoff,
             retry_backoff_max=retry_backoff_max,
             chunk_limit=chunk_limit,
+            workers=workers,
             mode=mode,
             config=config,
             translate_metadata=translate_metadata,
@@ -635,6 +642,7 @@ def translate(
         retry_backoff=retry_backoff,
         retry_backoff_max=retry_backoff_max,
         chunk_limit=chunk_limit,
+        workers=workers,
         mode=mode,
         config=config,
         translate_metadata=translate_metadata,
@@ -1080,6 +1088,29 @@ def _build_translation_memory_options(
     return options
 
 
+def _validate_worker_options(
+    workers: int,
+    translation_memory: TranslationMemoryOptions | None,
+    mode: UserMode,
+) -> None:
+    if workers < 1:
+        _print_expected_error(
+            "Quantidade de workers inválida.",
+            "Use --workers com valor 1 ou maior.",
+            mode,
+            detail=f"--workers {workers}",
+        )
+        raise typer.Exit(code=1)
+
+    if workers > 1 and translation_memory is not None:
+        _print_expected_error(
+            "--workers é incompatível com --translation-memory nesta versão.",
+            "Use --workers 1 com --translation-memory, ou remova --translation-memory para executar em paralelo.",
+            mode,
+        )
+        raise typer.Exit(code=1)
+
+
 def _resolve_translation_output_dir(output_dir: Path | None, mode: UserMode) -> Path | None:
     if output_dir is None:
         return None
@@ -1117,6 +1148,7 @@ def _run_translation(
     retry_backoff: float,
     retry_backoff_max: float,
     chunk_limit: int,
+    workers: int,
     mode: UserMode,
     config: AyvuConfig | None = None,
     translate_metadata: bool = False,
@@ -1148,6 +1180,7 @@ def _run_translation(
         dry_run=dry_run,
         fail_fast=fail_fast,
         chunk_limit=chunk_limit,
+        workers=workers,
         translate_metadata=translate_metadata,
         translate_alt_text=translate_alt_text,
         chapter_selection=chapter_selection,
@@ -1269,6 +1302,8 @@ def _run_translation(
                     on_chapter_done=on_chapter_done,
                     on_text_processed=progress_view.text_processed,
                     review_segments=review_segments,
+                    translator_factory=getattr(preflight, "translator_factory", None),
+                    cache_factory=lambda: TranslationCache(cache_path),
                 )
     except KeyboardInterrupt as exc:
         _print_interrupted_translation(
@@ -1352,6 +1387,7 @@ def _run_batch_translation(
     retry_backoff: float,
     retry_backoff_max: float,
     chunk_limit: int,
+    workers: int,
     mode: UserMode,
     config: AyvuConfig,
     translate_metadata: bool = False,
@@ -1396,6 +1432,7 @@ def _run_batch_translation(
                 retry_backoff=retry_backoff,
                 retry_backoff_max=retry_backoff_max,
                 chunk_limit=chunk_limit,
+                workers=workers,
                 mode=mode,
                 config=config,
                 translate_metadata=translate_metadata,
@@ -2084,6 +2121,7 @@ def _run_guided_translation(config: AyvuConfig) -> None:
         retry_backoff=DEFAULT_RETRY_BACKOFF,
         retry_backoff_max=DEFAULT_RETRY_BACKOFF_MAX,
         chunk_limit=3000,
+        workers=1,
         mode=UserMode.COMMON,
         config=config,
     )
@@ -2760,6 +2798,7 @@ def _resume_translation(state: TranslationResumeState, mode: UserMode) -> None:
             retry_backoff=state.retry_backoff,
             retry_backoff_max=state.retry_backoff_max,
             chunk_limit=state.chunk_limit,
+            workers=state.workers,
             mode=mode,
             translate_metadata=state.translate_metadata,
             translate_alt_text=state.translate_alt_text,

--- a/src/ayvu/domain.py
+++ b/src/ayvu/domain.py
@@ -211,6 +211,7 @@ class TranslationOptions:
     dry_run: bool = False
     fail_fast: bool = False
     chunk_limit: int = 3000
+    workers: int = 1
     max_documents: int | None = None
     translate_metadata: bool = False
     translate_alt_text: bool = False

--- a/src/ayvu/epub_io.py
+++ b/src/ayvu/epub_io.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
 from urllib.parse import unquote
@@ -39,6 +40,8 @@ ChapterStartCallback = Callable[[int, int, str], None]
 ChapterDoneCallback = Callable[[int, int, str, HtmlTranslationStats], None]
 TextProgressCallback = Callable[[str], None]
 MetadataReviewCallback = Callable[[str, TextTranslationResult], None]
+TranslatorFactory = Callable[[], Translator]
+CacheFactory = Callable[[], TranslationCache]
 OPF_NAMESPACE = "http://www.idpf.org/2007/opf"
 DC_NAMESPACE = "http://purl.org/dc/elements/1.1/"
 
@@ -61,6 +64,23 @@ class EpubDocument:
     name: str
     archive_path: str
     title: str | None = None
+
+
+@dataclass(frozen=True)
+class DocumentTranslationJob:
+    index: int
+    document: EpubDocument
+    content: bytes
+
+
+@dataclass(frozen=True)
+class DocumentTranslationResult:
+    index: int
+    document: EpubDocument
+    content: bytes
+    stats: HtmlTranslationStats
+    review_segments: tuple[ReviewSegment, ...]
+    text_statuses: tuple[str, ...]
 
 
 @dataclass(frozen=True)
@@ -206,7 +226,10 @@ def translate_epub(
     on_chapter_done: ChapterDoneCallback | None = None,
     on_text_processed: TextProgressCallback | None = None,
     review_segments: list[ReviewSegment] | None = None,
+    translator_factory: TranslatorFactory | None = None,
+    cache_factory: CacheFactory | None = None,
 ) -> TranslationReport:
+    _validate_worker_options(options, translator_factory=translator_factory, cache_factory=cache_factory)
     source_path = Path(input_path)
     destination_path = Path(output_path)
     book = epub.read_epub(str(source_path))
@@ -269,61 +292,47 @@ def translate_epub(
                 if options.fail_fast:
                     raise
 
-        for index, document in enumerate(documents, start=1):
-            if document.archive_path not in archive_names:
-                report.record_error(EpubStructureError.missing_document(document).as_message())
-                if options.fail_fast:
-                    raise FileNotFoundError(document.archive_path)
-                continue
-
-            if on_chapter_start:
-                on_chapter_start(index, total_documents, document.name)
-
-            try:
-                document_segment_index = 0
-
-                def on_segment_translated(segment: HtmlTranslatedSegment) -> None:
-                    nonlocal document_segment_index
-                    if review_segments is None:
-                        return
-                    document_segment_index += 1
-                    review_segments.append(
-                        _review_segment_for_document(
-                            segment,
-                            source_path=source_path,
-                            destination_path=destination_path,
-                            document=document,
-                            chapter_index=index,
-                            segment_index=document_segment_index,
-                            options=options,
-                        )
-                    )
-
-                translated_content, stats = translate_html(
-                    source_epub.read(document.archive_path),
-                    translator=translator,
-                    cache=cache,
-                    source=options.source,
-                    target=options.target,
-                    glossary=glossary,
-                    dry_run=options.dry_run,
-                    cache_only=options.cache_only,
-                    fail_fast=options.fail_fast,
-                    chunk_limit=options.chunk_limit,
-                    memory=memory,
-                    on_text_processed=on_text_processed,
-                    on_segment_translated=on_segment_translated if review_segments is not None else None,
-                    translate_alt_text=options.translate_alt_text,
-                )
-                if not options.dry_run:
-                    replacements.add(document.archive_path, translated_content)
-                report.record_chapter(stats)
-                if on_chapter_done:
-                    on_chapter_done(index, total_documents, document.name, stats)
-            except Exception as exc:
-                report.record_error(EpubStructureError.chapter_error(document, exc).as_message())
-                if options.fail_fast:
-                    raise
+        if options.workers > 1:
+            assert translator_factory is not None
+            assert cache_factory is not None
+            _translate_documents_parallel(
+                documents=documents,
+                archive_names=archive_names,
+                source_epub=source_epub,
+                source_path=source_path,
+                destination_path=destination_path,
+                translator_factory=translator_factory,
+                cache_factory=cache_factory,
+                options=options,
+                glossary=glossary,
+                report=report,
+                replacements=replacements,
+                total_documents=total_documents,
+                on_chapter_start=on_chapter_start,
+                on_chapter_done=on_chapter_done,
+                on_text_processed=on_text_processed,
+                review_segments=review_segments,
+            )
+        else:
+            _translate_documents_sequential(
+                documents=documents,
+                archive_names=archive_names,
+                source_epub=source_epub,
+                source_path=source_path,
+                destination_path=destination_path,
+                translator=translator,
+                cache=cache,
+                memory=memory,
+                options=options,
+                glossary=glossary,
+                report=report,
+                replacements=replacements,
+                total_documents=total_documents,
+                on_chapter_start=on_chapter_start,
+                on_chapter_done=on_chapter_done,
+                on_text_processed=on_text_processed,
+                review_segments=review_segments,
+            )
 
     if not options.dry_run:
         blocked = options.cache_only and options.require_full_cache and report.texts_missing > 0
@@ -336,6 +345,241 @@ def translate_epub(
             _copy_epub_with_replacements(source_path, destination_path, replacements)
 
     return report
+
+
+def _validate_worker_options(
+    options: TranslationOptions,
+    *,
+    translator_factory: TranslatorFactory | None,
+    cache_factory: CacheFactory | None,
+) -> None:
+    if options.workers < 1:
+        raise ValueError("worker count must be 1 or greater")
+    if options.workers == 1:
+        return
+    if options.translation_memory is not None:
+        raise ValueError("translation memory is not supported with multiple workers")
+    if translator_factory is None:
+        raise ValueError("translator_factory is required when workers is greater than 1")
+    if cache_factory is None:
+        raise ValueError("cache_factory is required when workers is greater than 1")
+
+
+def _translate_documents_sequential(
+    *,
+    documents: list[EpubDocument],
+    archive_names: set[str],
+    source_epub: ZipFile,
+    source_path: Path,
+    destination_path: Path,
+    translator: Translator,
+    cache: TranslationCache,
+    memory: TranslationMemory | None,
+    options: TranslationOptions,
+    glossary: Glossary | None,
+    report: TranslationReport,
+    replacements: EpubReplacements,
+    total_documents: int,
+    on_chapter_start: ChapterStartCallback | None,
+    on_chapter_done: ChapterDoneCallback | None,
+    on_text_processed: TextProgressCallback | None,
+    review_segments: list[ReviewSegment] | None,
+) -> None:
+    for index, document in enumerate(documents, start=1):
+        if document.archive_path not in archive_names:
+            report.record_error(EpubStructureError.missing_document(document).as_message())
+            if options.fail_fast:
+                raise FileNotFoundError(document.archive_path)
+            continue
+
+        if on_chapter_start:
+            on_chapter_start(index, total_documents, document.name)
+
+        try:
+            translated_content, stats = _translate_document_content(
+                DocumentTranslationJob(
+                    index=index,
+                    document=document,
+                    content=source_epub.read(document.archive_path),
+                ),
+                translator=translator,
+                cache=cache,
+                source_path=source_path,
+                destination_path=destination_path,
+                options=options,
+                glossary=glossary,
+                memory=memory,
+                on_text_processed=on_text_processed,
+                collect_review_segments=review_segments is not None,
+                review_segments=review_segments,
+            )
+            if not options.dry_run:
+                replacements.add(document.archive_path, translated_content)
+            report.record_chapter(stats)
+            if on_chapter_done:
+                on_chapter_done(index, total_documents, document.name, stats)
+        except Exception as exc:
+            report.record_error(EpubStructureError.chapter_error(document, exc).as_message())
+            if options.fail_fast:
+                raise
+
+
+def _translate_documents_parallel(
+    *,
+    documents: list[EpubDocument],
+    archive_names: set[str],
+    source_epub: ZipFile,
+    source_path: Path,
+    destination_path: Path,
+    translator_factory: TranslatorFactory,
+    cache_factory: CacheFactory,
+    options: TranslationOptions,
+    glossary: Glossary | None,
+    report: TranslationReport,
+    replacements: EpubReplacements,
+    total_documents: int,
+    on_chapter_start: ChapterStartCallback | None,
+    on_chapter_done: ChapterDoneCallback | None,
+    on_text_processed: TextProgressCallback | None,
+    review_segments: list[ReviewSegment] | None,
+) -> None:
+    jobs: list[DocumentTranslationJob] = []
+    for index, document in enumerate(documents, start=1):
+        if document.archive_path not in archive_names:
+            report.record_error(EpubStructureError.missing_document(document).as_message())
+            if options.fail_fast:
+                raise FileNotFoundError(document.archive_path)
+            continue
+        jobs.append(
+            DocumentTranslationJob(
+                index=index,
+                document=document,
+                content=source_epub.read(document.archive_path),
+            )
+        )
+
+    futures: dict[int, Future[DocumentTranslationResult]] = {}
+    with ThreadPoolExecutor(max_workers=options.workers) as executor:
+        for job in jobs:
+            futures[job.index] = executor.submit(
+                _translate_document_worker,
+                job=job,
+                source_path=source_path,
+                destination_path=destination_path,
+                translator_factory=translator_factory,
+                cache_factory=cache_factory,
+                options=options,
+                glossary=glossary,
+                collect_review_segments=review_segments is not None,
+            )
+
+        for job in jobs:
+            if on_chapter_start:
+                on_chapter_start(job.index, total_documents, job.document.name)
+            try:
+                result = futures[job.index].result()
+                for status in result.text_statuses:
+                    _notify_text_processed(on_text_processed, status)
+                if review_segments is not None:
+                    review_segments.extend(result.review_segments)
+                if not options.dry_run:
+                    replacements.add(result.document.archive_path, result.content)
+                report.record_chapter(result.stats)
+                if on_chapter_done:
+                    on_chapter_done(result.index, total_documents, result.document.name, result.stats)
+            except Exception as exc:
+                report.record_error(EpubStructureError.chapter_error(job.document, exc).as_message())
+                if options.fail_fast:
+                    raise
+
+
+def _translate_document_worker(
+    *,
+    job: DocumentTranslationJob,
+    source_path: Path,
+    destination_path: Path,
+    translator_factory: TranslatorFactory,
+    cache_factory: CacheFactory,
+    options: TranslationOptions,
+    glossary: Glossary | None,
+    collect_review_segments: bool,
+) -> DocumentTranslationResult:
+    text_statuses: list[str] = []
+    local_review_segments: list[ReviewSegment] = []
+    translator = translator_factory()
+    with cache_factory() as cache:
+        translated_content, stats = _translate_document_content(
+            job,
+            translator=translator,
+            cache=cache,
+            source_path=source_path,
+            destination_path=destination_path,
+            options=options,
+            glossary=glossary,
+            memory=None,
+            on_text_processed=text_statuses.append,
+            collect_review_segments=collect_review_segments,
+            review_segments=local_review_segments,
+        )
+    return DocumentTranslationResult(
+        index=job.index,
+        document=job.document,
+        content=translated_content,
+        stats=stats,
+        review_segments=tuple(local_review_segments),
+        text_statuses=tuple(text_statuses),
+    )
+
+
+def _translate_document_content(
+    job: DocumentTranslationJob,
+    *,
+    translator: Translator,
+    cache: TranslationCache,
+    source_path: Path,
+    destination_path: Path,
+    options: TranslationOptions,
+    glossary: Glossary | None,
+    memory: TranslationMemory | None,
+    on_text_processed: TextProgressCallback | None,
+    collect_review_segments: bool,
+    review_segments: list[ReviewSegment] | None = None,
+) -> tuple[bytes, HtmlTranslationStats]:
+    document_segment_index = 0
+
+    def on_segment_translated(segment: HtmlTranslatedSegment) -> None:
+        nonlocal document_segment_index
+        if not collect_review_segments or review_segments is None:
+            return
+        document_segment_index += 1
+        review_segments.append(
+            _review_segment_for_document(
+                segment,
+                source_path=source_path,
+                destination_path=destination_path,
+                document=job.document,
+                chapter_index=job.index,
+                segment_index=document_segment_index,
+                options=options,
+            )
+        )
+
+    return translate_html(
+        job.content,
+        translator=translator,
+        cache=cache,
+        source=options.source,
+        target=options.target,
+        glossary=glossary,
+        dry_run=options.dry_run,
+        cache_only=options.cache_only,
+        fail_fast=options.fail_fast,
+        chunk_limit=options.chunk_limit,
+        memory=memory,
+        on_text_processed=on_text_processed,
+        on_segment_translated=on_segment_translated if collect_review_segments else None,
+        translate_alt_text=options.translate_alt_text,
+    )
 
 
 def resolve_chapter_selection(

--- a/src/ayvu/preflight.py
+++ b/src/ayvu/preflight.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sqlite3
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -9,6 +10,7 @@ from .domain import LanguagePair, LanguagePairError
 from .epub_io import inspect_epub
 from .glossary import Glossary, GlossaryError, load_glossary
 from .translator import (
+    RequestRateLimiter,
     RouteResolutionError,
     RoutedTranslator,
     TranslationRoute,
@@ -33,6 +35,7 @@ class TranslationPreflightResult:
     translator: Translator
     glossary: Glossary
     route: TranslationRoute | None = None
+    translator_factory: Callable[[], Translator] | None = None
 
 
 def run_translation_preflight(
@@ -52,7 +55,8 @@ def run_translation_preflight(
 ) -> TranslationPreflightResult:
     _check_language_pair(language_pair)
     glossary = _load_checked_glossary(glossary_path)
-    translator = _create_checked_translator(
+    rate_limiter = RequestRateLimiter(requests_per_second) if requests_per_second is not None else None
+    translator_factory = _create_checked_translator_factory(
         translator_name,
         url,
         timeout,
@@ -60,7 +64,9 @@ def run_translation_preflight(
         requests_per_second=requests_per_second,
         retry_backoff=retry_backoff,
         retry_backoff_max=retry_backoff_max,
+        rate_limiter=rate_limiter,
     )
+    translator = translator_factory()
     _check_cache(cache_path)
     _check_epub(epub_path)
     route: TranslationRoute | None = None
@@ -68,7 +74,14 @@ def run_translation_preflight(
         route = _resolve_route_or_fallback(translator, language_pair, url)
         if route is not None and not route.is_direct:
             translator = RoutedTranslator(translator, route)
-    return TranslationPreflightResult(translator=translator, glossary=glossary, route=route)
+            base_factory = translator_factory
+            translator_factory = lambda: RoutedTranslator(base_factory(), route)
+    return TranslationPreflightResult(
+        translator=translator,
+        glossary=glossary,
+        route=route,
+        translator_factory=translator_factory,
+    )
 
 
 def _check_language_pair(language_pair: LanguagePair) -> None:
@@ -101,6 +114,7 @@ def _create_checked_translator(
     requests_per_second: float | None,
     retry_backoff: float,
     retry_backoff_max: float,
+    rate_limiter: RequestRateLimiter | None = None,
 ) -> Translator:
     try:
         return create_translator(
@@ -111,6 +125,7 @@ def _create_checked_translator(
             requests_per_second=requests_per_second,
             retry_backoff=retry_backoff,
             retry_backoff_max=retry_backoff_max,
+            rate_limiter=rate_limiter,
         )
     except TranslatorError as exc:
         raise PreflightError(
@@ -118,6 +133,31 @@ def _create_checked_translator(
             "Use --translator libretranslate.",
             detail=str(exc),
         ) from exc
+
+
+def _create_checked_translator_factory(
+    name: str,
+    url: str,
+    timeout: float,
+    retries: int,
+    requests_per_second: float | None,
+    retry_backoff: float,
+    retry_backoff_max: float,
+    rate_limiter: RequestRateLimiter | None,
+) -> Callable[[], Translator]:
+    def factory() -> Translator:
+        return _create_checked_translator(
+            name,
+            url,
+            timeout,
+            retries,
+            requests_per_second=requests_per_second,
+            retry_backoff=retry_backoff,
+            retry_backoff_max=retry_backoff_max,
+            rate_limiter=rate_limiter,
+        )
+
+    return factory
 
 
 def _check_cache(cache_path: Path) -> None:

--- a/src/ayvu/resume.py
+++ b/src/ayvu/resume.py
@@ -52,6 +52,7 @@ class TranslationResumeState:
     timeout: float
     retries: int
     chunk_limit: int
+    workers: int
     translate_metadata: bool
     translate_alt_text: bool
     chapter_selection: str | None
@@ -104,6 +105,7 @@ class TranslationResumeState:
             timeout=timeout,
             retries=retries,
             chunk_limit=options.chunk_limit,
+            workers=options.workers,
             translate_metadata=options.translate_metadata,
             translate_alt_text=options.translate_alt_text,
             chapter_selection=options.chapter_selection.source if options.chapter_selection else None,
@@ -153,6 +155,7 @@ class TranslationResumeState:
             timeout=_required_number(data, "timeout"),
             retries=_required_int(data, "retries"),
             chunk_limit=_required_int(data, "chunk_limit"),
+            workers=_optional_int_default(data, "workers", default=1),
             translate_metadata=_optional_bool(data, "translate_metadata", default=False),
             translate_alt_text=_optional_bool(data, "translate_alt_text", default=False),
             chapter_selection=_optional_text(data, "chapter_selection"),

--- a/src/ayvu/translator.py
+++ b/src/ayvu/translator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import time
+import threading
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Protocol
@@ -165,6 +166,7 @@ class RetryPolicy:
 class RequestRateLimiter:
     requests_per_second: float | None = None
     _last_request_at: float | None = field(default=None, init=False)
+    _lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
 
     def __post_init__(self) -> None:
         if self.requests_per_second is not None and self.requests_per_second <= 0:
@@ -174,20 +176,21 @@ class RequestRateLimiter:
         if self.requests_per_second is None:
             return
 
-        interval = 1.0 / self.requests_per_second
-        now = time.monotonic()
-        if self._last_request_at is None:
+        with self._lock:
+            interval = 1.0 / self.requests_per_second
+            now = time.monotonic()
+            if self._last_request_at is None:
+                self._last_request_at = now
+                return
+
+            next_request_at = self._last_request_at + interval
+            delay = next_request_at - now
+            if delay > 0:
+                time.sleep(delay)
+                self._last_request_at = next_request_at
+                return
+
             self._last_request_at = now
-            return
-
-        next_request_at = self._last_request_at + interval
-        delay = next_request_at - now
-        if delay > 0:
-            time.sleep(delay)
-            self._last_request_at = next_request_at
-            return
-
-        self._last_request_at = now
 
 
 class LibreTranslateResponseParser:
@@ -240,6 +243,7 @@ class LibreTranslateTranslator(Translator):
     requests_per_second: float | None = None
     retry_backoff: float = 0.5
     retry_backoff_max: float = 8.0
+    rate_limiter: RequestRateLimiter | None = None
 
     def __post_init__(self) -> None:
         self.endpoint = self._normalize_endpoint(self.url)
@@ -249,7 +253,7 @@ class LibreTranslateTranslator(Translator):
             backoff=self.retry_backoff,
             max_backoff=self.retry_backoff_max,
         )
-        self.rate_limiter = RequestRateLimiter(self.requests_per_second)
+        self.rate_limiter = self.rate_limiter or RequestRateLimiter(self.requests_per_second)
         self.response_parser = LibreTranslateResponseParser()
 
     def translate(self, text: str, source: str, target: str) -> str:
@@ -377,6 +381,7 @@ def create_translator(
     requests_per_second: float | None = None,
     retry_backoff: float = 0.5,
     retry_backoff_max: float = 8.0,
+    rate_limiter: RequestRateLimiter | None = None,
 ) -> Translator:
     if name != "libretranslate":
         supported = ", ".join(SUPPORTED_TRANSLATORS)
@@ -388,4 +393,5 @@ def create_translator(
         requests_per_second=requests_per_second,
         retry_backoff=retry_backoff,
         retry_backoff_max=retry_backoff_max,
+        rate_limiter=rate_limiter,
     )

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,4 +1,5 @@
 import json
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
@@ -45,6 +46,23 @@ def test_cache_is_language_specific(tmp_path):
         cache.set(_cache_key("Hello", "en", "pt"), "Olá")
 
         assert cache.get(_cache_key("Hello", "en", "es")) is None
+
+
+def test_cache_accepts_concurrent_writes_from_separate_connections(tmp_path):
+    cache_path = tmp_path / "translations.sqlite"
+
+    def write_entry(index: int) -> None:
+        with TranslationCache(cache_path) as cache:
+            cache.set(_cache_key(f"Text {index}"), f"T{index}")
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        list(executor.map(write_entry, range(24)))
+
+    with TranslationCache(cache_path) as cache:
+        rows = cache.summary(source_lang="en", target_lang="pt")
+
+    assert len(rows) == 1
+    assert rows[0].count == 24
 
 
 def test_cache_writable_check_does_not_persist_probe(tmp_path):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2600,6 +2600,8 @@ def test_translate_command_passes_execution_controls_to_preflight_and_resume(
             "0.25",
             "--retry-backoff-max",
             "2",
+            "--workers",
+            "3",
         ],
     )
 
@@ -2610,9 +2612,55 @@ def test_translate_command_passes_execution_controls_to_preflight_and_resume(
     assert preflight["requests_per_second"] == 3.5
     assert preflight["retry_backoff"] == 0.25
     assert preflight["retry_backoff_max"] == 2.0
+    assert calls["options"].workers == 3
     assert saved_state.requests_per_second == 3.5
     assert saved_state.retry_backoff == 0.25
     assert saved_state.retry_backoff_max == 2.0
+    assert saved_state.workers == 3
+
+
+def test_translate_command_rejects_invalid_workers(minimal_epub_path, monkeypatch):
+    def fail_preflight(**_kwargs: object) -> object:
+        raise AssertionError("preflight should not run with invalid workers")
+
+    monkeypatch.setattr("ayvu.cli.run_translation_preflight", fail_preflight)
+
+    result = runner.invoke(
+        app,
+        ["--mode", "developer", "translate", str(minimal_epub_path), "--workers", "0"],
+    )
+
+    assert result.exit_code == 1
+    assert "Quantidade de workers inválida." in result.output
+    assert "Use --workers com valor 1 ou maior." in result.output
+    assert "Traceback" not in result.output
+
+
+def test_translate_command_rejects_parallel_workers_with_translation_memory(
+    minimal_epub_path,
+    monkeypatch,
+):
+    def fail_preflight(**_kwargs: object) -> object:
+        raise AssertionError("preflight should not run with incompatible worker options")
+
+    monkeypatch.setattr("ayvu.cli.run_translation_preflight", fail_preflight)
+
+    result = runner.invoke(
+        app,
+        [
+            "--mode",
+            "developer",
+            "translate",
+            str(minimal_epub_path),
+            "--workers",
+            "2",
+            "--translation-memory",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "--workers é incompatível com --translation-memory nesta versão." in result.output
+    assert "Traceback" not in result.output
 
 
 def test_translate_command_uses_profile_target_and_glossary(

--- a/tests/test_epub_io.py
+++ b/tests/test_epub_io.py
@@ -1,4 +1,5 @@
 import csv
+import threading
 from pathlib import Path, PurePosixPath
 from zipfile import ZipFile
 
@@ -200,6 +201,60 @@ def test_translate_epub_translates_minimal_generated_epub_without_mutating_input
     # The paragraph is translated as one block, keeping the inline link and its text.
     assert '<a href="chapter2.xhtml#answer">chapter two</a>' in chapter
     assert "../images/pixel.png" in chapter
+
+
+def test_translate_epub_parallel_workers_preserves_order_and_review_segments(
+    minimal_epub_path: Path,
+    tmp_path: Path,
+):
+    output_path = tmp_path / "minimal-pt.epub"
+    cache_path = tmp_path / "cache.sqlite"
+    translator_ids: list[int] = []
+    translator_lock = threading.Lock()
+    review_segments = []
+    statuses: list[str] = []
+    options = TranslationOptions(
+        language_pair=LanguagePair(source="en", target="pt"),
+        workers=2,
+    )
+
+    def translator_factory() -> PrefixTranslator:
+        with translator_lock:
+            translator_ids.append(len(translator_ids) + 1)
+        return PrefixTranslator()
+
+    with TranslationCache(cache_path) as cache:
+        report = translate_epub(
+            minimal_epub_path,
+            output_path,
+            translator=PrefixTranslator(),
+            cache=cache,
+            options=options,
+            review_segments=review_segments,
+            on_text_processed=statuses.append,
+            translator_factory=translator_factory,
+            cache_factory=lambda: TranslationCache(cache_path),
+        )
+
+    assert output_path.exists()
+    assert report.errors == []
+    assert report.chapters_processed >= 2
+    assert len(translator_ids) == report.chapters_processed
+    assert statuses
+    assert [segment.chapter_index for segment in review_segments] == sorted(
+        segment.chapter_index for segment in review_segments
+    )
+    assert {segment.chapter_index for segment in review_segments} >= {1, 2}
+
+    with ZipFile(output_path) as output_epub:
+        names = output_epub.namelist()
+        chapter_one_name = next(name for name in names if name.endswith("text/chapter1.xhtml"))
+        chapter_two_name = next(name for name in names if name.endswith("text/chapter2.xhtml"))
+        chapter_one = output_epub.read(chapter_one_name).decode("utf-8")
+        chapter_two = output_epub.read(chapter_two_name).decode("utf-8")
+
+    assert "PT:Hello reader. Visit" in chapter_one
+    assert "PT:Goodbye reader." in chapter_two
 
 
 def test_translate_epub_cache_only_reuses_cache_without_calling_translator(

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -3,7 +3,7 @@ import pytest
 from ayvu.cache import CacheKey, TranslationCache
 from ayvu.domain import LanguagePair
 from ayvu.preflight import PreflightError, run_translation_preflight
-from ayvu.translator import RoutedTranslator, TranslatorError, TranslatorLanguage
+from ayvu.translator import RequestRateLimiter, RoutedTranslator, TranslatorError, TranslatorLanguage
 
 
 class FakeTranslator:
@@ -124,7 +124,9 @@ def test_preflight_passes_execution_controls_to_translator_factory(monkeypatch, 
     )
 
     assert calls["args"] == ("libretranslate",)
-    assert calls["kwargs"] == {
+    kwargs = calls["kwargs"]
+    assert isinstance(kwargs.pop("rate_limiter"), RequestRateLimiter)
+    assert kwargs == {
         "url": "http://localhost:5000",
         "timeout": 1.0,
         "retries": 0,
@@ -274,6 +276,40 @@ def test_preflight_wraps_translator_when_intermediate_route_is_needed(monkeypatc
     assert isinstance(result.translator, RoutedTranslator)
     assert result.route is not None
     assert result.route.intermediate == "en"
+
+
+def test_preflight_translator_factory_preserves_intermediate_route(monkeypatch, tmp_path):
+    languages = (
+        TranslatorLanguage(code="fr", name="French", targets=("en",)),
+        TranslatorLanguage(code="en", name="English", targets=("pt",)),
+        TranslatorLanguage(code="pt", name="Portuguese", targets=("en",)),
+    )
+    created: list[TranslatorWithLanguages] = []
+
+    def fake_create_translator(*_args: object, **_kwargs: object) -> TranslatorWithLanguages:
+        translator = TranslatorWithLanguages(languages)
+        created.append(translator)
+        return translator
+
+    monkeypatch.setattr("ayvu.preflight.create_translator", fake_create_translator)
+    monkeypatch.setattr("ayvu.preflight.inspect_epub", lambda _path: object())
+
+    result = run_translation_preflight(
+        epub_path=tmp_path / "book.epub",
+        cache_path=tmp_path / "cache.sqlite",
+        glossary_path=None,
+        translator_name="libretranslate",
+        url="http://localhost:5000",
+        timeout=1.0,
+        retries=0,
+        language_pair=LanguagePair(source="fr", target="pt"),
+        dry_run=False,
+    )
+
+    assert result.translator_factory is not None
+    worker_translator = result.translator_factory()
+    assert isinstance(worker_translator, RoutedTranslator)
+    assert len(created) == 2
 
 
 def test_preflight_reports_missing_route_with_clear_message(monkeypatch, tmp_path):

--- a/tests/test_resume.py
+++ b/tests/test_resume.py
@@ -32,6 +32,7 @@ def make_state(tmp_path: Path, stem: str = "book") -> TranslationResumeState:
             dry_run=False,
             fail_fast=True,
             chunk_limit=1200,
+            workers=3,
             translate_metadata=True,
             translate_alt_text=True,
             chapter_selection=ChapterSelection.parse("1-2,*chapter3*"),
@@ -66,6 +67,7 @@ def test_resume_state_round_trip(tmp_path):
     assert loaded.chapter_selection == "1-2,*chapter3*"
     assert loaded.timeout == 9.5
     assert loaded.retries == 3
+    assert loaded.workers == 3
     assert loaded.requests_per_second == 2.5
     assert loaded.retry_backoff == 0.25
     assert loaded.retry_backoff_max == 2.0
@@ -117,6 +119,7 @@ def test_resume_state_loads_legacy_file_without_translation_memory(tmp_path):
         "translation_memory_apply_threshold",
         "translation_memory_suggest_threshold",
         "translation_memory_max_candidates",
+        "workers",
         "requests_per_second",
         "retry_backoff",
         "retry_backoff_max",
@@ -129,6 +132,7 @@ def test_resume_state_loads_legacy_file_without_translation_memory(tmp_path):
 
     assert loaded.translation_memory_enabled is False
     assert loaded.translation_memory_options() is None
+    assert loaded.workers == 1
     assert loaded.requests_per_second is None
     assert loaded.retry_backoff == 0.5
     assert loaded.retry_backoff_max == 8.0

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -5,6 +5,7 @@ import pytest
 
 from ayvu.translator import (
     LibreTranslateTranslator,
+    RequestRateLimiter,
     RouteResolutionError,
     RoutedTranslator,
     TranslationRoute,
@@ -199,6 +200,27 @@ def test_libretranslate_rate_limiter_is_shared_between_languages_and_translate(
     assert len(session.gets) == 1
     assert len(session.posts) == 1
     assert sleeps == [pytest.approx(0.8)]
+
+
+def test_libretranslate_instances_can_share_rate_limiter(monkeypatch: pytest.MonkeyPatch) -> None:
+    sleeps: list[float] = []
+    times = iter([30.0, 30.25])
+    rate_limiter = RequestRateLimiter(requests_per_second=2.0)
+    first_session = FakeSession([make_response(200, '{"translatedText": "Ola"}')])
+    second_session = FakeSession([make_response(200, '{"translatedText": "Mundo"}')])
+    first = LibreTranslateTranslator(retries=0, rate_limiter=rate_limiter)
+    second = LibreTranslateTranslator(retries=0, rate_limiter=rate_limiter)
+    first.session = first_session
+    second.session = second_session
+    monkeypatch.setattr("ayvu.translator.time.monotonic", lambda: next(times))
+    monkeypatch.setattr("ayvu.translator.time.sleep", lambda delay: sleeps.append(delay))
+
+    first.translate("Hello", "en", "pt")
+    second.translate("World", "en", "pt")
+
+    assert len(first_session.posts) == 1
+    assert len(second_session.posts) == 1
+    assert sleeps == [pytest.approx(0.25)]
 
 
 def test_libretranslate_reports_http_error() -> None:


### PR DESCRIPTION
## Objective

Allow Ayvu to translate EPUB documents concurrently without corrupting the SQLite cache or changing deterministic EPUB, report, and review output ordering.

## What changed

- Added the `--workers` translate option with `1` as the conservative default.
- Added parallel document translation that uses a fresh translator/session and SQLite connection per worker.
- Replays worker results in original document order for EPUB replacements, reports, resume progress, and review CSV segments.
- Made the LibreTranslate rate limiter shareable and thread-safe so `--requests-per-second` remains global across worker translators.
- Added SQLite busy timeout handling for concurrent cache writes.
- Persisted `workers` in resume state with legacy fallback to `1`.
- Blocked `--workers > 1` with `--translation-memory` for this delivery to preserve deterministic behavior.
- Updated README, tutorial docs, changelog, and focused tests.

## Out of scope

- Rich live per-worker progress UI; current worker progress is replayed in deterministic chapter order.
- Parallel support for fuzzy translation memory.
- Changing EPUB document selection or chunking behavior.

## Validation

- `git diff --check`: no errors.
- `uv run pytest`: 315 tests passed.
- `UV_CACHE_DIR=/tmp/ayvu-uv-cache uv run ayvu translate --help`: verified `--workers` appears in CLI help.

## Related issue

Closes #116
Refs #99