### PR TITLE
Show execution controls in translation UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ lancadas e secoes versionadas quando uma release for publicada.
 - Opcao `--workers` no comando `translate` para processar documentos internos do
   EPUB em paralelo, mantendo `1` como padrao conservador, conexoes SQLite e
   sessoes HTTP separadas por worker e montagem final em ordem deterministica.
+- Plano, progresso, interrupcao e retomada agora mostram os controles de
+  execucao usados (`Workers`, `Rate limit` e `Retry policy`), incluindo a ordem
+  deterministica do progresso quando `--workers` e maior que `1`.
 - Estado local de retomada em `~/Documentos/Livros/Processando` ou na pasta de
   processamento configurada.
 - Checkpoints de progresso no estado de retomada, atualizados a cada capitulo com

--- a/README.md
+++ b/README.md
@@ -335,6 +335,9 @@ O padrão é `--workers 1`, que mantém a execução sequencial conservadora. Co
 SQLite separadas por worker, aplica os resultados na ordem original dos capítulos
 e preserva a ordem do EPUB, do relatório e do CSV de revisão. Se
 `--requests-per-second` estiver ativo, o limite é compartilhado entre os workers.
+O plano de tradução mostra `Workers`, `Rate limit` e `Retry policy` antes de
+começar; com execução paralela, a barra de capítulos também indica que o
+progresso é reportado na ordem do EPUB.
 
 ```bash
 uv run ayvu translate livro.epub \
@@ -490,8 +493,8 @@ uv run ayvu translate livro.epub \
 ```
 
 Trechos já traduzidos serão reaproveitados automaticamente.
-O checkpoint de retomada preserva as opções de execução do tradutor, como timeout, retries,
-limite de requisições por segundo e backoff.
+O checkpoint de retomada preserva as opções de execução do tradutor, como
+timeout, workers, retries, limite de requisições por segundo e backoff.
 
 O cache pode ser inspecionado, limpo, exportado e importado separadamente dos
 comandos de tradução:
@@ -533,7 +536,8 @@ uv run ayvu resume livro.epub --target pt
 
 Sem argumentos, `resume` continua a única tradução em andamento; havendo mais de
 uma, informe o EPUB e o `--target` para escolher. O comando mostra o checkpoint
-(até onde foi) e reexecuta a tradução com as opções salvas. Ao executar apenas
+(até onde foi), os controles de execução salvos (`Workers`, `Rate limit` e
+`Retry policy`) e reexecuta a tradução com as opções salvas. Ao executar apenas
 `uv run ayvu`, o modo comum também procura estados em andamento e oferece retomar
 a execução detectada, mostrando o mesmo resumo de checkpoint.
 

