### PR TITLE
Add translation performance profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ lancadas e secoes versionadas quando uma release for publicada.
 - Plano, progresso, interrupcao e retomada agora mostram os controles de
   execucao usados (`Workers`, `Rate limit` e `Retry policy`), incluindo a ordem
   deterministica do progresso quando `--workers` e maior que `1`.
+- Perfis de performance com `--performance-profile low|standard|high|custom`,
+  aplicando presets para workers, limite de requisicoes, chunking e politica de
+  retry, com flags explicitas tendo precedencia.
 - Estado local de retomada em `~/Documentos/Livros/Processando` ou na pasta de
   processamento configurada.
 - Checkpoints de progresso no estado de retomada, atualizados a cada capitulo com

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ O EPUB original nunca é alterado. A saída é gravada em um novo arquivo `.epub
 - Preservação de tags, CSS, imagens, links, sumário e nomes de arquivos internos.
 - Cache SQLite para retomar traduções interrompidas e evitar chamadas repetidas.
 - Execução paralela opcional por documento com `--workers`, mantendo `1` como padrão conservador.
+- Perfis de performance com `--performance-profile` para escolher presets `low`, `standard`, `high` ou `custom`.
 - Memória de tradução opcional para reaproveitar trechos parecidos por similaridade, com aplicação ou sugestão por limiar.
 - Checkpoints de progresso por capítulo e comando `resume` para retomar com segurança traduções longas.
 - Glossário JSON opcional e fluxo guiado para padronizar termos técnicos.
@@ -299,6 +300,32 @@ sobrescrevem os valores do perfil.
 Antes de iniciar a tradução, o Ayvu verifica internamente o par de idiomas, o glossário, o cache, o EPUB de entrada e, em traduções reais, o tradutor configurado. Se algo impedir a execução, o comando falha cedo com uma mensagem curta e um próximo passo.
 
 O Ayvu também resolve a rota de tradução consultando os idiomas do LibreTranslate: se não houver caminho direto entre origem e destino, tenta uma rota intermediária via inglês (por exemplo `fr -> en -> pt`). Quando a rota intermediária é usada, o modo comum avisa que a tradução passará por 2 etapas e que a qualidade pode ficar comprometida; o modo desenvolvedor mostra a rota explicitamente. Se nenhuma rota estiver disponível, o comando falha antes de processar o EPUB.
+
+### Perfis de performance
+
+O comando `translate` aceita `--performance-profile` para aplicar presets de execução:
+
+```bash
+uv run ayvu translate livro.epub --target pt --performance-profile low
+uv run ayvu translate livro.epub --target pt --performance-profile high
+```
+
+Os perfis disponíveis são:
+
+| Perfil | Uso recomendado | Configuração |
+|---|---|---|
+| `low` | Máquinas fracas ou servidor instável | `workers=1`, `requests_per_second=1`, `chunk_limit=1500`, retries mais pacientes |
+| `standard` | Padrão seguro | `workers=1`, sem limite de taxa, `chunk_limit=3000`, retries padrão |
+| `high` | Máquina e servidor estáveis | `workers=4`, sem limite de taxa, `chunk_limit=4000`, retries padrão |
+| `custom` | Ajuste manual por flags | Começa do padrão `standard` e usa os overrides informados |
+
+`standard` é o padrão quando `--performance-profile` não é informado. Configurações mais
+fortes, como `high`, são sempre opt-in. Flags explícitas continuam tendo precedência sobre
+o perfil: por exemplo, `--performance-profile high --workers 2` usa o restante do perfil
+`high`, mas limita os workers a `2`.
+
+No momento, `high` é incompatível com `--translation-memory`, porque esse recurso exige
+`--workers 1` nesta versão.
 
 ### Controle de requisições ao tradutor
 

--- a/docs/tutorial-modo-comum-e-dev.md
+++ b/docs/tutorial-modo-comum-e-dev.md
@@ -553,12 +553,19 @@ uv run ayvu --mode developer translate livro.epub \
   --target pt \
   --url http://localhost:5000 \
   --cache .cache/traducoes.sqlite \
+  --performance-profile custom \
   --requests-per-second 2 \
   --workers 2 \
   --retries 4 \
   --retry-backoff 1 \
   --retry-backoff-max 10
 ```