--- a/docs/tutorial-modo-comum-e-dev.md
+++ b/docs/tutorial-modo-comum-e-dev.md
@@ -102,9 +102,9 @@ Durante traduções reais, o Ayvu registra um checkpoint local em:
 ~/Documentos/Livros/Processando
 ```
 
-Esse checkpoint (`*.ayvu-state.json`) é atualizado a cada capítulo e guarda o progresso: total de capítulos, capítulo atual, capítulos concluídos e capítulos com falha.
+Esse checkpoint (`*.ayvu-state.json`) é atualizado a cada capítulo e guarda o progresso: total de capítulos, capítulo atual, capítulos concluídos e capítulos com falha. Ele também preserva os controles de execução usados na tradução, como workers, limite de requisições e backoff.
 
-Ao executar `uv run ayvu`, o modo comum procura estados em andamento, mostra o resumo do checkpoint e oferece retomar a tradução detectada. O cache SQLite continua sendo a parte que evita retraduzir textos já concluídos: na retomada, só os trechos ainda não cacheados (os que faltaram ou falharam) chamam o tradutor de novo.
+Ao executar `uv run ayvu`, o modo comum procura estados em andamento, mostra o resumo do checkpoint e os controles salvos (`Workers`, `Rate limit` e `Retry policy`), e oferece retomar a tradução detectada. O cache SQLite continua sendo a parte que evita retraduzir textos já concluídos: na retomada, só os trechos ainda não cacheados (os que faltaram ou falharam) chamam o tradutor de novo.
 
 ## Tutorial intermediário: preview, glossário e organização
 
@@ -493,9 +493,10 @@ uv run ayvu resume livro.epub --target pt
 
 Sem argumentos, ele retoma a única tradução em andamento; havendo mais de uma,
 informe o EPUB e o `--target`. O comando mostra o checkpoint (capítulos
-concluídos, capítulo atual e falhas) e reexecuta a tradução com as opções da
-execução original. O cache evita retraduzir o que já foi concluído, então só os
-trechos pendentes chamam o tradutor.
+concluídos, capítulo atual e falhas), os controles de execução salvos e
+reexecuta a tradução com as opções da execução original. O cache evita
+retraduzir o que já foi concluído, então só os trechos pendentes chamam o
+tradutor.
 
 ### Reconstruir usando apenas o cache
 
@@ -563,8 +564,10 @@ Use `--requests-per-second` quando o servidor local ficar instável sob muitas c
 usa backoff exponencial para falhas de conexão, timeout, HTTP `429` e HTTP `5xx`.
 Use `--workers` para processar documentos internos do EPUB em paralelo; o padrão
 é `1`, e valores maiores criam tradutor e conexão SQLite separados por worker,
-mantendo a montagem final em ordem. Se usar `--translation-memory`, mantenha
-`--workers 1` nesta versão.
+mantendo a montagem final em ordem. O plano e o checkpoint mostram `Workers`,
+`Rate limit` e `Retry policy`; com workers paralelos, a barra de capítulos
+indica que o progresso é reportado na ordem do EPUB. Se usar
+`--translation-memory`, mantenha `--workers 1` nesta versão.
 
 ## Checklist recomendado
 

--- a/src/ayvu/cli.py
+++ b/src/ayvu/cli.py
@@ -854,6 +854,11 @@ def _print_translation_plan(
     mode: UserMode,
     profile_name: str | None = None,
     profile_style: str | None = None,
+    workers: int = 1,
+    requests_per_second: float | None = None,
+    retries: int = 2,
+    retry_backoff: float = DEFAULT_RETRY_BACKOFF,
+    retry_backoff_max: float = DEFAULT_RETRY_BACKOFF_MAX,
 ) -> None:
     table = Table(title="Translation plan")
     table.add_column("Field")
@@ -867,9 +872,66 @@ def _print_translation_plan(
         table.add_row("Profile", profile_name)
     if profile_style:
         table.add_row("Profile style", profile_style)
+    for label, value in _execution_control_rows(
+        workers=workers,
+        requests_per_second=requests_per_second,
+        retries=retries,
+        retry_backoff=retry_backoff,
+        retry_backoff_max=retry_backoff_max,
+    ):
+        table.add_row(label, value)
     console.print(table)
     if source_inferred and mode == UserMode.COMMON:
         console.print(f"[dim]Idioma de origem detectado do EPUB: {language_pair.source}[/dim]")
+
+
+def _execution_control_rows(
+    *,
+    workers: int,
+    requests_per_second: float | None,
+    retries: int,
+    retry_backoff: float,
+    retry_backoff_max: float,
+) -> tuple[tuple[str, str], ...]:
+    return (
+        ("Workers", _format_workers(workers)),
+        ("Rate limit", _format_rate_limit(requests_per_second, workers=workers)),
+        ("Retry policy", _format_retry_policy(retries, retry_backoff, retry_backoff_max)),
+    )
+
+
+def _format_workers(workers: int) -> str:
+    if workers == 1:
+        return "1 (sequential)"
+    return f"{workers} (parallel, reported in EPUB order)"
+
+
+def _format_rate_limit(requests_per_second: float | None, *, workers: int) -> str:
+    if requests_per_second is None:
+        return "none"
+    suffix = " shared across workers" if workers > 1 else ""
+    return f"{_format_number(requests_per_second)} requests/second{suffix}"
+
+
+def _format_retry_policy(retries: int, retry_backoff: float, retry_backoff_max: float) -> str:
+    if retries <= 0:
+        return "disabled"
+    return (
+        f"{retries} retries, {_format_number(retry_backoff)}s initial backoff, "
+        f"{_format_number(retry_backoff_max)}s max"
+    )
+
+
+def _format_execution_summary(state: TranslationResumeState) -> str:
+    return (
+        f"{_format_workers(state.workers)}; "
+        f"{_format_rate_limit(state.requests_per_second, workers=state.workers)}; "
+        f"{_format_retry_policy(state.retries, state.retry_backoff, state.retry_backoff_max)}"
+    )
+
+
+def _format_number(value: float) -> str:
+    return f"{value:g}"
 
 
 def _print_translation_route(route: TranslationRoute | None, mode: UserMode) -> None:
@@ -1174,6 +1236,11 @@ def _run_translation(
         mode=mode,
         profile_name=resolved_profile_name,
         profile_style=profile.style if profile else None,
+        workers=workers,
+        requests_per_second=requests_per_second,
+        retries=retries,
+        retry_backoff=retry_backoff,
+        retry_backoff_max=retry_backoff_max,
     )
     translation_options = TranslationOptions(
         language_pair=language_pair,
@@ -1267,7 +1334,7 @@ def _run_translation(
             TimeElapsedColumn(),
             console=console,
         ) as progress:
-            progress_view = TranslationProgress(progress, dry_run=dry_run)
+            progress_view = TranslationProgress(progress, dry_run=dry_run, workers=workers)
 
             def on_chapter_start(index: int, total: int, name: str) -> None:
                 nonlocal resume_state
@@ -1311,6 +1378,11 @@ def _run_translation(
             output_path=output_path,
             cache_path=cache_path,
             dry_run=dry_run,
+            workers=workers,
+            requests_per_second=requests_per_second,
+            retries=retries,
+            retry_backoff=retry_backoff,
+            retry_backoff_max=retry_backoff_max,
         )
         raise typer.Exit(code=1) from exc
 
@@ -1403,6 +1475,11 @@ def _run_batch_translation(
         output_dir=resolved_output_dir,
         report_dir=report_dir,
         continue_on_error=continue_on_error,
+        workers=workers,
+        requests_per_second=requests_per_second,
+        retries=retries,
+        retry_backoff=retry_backoff,
+        retry_backoff_max=retry_backoff_max,
     )
 
     results: list[BatchTranslationResult] = []
@@ -1492,6 +1569,11 @@ def _print_batch_plan(
     output_dir: Path,
     report_dir: Path,
     continue_on_error: bool,
+    workers: int,
+    requests_per_second: float | None,
+    retries: int,
+    retry_backoff: float,
+    retry_backoff_max: float,
 ) -> None:
     table = Table(title="Batch translation plan")
     table.add_column("Field")
@@ -1500,6 +1582,14 @@ def _print_batch_plan(
     table.add_row("Output folder", str(output_dir))
     table.add_row("Reports folder", str(report_dir))
     table.add_row("Continue on error", "yes" if continue_on_error else "no")
+    for label, value in _execution_control_rows(
+        workers=workers,
+        requests_per_second=requests_per_second,
+        retries=retries,
+        retry_backoff=retry_backoff,
+        retry_backoff_max=retry_backoff_max,
+    ):
+        table.add_row(label, value)
     console.print(table)
 
 
@@ -1904,6 +1994,11 @@ def _print_interrupted_translation(
     output_path: Path,
     cache_path: Path,
     dry_run: bool,
+    workers: int,
+    requests_per_second: float | None,
+    retries: int,
+    retry_backoff: float,
+    retry_backoff_max: float,
 ) -> None:
     console.print("[yellow]Translation interrupted by user.[/yellow]")
     console.print("Cached translations saved before the interruption can be reused with the same --cache path.")
@@ -1928,6 +2023,14 @@ def _print_interrupted_translation(
     table.add_row("Texts missing", str(snapshot.texts_missing))
     table.add_row("Text errors", str(snapshot.text_errors))
     table.add_row("Current chapter", snapshot.current_chapter or "-")
+    for label, value in _execution_control_rows(
+        workers=workers,
+        requests_per_second=requests_per_second,
+        retries=retries,
+        retry_backoff=retry_backoff,
+        retry_backoff_max=retry_backoff_max,
+    ):
+        table.add_row(label, value)
     console.print(table)
 
 
@@ -2845,22 +2948,28 @@ def _select_resume_state(
 
 
 def _print_resume_checkpoint(state: TranslationResumeState) -> None:
-    if not _has_checkpoint_progress(state):
-        return
-
     table = Table(title="Resume checkpoint")
     table.add_column("Metric")
     table.add_column("Value")
-    table.add_row("Chapters completed", _checkpoint_chapter_value(state))
-    if state.current_chapter:
-        table.add_row("Current chapter", state.current_chapter)
-    if state.failed_chapters:
-        table.add_row("Chapters with failures", str(len(state.failed_chapters)))
-        table.add_row("Failed segments", str(state.failed_segment_count))
+    if _has_checkpoint_progress(state):
+        table.add_row("Chapters completed", _checkpoint_chapter_value(state))
+        if state.current_chapter:
+            table.add_row("Current chapter", state.current_chapter)
+        if state.failed_chapters:
+            table.add_row("Chapters with failures", str(len(state.failed_chapters)))
+            table.add_row("Failed segments", str(state.failed_segment_count))
+    for label, value in _execution_control_rows(
+        workers=state.workers,
+        requests_per_second=state.requests_per_second,
+        retries=state.retries,
+        retry_backoff=state.retry_backoff,
+        retry_backoff_max=state.retry_backoff_max,
+    ):
+        table.add_row(label, value)
     table.add_row("Last update", state.updated_at)
     console.print(table)
     console.print(
-        "Cached translations are reused; only segments still missing from the cache are retried."
+        "Saved execution settings and cached translations are reused; only segments still missing from the cache are retried."
     )
 
 
@@ -2887,12 +2996,14 @@ def _print_running_resume_states(states: tuple[TranslationResumeState, ...]) -> 
     table.add_column("Output")
     table.add_column("Target")
     table.add_column("Cache")
+    table.add_column("Execution")
     for state in states:
         table.add_row(
             state.input_path.name,
             state.output_path.name,
             state.target,
             state.cache_path.name,
+            _format_execution_summary(state),
         )
     console.print(table)
 

--- a/src/ayvu/cli_progress.py
+++ b/src/ayvu/cli_progress.py
@@ -60,14 +60,15 @@ class TextProgressCounters:
 
 
 class TranslationProgress:
-    def __init__(self, progress: Progress, dry_run: bool) -> None:
+    def __init__(self, progress: Progress, dry_run: bool, workers: int = 1) -> None:
         self._progress = progress
         self._dry_run = dry_run
+        self._workers = workers
         self._counters = TextProgressCounters()
         self._chapters_processed = 0
         self._total_chapters: int | None = None
         self._current_chapter: str | None = None
-        self._chapter_task = progress.add_task("Chapters", total=None)
+        self._chapter_task = progress.add_task(self._chapter_label(), total=None)
         self._text_task = progress.add_task("Texts", total=None)
 
     def chapter_started(self, index: int, total: int, name: str) -> None:
@@ -106,7 +107,12 @@ class TranslationProgress:
         )
 
     def _chapter_description(self, index: int, total: int, name: str) -> str:
-        return f"Chapters {index}/{total}: {_shorten(name)}"
+        return f"{self._chapter_label()} {index}/{total}: {_shorten(name)}"
+
+    def _chapter_label(self) -> str:
+        if self._workers > 1:
+            return f"Chapters ({self._workers} workers, EPUB order)"
+        return "Chapters"
 
     def _text_description(self) -> str:
         new_label = "would translate" if self._dry_run else "new"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -359,6 +359,8 @@ def test_root_command_shows_processing_translation_state(tmp_path, monkeypatch):
     assert "book.epub" in result.output
     assert "book-pt.epub" in result.output
     assert "cache.sqlite" in result.output
+    assert "Execution" in result.output
+    assert "1 (sequential)" in result.output
     assert "Continue detected translation?" in result.output
     assert "Detected translation was not resumed." in result.output
     assert "Choose an option" in result.output
@@ -583,6 +585,11 @@ def _running_resume_state(
     stem: str,
     target: str,
     create_epub: bool = True,
+    workers: int = 1,
+    requests_per_second: float | None = None,
+    retries: int = 2,
+    retry_backoff: float = 0.5,
+    retry_backoff_max: float = 8.0,
 ) -> TranslationResumeState:
     epub_path = tmp_path / "Original" / f"{stem}.epub"
     if create_epub:
@@ -595,10 +602,16 @@ def _running_resume_state(
         translator_name="libretranslate",
         url="http://localhost:5000",
         glossary_path=None,
-        options=TranslationOptions(language_pair=LanguagePair(source="en", target=target)),
+        options=TranslationOptions(
+            language_pair=LanguagePair(source="en", target=target),
+            workers=workers,
+        ),
         overwrite=False,
         timeout=30.0,
-        retries=2,
+        retries=retries,
+        requests_per_second=requests_per_second,
+        retry_backoff=retry_backoff,
+        retry_backoff_max=retry_backoff_max,
     )
 
 
@@ -628,9 +641,16 @@ def _patch_resume_pipeline(monkeypatch, processing_dir: Path, calls: dict[str, o
 
 def test_resume_command_resumes_single_state(tmp_path, monkeypatch):
     processing_dir = tmp_path / "Processando"
-    state = _running_resume_state(tmp_path, "book", "pt").record_chapter(
-        "chapter-one.xhtml", 2, ok=True
-    )
+    state = _running_resume_state(
+        tmp_path,
+        "book",
+        "pt",
+        workers=2,
+        requests_per_second=2.5,
+        retries=4,
+        retry_backoff=1.0,
+        retry_backoff_max=10.0,
+    ).record_chapter("chapter-one.xhtml", 2, ok=True)
     ResumeStateStore(processing_dir).save(state)
     calls: dict[str, object] = {}
     _patch_resume_pipeline(monkeypatch, processing_dir, calls)
@@ -641,8 +661,14 @@ def test_resume_command_resumes_single_state(tmp_path, monkeypatch):
     assert "Resuming translation:" in result.output
     assert "Resume checkpoint" in result.output
     assert "1/2" in result.output
+    assert "Workers" in result.output
+    assert "2 (parallel" in result.output
+    assert "2.5 requests/second" in result.output
+    assert "shared across workers" in result.output
+    assert "4 retries" in result.output
     assert calls["options"].source == "en"
     assert calls["options"].target == "pt"
+    assert calls["options"].workers == 2
 
 
 def test_resume_command_without_state_reports_clear_error(tmp_path, monkeypatch):
@@ -2322,6 +2348,16 @@ def test_translate_command_handles_keyboard_interrupt_cleanly(tmp_path, monkeypa
             str(output_path),
             "--cache",
             str(cache_path),
+            "--workers",
+            "2",
+            "--requests-per-second",
+            "2.5",
+            "--retries",
+            "4",
+            "--retry-backoff",
+            "1",
+            "--retry-backoff-max",
+            "10",
         ],
     )
 
@@ -2335,6 +2371,11 @@ def test_translate_command_handles_keyboard_interrupt_cleanly(tmp_path, monkeypa
     assert "Texts translated" in result.output
     assert "Texts from cache" in result.output
     assert "Text errors" in result.output
+    assert "Workers" in result.output
+    assert "2 (parallel" in result.output
+    assert "2.5 requests/second" in result.output
+    assert "shared across workers" in result.output
+    assert "4 retries" in result.output
     assert "chapter-two.xhtml" in result.output
     assert "Cached translations saved before the interruption can be reused" in result.output
     assert str(cache_path) in result.output
@@ -2617,6 +2658,12 @@ def test_translate_command_passes_execution_controls_to_preflight_and_resume(
     assert saved_state.retry_backoff == 0.25
     assert saved_state.retry_backoff_max == 2.0
     assert saved_state.workers == 3
+    assert "Workers" in result.output
+    assert "3 (parallel" in result.output
+    assert "3.5 requests/second" in result.output
+    assert "shared across workers" in result.output
+    assert "2 retries" in result.output
+    assert "0.25s initial backoff" in result.output
 
 
 def test_translate_command_rejects_invalid_workers(minimal_epub_path, monkeypatch):

--- a/tests/test_cli_progress.py
+++ b/tests/test_cli_progress.py
@@ -70,3 +70,29 @@ def test_translation_progress_snapshot_tracks_partial_state():
     assert snapshot.texts_from_cache == 1
     assert snapshot.texts_from_memory == 1
     assert snapshot.texts_missing == 1
+
+
+def test_translation_progress_marks_parallel_progress_as_epub_order():
+    class FakeProgress:
+        def __init__(self) -> None:
+            self.descriptions: list[str] = []
+
+        def add_task(self, description: str, total: object = None) -> int:
+            self.descriptions.append(description)
+            return len(self.descriptions)
+
+        def update(self, *_args: object, **kwargs: object) -> None:
+            description = kwargs.get("description")
+            if isinstance(description, str):
+                self.descriptions.append(description)
+
+        def advance(self, *_args: object, **_kwargs: object) -> None:
+            return None
+
+    fake = FakeProgress()
+    progress = TranslationProgress(fake, dry_run=False, workers=3)
+
+    progress.chapter_started(1, 2, "chapter-one.xhtml")
+
+    assert "Chapters (3 workers, EPUB order)" in fake.descriptions
+    assert "Chapters (3 workers, EPUB order) 1/2: chapter-one.xhtml" in fake.descriptions


### PR DESCRIPTION
## Objective

Make Ayvu's terminal UX and resume flow show the execution controls used for long translations.

## What changed

- Added execution control rows to the translation and batch plans for workers, rate limiting, and retry policy.
- Shows saved execution controls in resume checkpoints, in-progress translation lists, and interruption summaries.
- Marks parallel chapter progress as reported in EPUB order when workers are greater than 1.
- Updated README, tutorial docs, changelog, and focused tests for the UX behavior.

## Out of scope

- Live per-worker progress UI.
- Changes to translation, cache, retry, rate-limit, or worker execution semantics.
- Parallel support for translation memory.

## Validation

- `uv run pytest`: 316 tests passed.
- `git diff --check`: no errors.

## Related issue

Closes #117
Refs #99