+
+Use `--performance-profile` para escolher um preset de execução. `standard` é o
+padrão conservador, `low` reduz pressão sobre máquinas e servidores fracos,
+`high` usa `workers` paralelos para ambientes mais fortes, e `custom` começa do
+padrão para ajuste manual por flags. Flags explícitas, como `--workers` ou
+`--requests-per-second`, sobrescrevem o valor vindo do perfil.
 
 Use `--requests-per-second` quando o servidor local ficar instável sob muitas chamadas. O retry
 usa backoff exponencial para falhas de conexão, timeout, HTTP `429` e HTTP `5xx`.

--- a/src/ayvu/cli.py
+++ b/src/ayvu/cli.py
@@ -25,8 +25,11 @@ from .config import (
 from .domain import (
     ChapterSelection,
     ChapterSelectionError,
+    DEFAULT_PERFORMANCE_PROFILE,
     LanguagePair,
     OutputPlan,
+    PERFORMANCE_PROFILES,
+    PerformanceProfile,
     TranslationMemoryError,
     TranslationMemoryOptions,
     TranslationOptions,
@@ -123,6 +126,17 @@ class BatchTranslationResult:
     output_path: Path | None = None
     report_path: Path | None = None
     detail: str = ""
+
+
+@dataclass(frozen=True)
+class ExecutionControls:
+    performance_profile_name: str
+    workers: int
+    requests_per_second: float | None
+    retries: int
+    retry_backoff: float
+    retry_backoff_max: float
+    chunk_limit: int
 
 
 @app.callback(invoke_without_command=True)
@@ -479,6 +493,11 @@ def translate(
         "--profile",
         help="Translation profile from the Ayvu config.",
     ),
+    performance_profile_name: str = typer.Option(
+        DEFAULT_PERFORMANCE_PROFILE,
+        "--performance-profile",
+        help="Performance profile: low, standard, high, or custom.",
+    ),
     dry_run: bool = typer.Option(False, "--dry-run", help="Process without writing translated EPUB."),
     fail_fast: bool = typer.Option(False, "--fail-fast", help="Stop at the first chapter/text error."),
     chapters: Optional[str] = typer.Option(
@@ -493,25 +512,25 @@ def translate(
     ),
     overwrite: bool = typer.Option(False, "--overwrite", help="Allow replacing an existing output file."),
     timeout: float = typer.Option(30.0, "--timeout", help="Translator HTTP timeout in seconds."),
-    retries: int = typer.Option(
-        2,
+    retries: Optional[int] = typer.Option(
+        None,
         "--retries",
-        help="HTTP retry count for connection errors, timeouts, 429, and 5xx.",
+        help="Override the performance profile HTTP retry count.",
     ),
     requests_per_second: Optional[float] = typer.Option(
         None,
         "--requests-per-second",
-        help="Maximum translator HTTP requests per second. Omit for no rate limit.",
+        help="Override the performance profile maximum translator HTTP requests per second.",
     ),
-    retry_backoff: float = typer.Option(
-        DEFAULT_RETRY_BACKOFF,
+    retry_backoff: Optional[float] = typer.Option(
+        None,
         "--retry-backoff",
-        help="Initial retry backoff delay in seconds.",
+        help="Override the performance profile initial retry backoff delay in seconds.",
     ),
-    retry_backoff_max: float = typer.Option(
-        DEFAULT_RETRY_BACKOFF_MAX,
+    retry_backoff_max: Optional[float] = typer.Option(
+        None,
         "--retry-backoff-max",
-        help="Maximum retry backoff delay in seconds.",
+        help="Override the performance profile maximum retry backoff delay in seconds.",
     ),
     translate_metadata: bool = typer.Option(
         False,
@@ -523,11 +542,15 @@ def translate(
         "--translate-alt-text",
         help="Also translate the alt text of images. Text inside images (OCR) is out of scope.",
     ),
-    chunk_limit: int = typer.Option(3000, "--chunk-limit", help="Maximum characters sent per request."),
-    workers: int = typer.Option(
-        1,
+    chunk_limit: Optional[int] = typer.Option(
+        None,
+        "--chunk-limit",
+        help="Override the performance profile maximum characters sent per request.",
+    ),
+    workers: Optional[int] = typer.Option(
+        None,
         "--workers",
-        help="Number of parallel document workers. Defaults to 1 for conservative sequential execution.",
+        help="Override the performance profile number of parallel document workers.",
     ),
     cache_only: bool = typer.Option(
         False,
@@ -585,7 +608,21 @@ def translate(
         suggest_threshold=tm_suggest_threshold,
         mode=mode,
     )
-    _validate_worker_options(workers=workers, translation_memory=tm_options, mode=mode)
+    execution_controls = _resolve_execution_controls(
+        performance_profile_name=performance_profile_name,
+        workers=workers,
+        requests_per_second=requests_per_second,
+        retries=retries,
+        retry_backoff=retry_backoff,
+        retry_backoff_max=retry_backoff_max,
+        chunk_limit=chunk_limit,
+        mode=mode,
+    )
+    _validate_worker_options(
+        workers=execution_controls.workers,
+        translation_memory=tm_options,
+        mode=mode,
+    )
 
     if len(epub_list) > 1:
         _run_batch_translation(
@@ -598,18 +635,19 @@ def translate(
             cache_path=cache_path,
             glossary_path=glossary_path,
             profile_name=profile_name,
+            performance_profile_name=execution_controls.performance_profile_name,
             dry_run=dry_run,
             fail_fast=fail_fast,
             chapter_selection=chapter_selection,
             continue_on_error=continue_on_error,
             overwrite=overwrite,
             timeout=timeout,
-            retries=retries,
-            requests_per_second=requests_per_second,
-            retry_backoff=retry_backoff,
-            retry_backoff_max=retry_backoff_max,
-            chunk_limit=chunk_limit,
-            workers=workers,
+            retries=execution_controls.retries,
+            requests_per_second=execution_controls.requests_per_second,
+            retry_backoff=execution_controls.retry_backoff,
+            retry_backoff_max=execution_controls.retry_backoff_max,
+            chunk_limit=execution_controls.chunk_limit,
+            workers=execution_controls.workers,
             mode=mode,
             config=config,
             translate_metadata=translate_metadata,
@@ -632,17 +670,18 @@ def translate(
         cache_path=cache_path,
         glossary_path=glossary_path,
         profile_name=profile_name,
+        performance_profile_name=execution_controls.performance_profile_name,
         dry_run=dry_run,
         fail_fast=fail_fast,
         chapter_selection=chapter_selection,
         overwrite=overwrite,
         timeout=timeout,
-        retries=retries,
-        requests_per_second=requests_per_second,
-        retry_backoff=retry_backoff,
-        retry_backoff_max=retry_backoff_max,
-        chunk_limit=chunk_limit,
-        workers=workers,
+        retries=execution_controls.retries,
+        requests_per_second=execution_controls.requests_per_second,
+        retry_backoff=execution_controls.retry_backoff,
+        retry_backoff_max=execution_controls.retry_backoff_max,
+        chunk_limit=execution_controls.chunk_limit,
+        workers=execution_controls.workers,
         mode=mode,
         config=config,
         translate_metadata=translate_metadata,
@@ -854,6 +893,7 @@ def _print_translation_plan(
     mode: UserMode,
     profile_name: str | None = None,
     profile_style: str | None = None,
+    performance_profile_name: str | None = None,
     workers: int = 1,
     requests_per_second: float | None = None,
     retries: int = 2,
@@ -872,6 +912,8 @@ def _print_translation_plan(
         table.add_row("Profile", profile_name)
     if profile_style:
         table.add_row("Profile style", profile_style)
+    if performance_profile_name:
+        table.add_row("Performance profile", performance_profile_name)
     for label, value in _execution_control_rows(
         workers=workers,
         requests_per_second=requests_per_second,
@@ -932,6 +974,51 @@ def _format_execution_summary(state: TranslationResumeState) -> str:
 
 def _format_number(value: float) -> str:
     return f"{value:g}"
+
+
+def _resolve_execution_controls(
+    *,
+    performance_profile_name: str,
+    workers: int | None,
+    requests_per_second: float | None,
+    retries: int | None,
+    retry_backoff: float | None,
+    retry_backoff_max: float | None,
+    chunk_limit: int | None,
+    mode: UserMode,
+) -> ExecutionControls:
+    profile = _resolve_performance_profile(performance_profile_name, mode=mode)
+    return ExecutionControls(
+        performance_profile_name=profile.name,
+        workers=workers if workers is not None else profile.workers,
+        requests_per_second=(
+            requests_per_second
+            if requests_per_second is not None
+            else profile.requests_per_second
+        ),
+        retries=retries if retries is not None else profile.retries,
+        retry_backoff=retry_backoff if retry_backoff is not None else profile.retry_backoff,
+        retry_backoff_max=(
+            retry_backoff_max if retry_backoff_max is not None else profile.retry_backoff_max
+        ),
+        chunk_limit=chunk_limit if chunk_limit is not None else profile.chunk_limit,
+    )
+
+
+def _resolve_performance_profile(name: str, mode: UserMode) -> PerformanceProfile:
+    normalized = name.strip().lower() if name else DEFAULT_PERFORMANCE_PROFILE
+    profile = PERFORMANCE_PROFILES.get(normalized)
+    if profile is not None:
+        return profile
+
+    available = ", ".join(sorted(PERFORMANCE_PROFILES))
+    _print_expected_error(
+        "Perfil de performance não encontrado.",
+        "Use --performance-profile com um dos perfis disponíveis, ou remova a opção para usar standard.",
+        mode,
+        detail=f"Perfil solicitado: {name}. Perfis disponíveis: {available}.",
+    )
+    raise typer.Exit(code=1)
 
 
 def _print_translation_route(route: TranslationRoute | None, mode: UserMode) -> None:
@@ -1200,6 +1287,7 @@ def _run_translation(
     cache_path: Path,
     glossary_path: Path | None,
     profile_name: str | None,
+    performance_profile_name: str | None,
     dry_run: bool,
     fail_fast: bool,
     chapter_selection: ChapterSelection | None,
@@ -1236,6 +1324,7 @@ def _run_translation(
         mode=mode,
         profile_name=resolved_profile_name,
         profile_style=profile.style if profile else None,
+        performance_profile_name=performance_profile_name,
         workers=workers,
         requests_per_second=requests_per_second,
         retries=retries,
@@ -1448,6 +1537,7 @@ def _run_batch_translation(
     cache_path: Path,
     glossary_path: Path | None,
     profile_name: str | None,
+    performance_profile_name: str | None,
     dry_run: bool,
     fail_fast: bool,
     chapter_selection: ChapterSelection | None,
@@ -1475,6 +1565,7 @@ def _run_batch_translation(
         output_dir=resolved_output_dir,
         report_dir=report_dir,
         continue_on_error=continue_on_error,
+        performance_profile_name=performance_profile_name,
         workers=workers,
         requests_per_second=requests_per_second,
         retries=retries,
@@ -1499,6 +1590,7 @@ def _run_batch_translation(
                 cache_path=cache_path,
                 glossary_path=glossary_path,
                 profile_name=profile_name,
+                performance_profile_name=performance_profile_name,
                 dry_run=dry_run,
                 fail_fast=fail_fast,
                 chapter_selection=chapter_selection,
@@ -1569,6 +1661,7 @@ def _print_batch_plan(
     output_dir: Path,
     report_dir: Path,
     continue_on_error: bool,
+    performance_profile_name: str | None,
     workers: int,
     requests_per_second: float | None,
     retries: int,
@@ -1582,6 +1675,8 @@ def _print_batch_plan(
     table.add_row("Output folder", str(output_dir))
     table.add_row("Reports folder", str(report_dir))
     table.add_row("Continue on error", "yes" if continue_on_error else "no")
+    if performance_profile_name:
+        table.add_row("Performance profile", performance_profile_name)
     for label, value in _execution_control_rows(
         workers=workers,
         requests_per_second=requests_per_second,
@@ -2214,6 +2309,7 @@ def _run_guided_translation(config: AyvuConfig) -> None:
         cache_path=DEFAULT_CACHE_PATH,
         glossary_path=glossary_path,
         profile_name=profile_name,
+        performance_profile_name=DEFAULT_PERFORMANCE_PROFILE,
         dry_run=False,
         fail_fast=False,
         chapter_selection=None,
@@ -2891,6 +2987,7 @@ def _resume_translation(state: TranslationResumeState, mode: UserMode) -> None:
             cache_path=state.cache_path,
             glossary_path=state.glossary_path,
             profile_name=None,
+            performance_profile_name=None,
             dry_run=False,
             fail_fast=state.fail_fast,
             chapter_selection=_parse_chapter_selection(state.chapter_selection, mode=mode),

--- a/src/ayvu/domain.py
+++ b/src/ayvu/domain.py
@@ -206,6 +206,68 @@ class TranslationMemoryOptions:
 
 
 @dataclass(frozen=True)
+class PerformanceProfile:
+    name: str
+    workers: int
+    requests_per_second: float | None
+    retries: int
+    retry_backoff: float
+    retry_backoff_max: float
+    chunk_limit: int
+    description: str
+
+
+PERFORMANCE_PROFILE_LOW = "low"
+PERFORMANCE_PROFILE_STANDARD = "standard"
+PERFORMANCE_PROFILE_HIGH = "high"
+PERFORMANCE_PROFILE_CUSTOM = "custom"
+DEFAULT_PERFORMANCE_PROFILE = PERFORMANCE_PROFILE_STANDARD
+
+PERFORMANCE_PROFILES: dict[str, PerformanceProfile] = {
+    PERFORMANCE_PROFILE_LOW: PerformanceProfile(
+        name=PERFORMANCE_PROFILE_LOW,
+        workers=1,
+        requests_per_second=1.0,
+        retries=4,
+        retry_backoff=1.0,
+        retry_backoff_max=12.0,
+        chunk_limit=1500,
+        description="Conservative settings for weak machines or fragile translator servers.",
+    ),
+    PERFORMANCE_PROFILE_STANDARD: PerformanceProfile(
+        name=PERFORMANCE_PROFILE_STANDARD,
+        workers=1,
+        requests_per_second=None,
+        retries=2,
+        retry_backoff=0.5,
+        retry_backoff_max=8.0,
+        chunk_limit=3000,
+        description="Default sequential settings for predictable local translation.",
+    ),
+    PERFORMANCE_PROFILE_HIGH: PerformanceProfile(
+        name=PERFORMANCE_PROFILE_HIGH,
+        workers=4,
+        requests_per_second=None,
+        retries=2,
+        retry_backoff=0.5,
+        retry_backoff_max=8.0,
+        chunk_limit=4000,
+        description="Opt-in parallel settings for stronger machines and stable translator servers.",
+    ),
+    PERFORMANCE_PROFILE_CUSTOM: PerformanceProfile(
+        name=PERFORMANCE_PROFILE_CUSTOM,
+        workers=1,
+        requests_per_second=None,
+        retries=2,
+        retry_backoff=0.5,
+        retry_backoff_max=8.0,
+        chunk_limit=3000,
+        description="Start from standard settings and rely on explicit CLI overrides.",
+    ),
+}
+
+
+@dataclass(frozen=True)
 class TranslationOptions:
     language_pair: LanguagePair
     dry_run: bool = False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2666,6 +2666,122 @@ def test_translate_command_passes_execution_controls_to_preflight_and_resume(
     assert "0.25s initial backoff" in result.output
 
 
+def test_translate_command_uses_low_performance_profile(
+    minimal_epub_path,
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setattr("ayvu.cli.default_translated_books_dir", lambda: tmp_path / "Traduzidos")
+    calls: dict[str, object] = {}
+    _mock_translation_pipeline(monkeypatch, calls)
+
+    result = runner.invoke(
+        app,
+        [
+            "--mode",
+            "developer",
+            "translate",
+            str(minimal_epub_path),
+            "--performance-profile",
+            "low",
+        ],
+    )
+
+    preflight = calls["preflight"]
+    options = calls["options"]
+    assert result.exit_code == 0
+    assert preflight["requests_per_second"] == 1.0
+    assert preflight["retries"] == 4
+    assert preflight["retry_backoff"] == 1.0
+    assert preflight["retry_backoff_max"] == 12.0
+    assert options.workers == 1
+    assert options.chunk_limit == 1500
+    assert "Performance profile" in result.output
+    assert "low" in result.output
+    assert "1 requests/second" in result.output
+    assert "4 retries" in result.output
+
+
+def test_translate_command_explicit_execution_flags_override_performance_profile(
+    minimal_epub_path,
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setattr("ayvu.cli.default_translated_books_dir", lambda: tmp_path / "Traduzidos")
+    calls: dict[str, object] = {}
+    _mock_translation_pipeline(monkeypatch, calls)
+
+    result = runner.invoke(
+        app,
+        [
+            "--mode",
+            "developer",
+            "translate",
+            str(minimal_epub_path),
+            "--performance-profile",
+            "high",
+            "--workers",
+            "2",
+            "--requests-per-second",
+            "3",
+            "--retries",
+            "5",
+            "--retry-backoff",
+            "0.75",
+            "--retry-backoff-max",
+            "6",
+            "--chunk-limit",
+            "2200",
+        ],
+    )
+
+    preflight = calls["preflight"]
+    options = calls["options"]
+    assert result.exit_code == 0
+    assert preflight["requests_per_second"] == 3.0
+    assert preflight["retries"] == 5
+    assert preflight["retry_backoff"] == 0.75
+    assert preflight["retry_backoff_max"] == 6.0
+    assert options.workers == 2
+    assert options.chunk_limit == 2200
+    assert "Performance profile" in result.output
+    assert "high" in result.output
+    assert "2 (parallel" in result.output
+    assert "3 requests/second shared across workers" in result.output
+
+
+def test_translate_command_reports_unknown_performance_profile_without_traceback(
+    minimal_epub_path,
+    monkeypatch,
+):
+    called = False
+
+    def fail_preflight(**_kwargs: object) -> object:
+        nonlocal called
+        called = True
+        raise AssertionError("preflight should not run for an unknown performance profile")
+
+    monkeypatch.setattr("ayvu.cli.run_translation_preflight", fail_preflight)
+
+    result = runner.invoke(
+        app,
+        [
+            "--mode",
+            "developer",
+            "translate",
+            str(minimal_epub_path),
+            "--performance-profile",
+            "turbo",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Perfil de performance não encontrado." in result.output
+    assert "--performance-profile" in result.output
+    assert "Traceback" not in result.output
+    assert not called
+
+
 def test_translate_command_rejects_invalid_workers(minimal_epub_path, monkeypatch):
     def fail_preflight(**_kwargs: object) -> object:
         raise AssertionError("preflight should not run with invalid workers")
@@ -2701,6 +2817,33 @@ def test_translate_command_rejects_parallel_workers_with_translation_memory(
             str(minimal_epub_path),
             "--workers",
             "2",
+            "--translation-memory",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "--workers é incompatível com --translation-memory nesta versão." in result.output
+    assert "Traceback" not in result.output
+
+
+def test_translate_command_rejects_high_performance_profile_with_translation_memory(
+    minimal_epub_path,
+    monkeypatch,
+):
+    def fail_preflight(**_kwargs: object) -> object:
+        raise AssertionError("preflight should not run with incompatible performance profile")
+
+    monkeypatch.setattr("ayvu.cli.run_translation_preflight", fail_preflight)
+
+    result = runner.invoke(
+        app,
+        [
+            "--mode",
+            "developer",
+            "translate",
+            str(minimal_epub_path),
+            "--performance-profile",
+            "high",
             "--translation-memory",
         ],
     )


### PR DESCRIPTION
## Objective

Add performance profiles so Ayvu can run with conservative defaults on weaker machines and opt-in stronger settings on stable translator servers.

## What changed

- Added built-in `low`, `standard`, `high`, and `custom` performance profiles.
- Added `--performance-profile` to `translate`, with `standard` preserving the current default behavior.
- Resolves workers, request rate limiting, chunk limit, and retry/backoff settings from the selected profile.
- Keeps explicit execution flags as overrides over the selected profile.
- Reuses the existing worker validation so `high` remains incompatible with `--translation-memory` in this version.
- Updated README, tutorial docs, changelog, and focused CLI tests.

## Out of scope

- Automatic performance tuning.
- Backend-specific performance capabilities.
- Persisting custom performance profiles in config.json.
- Parallel support for translation memory.

## Validation

- `uv run pytest`: 320 tests passed.
- `git diff --check`: no errors.

## Related issue

Closes #101
Refs #102